### PR TITLE
Updating demo utilities to support creating Certificates

### DIFF
--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -17,6 +17,7 @@ from kmip.core.attributes import CryptographicAlgorithm
 from kmip.core.attributes import CryptographicLength
 
 from kmip.core.enums import AttributeType
+from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import CryptographicAlgorithm as CryptoAlgorithmEnum
 from kmip.core.enums import CryptographicUsageMask
 from kmip.core.enums import ObjectType
@@ -31,11 +32,13 @@ from kmip.core.objects import KeyBlock
 from kmip.core.objects import KeyMaterial
 from kmip.core.objects import KeyValue
 
+from kmip.core.secrets import Certificate
 from kmip.core.secrets import PrivateKey
 from kmip.core.secrets import PublicKey
 from kmip.core.secrets import SymmetricKey
 from kmip.core.secrets import SecretData
 
+import binascii
 import optparse
 import sys
 
@@ -167,7 +170,8 @@ def build_cli_parser(operation):
             default="SYMMETRIC_KEY",
             dest="type",
             help=("Type of the object to register. Supported types include: "
-                  "PRIVATE_KEY, PUBLIC_KEY, SYMMETRIC_KEY, SECRET_DATA"))
+                  "CERTIFICATE, PRIVATE_KEY, PUBLIC_KEY, SYMMETRIC_KEY, "
+                  "SECRET_DATA"))
     elif operation is Operation.QUERY:
         pass
     elif operation is Operation.DISCOVER_VERSIONS:
@@ -179,8 +183,11 @@ def build_cli_parser(operation):
 
 
 def build_cryptographic_usage_mask(logger, object_type):
-    if (object_type == ObjectType.SYMMETRIC_KEY or
-       object_type == ObjectType.SECRET_DATA):
+    if object_type == ObjectType.CERTIFICATE:
+        flags = [CryptographicUsageMask.ENCRYPT,
+                 CryptographicUsageMask.VERIFY]
+    elif (object_type == ObjectType.SYMMETRIC_KEY or
+          object_type == ObjectType.SECRET_DATA):
         flags = [CryptographicUsageMask.ENCRYPT,
                  CryptographicUsageMask.DECRYPT]
     elif object_type == ObjectType.PUBLIC_KEY:
@@ -201,7 +208,18 @@ def build_cryptographic_usage_mask(logger, object_type):
 
 def build_object(logger, object_type, key_format_type):
 
-    key_value = build_key_value(logger, object_type)
+    if object_type == ObjectType.CERTIFICATE:
+        value = build_secret_value(logger, object_type)
+        return Certificate(
+            certificate_type=CertificateTypeEnum.X_509,
+            certificate_value=value)
+    else:
+        return build_key(logger, object_type, key_format_type)
+
+
+def build_key(logger, object_type, key_format_type):
+
+    key_value = build_secret_value(logger, object_type)
     cryptographic_algorithm = build_cryptographic_algorithm(
         logger, object_type)
     cryptographic_length = build_cryptographic_length(logger, object_type)
@@ -223,7 +241,7 @@ def build_object(logger, object_type, key_format_type):
         return SecretData(secret_data_type=kind,
                           key_block=key_block)
     else:
-        logger.error("Unrecognized object type, could not build object")
+        logger.error("Unrecognized object type, could not build key")
         sys.exit()
 
 
@@ -255,9 +273,62 @@ def build_cryptographic_algorithm(logger, object_type):
         sys.exit()
 
 
