### PR TITLE
Adding handling for SecretData and OpaqueData objects

### DIFF
--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -330,10 +330,11 @@ class SecretDataType(Enum):
     PASSWORD = 0x00000001
     SEED     = 0x00000002
 
-
 # 9.1.3.2.10
 class OpaqueDataType(Enum):
-    pass
+    NONE = 0x80000000 # Not defined by the standard, but we need something.
+                      # The standard does say that values starting 0x8xxxxxx
+                      # are considered extensions
 
 
 # 9.1.3.2.11

--- a/kmip/demos/get.py
+++ b/kmip/demos/get.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
                            credential)
     uuid = result.uuid.value
 
-    result = client.get(uuid, credential)
+    result = client.get(uuid=uuid, credential=credential)
     client.close()
 
     logger.debug('get() result status: {0}'.format(result.result_status.enum))


### PR DESCRIPTION
Secret Data (2.2.7) can now be registered
Opaque Object (2.2.8) can now be registered

This required the adding of a NONE type to the OpaqueDataType enum
with the value of 0. This is not indicated by the standard but we
needed some value to satisfy response decoding.

Also fixed get demo

This has been tested vs a HP Atalla ESKM HSM