### PR TITLE
Adding server key and cert files to installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include AUTHORS.txt CHANGES.txt LICENSE.txt README.rst
 global-include logconfig.ini
 recursive-include bin run_server.sh
 recursive-include kmip *.py
+include kmip/demos/certs/server.*

--- a/kmip/services/kmip_server.py
+++ b/kmip/services/kmip_server.py
@@ -81,10 +81,10 @@ class KMIPServer(object):
         self.port = int(conf.get_valid_value(port, 'server',
                                              'port', conf.DEFAULT_PORT))
         self.keyfile = conf.get_valid_value(
-            keyfile, 'server', 'keyfile', conf.DEFAULT_CERTFILE)
+            keyfile, 'server', 'keyfile', conf.DEFAULT_KEYFILE)
 
         self.certfile = conf.get_valid_value(
-            certfile, 'server', 'certfile', conf.DEFAULT_KEYFILE)
+            certfile, 'server', 'certfile', conf.DEFAULT_CERTFILE)
 
         self.cert_reqs = getattr(ssl, conf.get_valid_value(
             cert_reqs, 'server', 'cert_reqs', 'CERT_NONE'))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setuptools.setup(
     url='https://github.com/OpenKMIP/PyKMIP',
     license='Apache License, Version 2.0',
     packages=setuptools.find_packages(exclude=["kmip.tests", "kmip.tests.*"]),
-    package_data={'kmip': ['logconfig.ini']},
+    package_data={'kmip': ['logconfig.ini'],
+                  'kmip.demos': ['certs/server.crt', 'certs/server.key']},
     install_requires=[
         "enum34",
         "six",


### PR DESCRIPTION
This change adds the server key and cert files from kmip/demos/certs to
the MANIFEST.in and setup.py files. These files are being added to
resolve missing file issues when using the default config values.

In cases where a user is instantiating a KMIPClient and passing
ca_cert=None an exception will be raised with newer versions of
Python(2.7.8+). This exception is based on the missing server.crt file
that is specified in the default configuration.

Likewise, when instantiating a KMIPServer with keyfile=None or
certfile=None the default values will be used. This will also cause an
exception with newer versions of Python.

Although it may be unlikely that an end user would instantiate these
classes without providing cert and key files, there are cases(namely
testing) where it is acceptable to pass None values for these files. In
these cases the files should be present to allow proper execution.

Changes
- adding server.crt and server.key to MANIFEST.in and setup.py
- correcting mismatched default values for KMIPServer certfile and
  keyfile