-def build_key_value(logger, object_type):
-    if (object_type == ObjectType.SYMMETRIC_KEY
-       or object_type == ObjectType.SECRET_DATA):
+def build_secret_value(logger, object_type):
+    if object_type == ObjectType.CERTIFICATE:
+        # Encoding from Section 13.2 of the KMIP 1.1 Test Cases document.
+        return (
+            b'\x30\x82\x03\x12\x30\x82\x01\xFA\xA0\x03\x02\x01\x02\x02\x01\x01'
+            b'\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x05\x05\x00\x30'
+            b'\x3B\x31\x0B\x30\x09\x06\x03\x55\x04\x06\x13\x02\x55\x53\x31\x0D'
+            b'\x30\x0B\x06\x03\x55\x04\x0A\x13\x04\x54\x45\x53\x54\x31\x0E\x30'
+            b'\x0C\x06\x03\x55\x04\x0B\x13\x05\x4F\x41\x53\x49\x53\x31\x0D\x30'
+            b'\x0B\x06\x03\x55\x04\x03\x13\x04\x4B\x4D\x49\x50\x30\x1E\x17\x0D'
+            b'\x31\x30\x31\x31\x30\x31\x32\x33\x35\x39\x35\x39\x5A\x17\x0D\x32'
+            b'\x30\x31\x31\x30\x31\x32\x33\x35\x39\x35\x39\x5A\x30\x3B\x31\x0B'
+            b'\x30\x09\x06\x03\x55\x04\x06\x13\x02\x55\x53\x31\x0D\x30\x0B\x06'
+            b'\x03\x55\x04\x0A\x13\x04\x54\x45\x53\x54\x31\x0E\x30\x0C\x06\x03'
+            b'\x55\x04\x0B\x13\x05\x4F\x41\x53\x49\x53\x31\x0D\x30\x0B\x06\x03'
+            b'\x55\x04\x03\x13\x04\x4B\x4D\x49\x50\x30\x82\x01\x22\x30\x0D\x06'
+            b'\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01\x05\x00\x03\x82\x01\x0F'
+            b'\x00\x30\x82\x01\x0A\x02\x82\x01\x01\x00\xAB\x7F\x16\x1C\x00\x42'
+            b'\x49\x6C\xCD\x6C\x6D\x4D\xAD\xB9\x19\x97\x34\x35\x35\x77\x76\x00'
+            b'\x3A\xCF\x54\xB7\xAF\x1E\x44\x0A\xFB\x80\xB6\x4A\x87\x55\xF8\x00'
+            b'\x2C\xFE\xBA\x6B\x18\x45\x40\xA2\xD6\x60\x86\xD7\x46\x48\x34\x6D'
+            b'\x75\xB8\xD7\x18\x12\xB2\x05\x38\x7C\x0F\x65\x83\xBC\x4D\x7D\xC7'
+            b'\xEC\x11\x4F\x3B\x17\x6B\x79\x57\xC4\x22\xE7\xD0\x3F\xC6\x26\x7F'
+            b'\xA2\xA6\xF8\x9B\x9B\xEE\x9E\x60\xA1\xD7\xC2\xD8\x33\xE5\xA5\xF4'
+            b'\xBB\x0B\x14\x34\xF4\xE7\x95\xA4\x11\x00\xF8\xAA\x21\x49\x00\xDF'
+            b'\x8B\x65\x08\x9F\x98\x13\x5B\x1C\x67\xB7\x01\x67\x5A\xBD\xBC\x7D'
+            b'\x57\x21\xAA\xC9\xD1\x4A\x7F\x08\x1F\xCE\xC8\x0B\x64\xE8\xA0\xEC'
+            b'\xC8\x29\x53\x53\xC7\x95\x32\x8A\xBF\x70\xE1\xB4\x2E\x7B\xB8\xB7'
+            b'\xF4\xE8\xAC\x8C\x81\x0C\xDB\x66\xE3\xD2\x11\x26\xEB\xA8\xDA\x7D'
+            b'\x0C\xA3\x41\x42\xCB\x76\xF9\x1F\x01\x3D\xA8\x09\xE9\xC1\xB7\xAE'
+            b'\x64\xC5\x41\x30\xFB\xC2\x1D\x80\xE9\xC2\xCB\x06\xC5\xC8\xD7\xCC'
+            b'\xE8\x94\x6A\x9A\xC9\x9B\x1C\x28\x15\xC3\x61\x2A\x29\xA8\x2D\x73'
+            b'\xA1\xF9\x93\x74\xFE\x30\xE5\x49\x51\x66\x2A\x6E\xDA\x29\xC6\xFC'
+            b'\x41\x13\x35\xD5\xDC\x74\x26\xB0\xF6\x05\x02\x03\x01\x00\x01\xA3'
+            b'\x21\x30\x1F\x30\x1D\x06\x03\x55\x1D\x0E\x04\x16\x04\x14\x04\xE5'
+            b'\x7B\xD2\xC4\x31\xB2\xE8\x16\xE1\x80\xA1\x98\x23\xFA\xC8\x58\x27'
+            b'\x3F\x6B\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x05\x05'
+            b'\x00\x03\x82\x01\x01\x00\xA8\x76\xAD\xBC\x6C\x8E\x0F\xF0\x17\x21'
+            b'\x6E\x19\x5F\xEA\x76\xBF\xF6\x1A\x56\x7C\x9A\x13\xDC\x50\xD1\x3F'
+            b'\xEC\x12\xA4\x27\x3C\x44\x15\x47\xCF\xAB\xCB\x5D\x61\xD9\x91\xE9'
+            b'\x66\x31\x9D\xF7\x2C\x0D\x41\xBA\x82\x6A\x45\x11\x2F\xF2\x60\x89'
+            b'\xA2\x34\x4F\x4D\x71\xCF\x7C\x92\x1B\x4B\xDF\xAE\xF1\x60\x0D\x1B'
+            b'\xAA\xA1\x53\x36\x05\x7E\x01\x4B\x8B\x49\x6D\x4F\xAE\x9E\x8A\x6C'
+            b'\x1D\xA9\xAE\xB6\xCB\xC9\x60\xCB\xF2\xFA\xE7\x7F\x58\x7E\xC4\xBB'
+            b'\x28\x20\x45\x33\x88\x45\xB8\x8D\xD9\xAE\xEA\x53\xE4\x82\xA3\x6E'
+            b'\x73\x4E\x4F\x5F\x03\xB9\xD0\xDF\xC4\xCA\xFC\x6B\xB3\x4E\xA9\x05'
+            b'\x3E\x52\xBD\x60\x9E\xE0\x1E\x86\xD9\xB0\x9F\xB5\x11\x20\xC1\x98'
+            b'\x34\xA9\x97\xB0\x9C\xE0\x8D\x79\xE8\x13\x11\x76\x2F\x97\x4B\xB1'
+            b'\xC8\xC0\x91\x86\xC4\xD7\x89\x33\xE0\xDB\x38\xE9\x05\x08\x48\x77'
+            b'\xE1\x47\xC7\x8A\xF5\x2F\xAE\x07\x19\x2F\xF1\x66\xD1\x9F\xA9\x4A'
+            b'\x11\xCC\x11\xB2\x7E\xD0\x50\xF7\xA2\x7F\xAE\x13\xB2\x05\xA5\x74'
+            b'\xC4\xEE\x00\xAA\x8B\xD6\x5D\x0D\x70\x57\xC9\x85\xC8\x39\xEF\x33'
+            b'\x6A\x44\x1E\xD5\x3A\x53\xC6\xB6\xB6\x96\xF1\xBD\xEB\x5F\x7E\xA8'
+            b'\x11\xEB\xB2\x5A\x7F\x86')
+    elif (object_type == ObjectType.SYMMETRIC_KEY or
+          object_type == ObjectType.SECRET_DATA):
         return (
             b'\x30\x82\x02\x76\x02\x01\x00\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7'
             b'\x0D\x01\x01\x01\x05\x00\x04\x82\x02\x60\x30\x82\x02\x5C\x02\x01'
@@ -324,7 +395,7 @@ def build_key_value(logger, object_type):
             b'\x18\x90\xEC\x1C\x86\x19\xE8\x7A\x2B\xD3\x8F\x9D\x03\xB3\x7F\xAC'
             b'\x74\x2E\xFB\x74\x8C\x78\x85\x94\x2C\x39')
     else:
