### PR TITLE
Adding config argument to integration test suite

### DIFF
--- a/kmip/tests/integration/conftest.py
+++ b/kmip/tests/integration/conftest.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from kmip.services.kmip_client import KMIPProxy
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--config",
+        action="store",
+        default="client",
+        help="Config file section name for client configuration settings")
+
+
+@pytest.fixture(scope="class")
+def client(request):
+    config = request.config.getoption("--config")
+
+    client = KMIPProxy(config=config)
+    client.open()
+
+    def finalize():
+        client.close()
+
+    request.addfinalizer(finalize)
+    request.cls.client = client

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from testtools import TestCase
+
+from kmip.core.enums import ResultStatus
+from kmip.core.enums import QueryFunction as QueryFunctionEnum
+
+from kmip.core.misc import QueryFunction
+
+
+@pytest.mark.usefixtures("client")
+class TestIntegration(TestCase):
+
+    def setUp(self):
+        super(TestIntegration, self).setUp()
+
+    def tearDown(self):
+        super(TestIntegration, self).tearDown()
+
+    def test_discover_versions(self):
+        result = self.client.discover_versions()
+
+        expected = ResultStatus.SUCCESS
+        observed = result.result_status.enum
+
+        self.assertEqual(expected, observed)
+
+    def test_query(self):
+        # Build query function list, asking for all server data.
+        query_functions = list()
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_OPERATIONS))
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_OBJECTS))
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_SERVER_INFORMATION))
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_APPLICATION_NAMESPACES))
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_EXTENSION_LIST))
+        query_functions.append(
+            QueryFunction(QueryFunctionEnum.QUERY_EXTENSION_MAP))
+
+        result = self.client.query(query_functions=query_functions)
+
+        expected = ResultStatus.SUCCESS
+        observed = result.result_status.enum
+
+        self.assertEqual(expected, observed)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = flake8 kmip/
 # Note: This requires local or remote access to a KMIP appliance or service
 deps = {[testenv]deps}
 commands =
-    py.test --strict kmip/tests/integration
+    py.test --strict kmip/tests/integration {posargs}
 
 [flake8]
 exclude = .git,.tox,dist,rpmbuild,*.egg-info


### PR DESCRIPTION
This change adds a pytest config argument, allowing the integration test suite to be run with the client configured with a specific section from the PyKMIP configuration file. A simple integration test class is added to demonstrate how to use the client created using the config argument.

To run the integration test suite with a specific configuration, use:

$ tox -e integration -- --config <config-section>

where <config-section> is the name of the config file section to use for the PyKMIP client.