-        logger.error("Unrecognized object type, could not build key value")
+        logger.error("Unrecognized object type, could not build secret value")
         sys.exit()
 
 
@@ -370,12 +441,22 @@ def log_attribute_list(logger, attributes):
 
 
 def log_secret(logger, secret_type, secret_value):
-    if secret_type is ObjectType.PRIVATE_KEY:
+    if secret_type is ObjectType.CERTIFICATE:
+        log_certificate(logger, secret_value)
+    elif secret_type is ObjectType.PRIVATE_KEY:
         log_private_key(logger, secret_value)
     elif secret_type is ObjectType.PUBLIC_KEY:
         log_public_key(logger, secret_value)
     else:
         logger.info('generic secret: {0}'.format(secret_value))
+
+
+def log_certificate(logger, certificate):
+    logger.info('certificate:')
+    logger.info('* certificate type: {0}'.format(
+        certificate.certificate_type))
+    logger.info('* certificate value: {0}'.format(
+        binascii.hexlify(certificate.certificate_value.value)))
 
 
 def log_public_key(logger, public_key):


### PR DESCRIPTION
This change updates the unit demo utilities, adding in support for the creation, registration, and retrieval of X.509 Certificate objects. Support includes an example encoding of a Certificate as well as updated logging routines to display retrieved Certificate data.