### PR TITLE
Fixing infinite recursion bug with object inheritance

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -61,23 +61,23 @@ class Name(Struct):
     class NameValue(TextString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.NAME_VALUE)
+            super(Name.NameValue, self).__init__(value, Tags.NAME_VALUE)
 
     class NameType(Enumeration):
 
         ENUM_TYPE = enums.NameType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.NAME_TYPE)
+            super(Name.NameType, self).__init__(value, Tags.NAME_TYPE)
 
     def __init__(self, name_value=None, name_type=None):
-        super(self.__class__, self).__init__(tag=Tags.NAME)
+        super(Name, self).__init__(tag=Tags.NAME)
         self.name_value = name_value
         self.name_type = name_type
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(Name, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the value and type of the name
@@ -97,14 +97,14 @@ class Name(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(Name, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
         self.__validate()
 
     def __validate(self):
-        name = self.__class__.__name__
+        name = Name.__name__
         msg = ErrorStrings.BAD_EXP_RECV
         if self.name_value and \
                 not isinstance(self.name_value, Name.NameValue) and \
@@ -157,7 +157,7 @@ class ObjectType(Enumeration):
     ENUM_TYPE = enums.ObjectType
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.OBJECT_TYPE)
+        super(ObjectType, self).__init__(value, Tags.OBJECT_TYPE)
 
 
 # 3.4
@@ -166,16 +166,16 @@ class CryptographicAlgorithm(Enumeration):
     ENUM_TYPE = enums.CryptographicAlgorithm
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value,
-                                             Tags.CRYPTOGRAPHIC_ALGORITHM)
+        super(CryptographicAlgorithm, self).__init__(
+            value, Tags.CRYPTOGRAPHIC_ALGORITHM)
 
 
 # 3.5
 class CryptographicLength(Integer):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value,
-                                             Tags.CRYPTOGRAPHIC_LENGTH)
+        super(CryptographicLength, self).__init__(
+            value, Tags.CRYPTOGRAPHIC_LENGTH)
 
 
 # 3.6
@@ -207,36 +207,37 @@ class CryptographicParameters(Struct):
         ENUM_TYPE = enums.BlockCipherMode
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.BLOCK_CIPHER_MODE)
+            super(CryptographicParameters.BlockCipherMode, self).__init__(
+                value, Tags.BLOCK_CIPHER_MODE)
 
     class PaddingMethod(Enumeration):
         ENUM_TYPE = enums.PaddingMethod
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.PADDING_METHOD)
+            super(CryptographicParameters.PaddingMethod, self).__init__(
+                value, Tags.PADDING_METHOD)
 
     class KeyRoleType(Enumeration):
         ENUM_TYPE = enums.KeyRoleType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.KEY_ROLE_TYPE)
+            super(CryptographicParameters.KeyRoleType, self).__init__(
+                value, Tags.KEY_ROLE_TYPE)
 
     def __init__(self,
                  block_cipher_mode=None,
                  padding_method=None,
                  hashing_algorithm=None,
                  key_role_type=None):
-        super(self.__class__, self).__init__(tag=Tags.CRYPTOGRAPHIC_PARAMETERS)
+        super(CryptographicParameters, self).__init__(
+            tag=Tags.CRYPTOGRAPHIC_PARAMETERS)
         self.block_cipher_mode = block_cipher_mode
         self.padding_method = padding_method
         self.hashing_algorithm = hashing_algorithm
         self.key_role_type = key_role_type
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(CryptographicParameters, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.BLOCK_CIPHER_MODE, tstream):
@@ -273,7 +274,7 @@ class CryptographicParameters(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(CryptographicParameters, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -531,16 +532,15 @@ class CryptographicUsageMask(Integer):
     ENUM_TYPE = enums.CryptographicUsageMask
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value,
-                                             Tags.CRYPTOGRAPHIC_USAGE_MASK)
+        super(CryptographicUsageMask, self).__init__(
+            value, Tags.CRYPTOGRAPHIC_USAGE_MASK)
 
 
 # 3.33
 class ObjectGroup(TextString):
 
     def __init__(self, value=None):
-        super(self.__class__,
-              self).__init__(value, Tags.OBJECT_GROUP)
+        super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
 
 
 # 3.36
@@ -711,8 +711,8 @@ class ApplicationSpecificInformation(Struct):
 class ContactInformation(TextString):
 
     def __init__(self, value=None):
-        super(self.__class__,
-              self).__init__(value, Tags.CONTACT_INFORMATION)
+        super(ContactInformation, self).__init__(
+            value, Tags.CONTACT_INFORMATION)
 
 
 # 3.39
@@ -722,5 +722,4 @@ class ContactInformation(TextString):
 class CustomAttribute(TextString):
 
     def __init__(self, value=None):
-        super(self.__class__,
-              self).__init__(value, Tags.ATTRIBUTE_VALUE)
+        super(CustomAttribute, self).__init__(value, Tags.ATTRIBUTE_VALUE)

--- a/kmip/core/keys.py
+++ b/kmip/core/keys.py
@@ -28,37 +28,37 @@ from kmip.core.utils import BytearrayStream
 class RawKey(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(RawKey, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 class OpaqueKey(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(OpaqueKey, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 class PKCS1Key(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(PKCS1Key, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 class PKCS8Key(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(PKCS8Key, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 class X509Key(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(X509Key, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 class ECPrivateKey(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(ECPrivateKey, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 # 2.1.7.1
@@ -67,15 +67,15 @@ class TransparentSymmetricKey(Struct):
     class Key(ByteString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.KEY)
+            super(TransparentSymmetricKey.Key, self).__init__(value, Tags.KEY)
 
     def __init__(self, key=None):
-        super(self.__class__, self).__init__(Tags.KEY_MATERIAL)
+        super(TransparentSymmetricKey, self).__init__(Tags.KEY_MATERIAL)
         self.key = key
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(TransparentSymmetricKey, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.key = TransparentSymmetricKey.Key()
@@ -91,7 +91,7 @@ class TransparentSymmetricKey(Struct):
 
         # Write the length and value of the key wrapping data
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(TransparentSymmetricKey, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/messages.py
+++ b/kmip/core/messages/messages.py
@@ -38,7 +38,7 @@ class RequestHeader(Struct):
                  batch_order_option=None,
                  time_stamp=None,
                  batch_count=None):
-        super(self.__class__, self).__init__(tag=Tags.REQUEST_HEADER)
+        super(RequestHeader, self).__init__(tag=Tags.REQUEST_HEADER)
         self.protocol_version = protocol_version
         self.maximum_response_size = maximum_response_size
         self.asynchronous_indicator = asynchronous_indicator
@@ -49,7 +49,7 @@ class RequestHeader(Struct):
         self.batch_count = batch_count
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(RequestHeader, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.protocol_version = contents.ProtocolVersion()
@@ -111,7 +111,7 @@ class RequestHeader(Struct):
 
         # Write the length and value of the request header
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(RequestHeader, self).write(ostream)
         ostream.write(tstream.buffer)
 
 
@@ -121,14 +121,14 @@ class ResponseHeader(Struct):
                  protocol_version=None,
                  time_stamp=None,
                  batch_count=None):
-        super(self.__class__, self).__init__(tag=Tags.RESPONSE_HEADER)
+        super(ResponseHeader, self).__init__(tag=Tags.RESPONSE_HEADER)
         self.protocol_version = protocol_version
         self.time_stamp = time_stamp
         self.batch_count = batch_count
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(ResponseHeader, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.protocol_version = contents.ProtocolVersion()
@@ -153,7 +153,7 @@ class ResponseHeader(Struct):
 
         # Write the length and value of the request header
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(ResponseHeader, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -175,7 +175,7 @@ class RequestBatchItem(Struct):
                  unique_batch_item_id=None,
                  request_payload=None,
                  message_extension=None):
-        super(self.__class__, self).__init__(tag=Tags.REQUEST_BATCH_ITEM)
+        super(RequestBatchItem, self).__init__(tag=Tags.REQUEST_BATCH_ITEM)
 
         self.payload_factory = RequestPayloadFactory()
 
@@ -185,7 +185,7 @@ class RequestBatchItem(Struct):
         self.message_extension = message_extension
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(RequestBatchItem, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the batch item operation
@@ -226,7 +226,7 @@ class RequestBatchItem(Struct):
 
         # Write the length and value of the batch item
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(RequestBatchItem, self).write(ostream)
         ostream.write(tstream.buffer)
 
 
@@ -241,7 +241,7 @@ class ResponseBatchItem(Struct):
                  async_correlation_value=None,
                  response_payload=None,
                  message_extension=None):
-        super(self.__class__, self).__init__(tag=Tags.RESPONSE_BATCH_ITEM)
+        super(ResponseBatchItem, self).__init__(tag=Tags.RESPONSE_BATCH_ITEM)
 
         self.payload_factory = ResponsePayloadFactory()
 
@@ -256,7 +256,7 @@ class ResponseBatchItem(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(ResponseBatchItem, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the batch item operation if it is present
@@ -327,7 +327,7 @@ class ResponseBatchItem(Struct):
 
         # Write the length and value of the batch item
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(ResponseBatchItem, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -337,12 +337,12 @@ class ResponseBatchItem(Struct):
 class RequestMessage(Struct):
 
     def __init__(self, request_header=None, batch_items=None,):
-        super(self.__class__, self).__init__(tag=Tags.REQUEST_MESSAGE)
+        super(RequestMessage, self).__init__(tag=Tags.REQUEST_MESSAGE)
         self.request_header = request_header
         self.batch_items = batch_items
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(RequestMessage, self).read(istream)
 
         self.request_header = RequestHeader()
         self.request_header.read(istream)
@@ -363,20 +363,20 @@ class RequestMessage(Struct):
 
         # Write the TTLV encoding of the request message
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(RequestMessage, self).write(ostream)
         ostream.write(tstream.buffer)
 
 
 class ResponseMessage(Struct):
 
     def __init__(self, response_header=None, batch_items=None,):
-        super(self.__class__, self).__init__(tag=Tags.RESPONSE_MESSAGE)
+        super(ResponseMessage, self).__init__(tag=Tags.RESPONSE_MESSAGE)
         self.response_header = response_header
         self.batch_items = batch_items
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(ResponseMessage, self).read(istream)
 
         self.response_header = ResponseHeader()
         self.response_header.read(istream)
@@ -398,7 +398,7 @@ class ResponseMessage(Struct):
 
         # Write the TTLV encoding of the request message
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(ResponseMessage, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/create.py
+++ b/kmip/core/messages/payloads/create.py
@@ -29,13 +29,14 @@ class CreateRequestPayload(Struct):
     def __init__(self,
                  object_type=None,
                  template_attribute=None):
-        super(self.__class__, self).__init__(tag=enums.Tags.REQUEST_PAYLOAD)
+        super(CreateRequestPayload, self).__init__(
+            tag=enums.Tags.REQUEST_PAYLOAD)
         self.object_type = object_type
         self.template_attribute = template_attribute
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(CreateRequestPayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
@@ -56,7 +57,7 @@ class CreateRequestPayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(CreateRequestPayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -70,14 +71,15 @@ class CreateResponsePayload(Struct):
                  object_type=None,
                  unique_identifier=None,
                  template_attribute=None):
-        super(self.__class__, self).__init__(tag=enums.Tags.RESPONSE_PAYLOAD)
+        super(CreateResponsePayload, self).__init__(
+            tag=enums.Tags.RESPONSE_PAYLOAD)
         self.object_type = object_type
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(CreateResponsePayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
@@ -105,7 +107,7 @@ class CreateResponsePayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(CreateResponsePayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/destroy.py
+++ b/kmip/core/messages/payloads/destroy.py
@@ -27,12 +27,12 @@ class DestroyRequestPayload(Struct):
 
     def __init__(self,
                  unique_identifier=None):
-        super(self.__class__, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(DestroyRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
         self.unique_identifier = unique_identifier
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(DestroyRequestPayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
@@ -50,7 +50,7 @@ class DestroyRequestPayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(DestroyRequestPayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -65,12 +65,13 @@ class DestroyResponsePayload(Struct):
 
     def __init__(self,
                  unique_identifier=None):
-        super(self.__class__, self).__init__(enums.Tags.RESPONSE_PAYLOAD)
+        super(DestroyResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD)
         self.unique_identifier = unique_identifier
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(DestroyResponsePayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
@@ -86,7 +87,7 @@ class DestroyResponsePayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(DestroyResponsePayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/get.py
+++ b/kmip/core/messages/payloads/get.py
@@ -35,22 +35,23 @@ class GetRequestPayload(Struct):
         ENUM_TYPE = enums.KeyCompressionType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.KEY_COMPRESSION_TYPE)
+            super(GetRequestPayload.KeyCompressionType, self).__init__(
+                value, Tags.KEY_COMPRESSION_TYPE)
 
     # 9.1.3.2.3
     class KeyFormatType(Enumeration):
         ENUM_TYPE = enums.KeyFormatType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.KEY_FORMAT_TYPE)
+            super(GetRequestPayload.KeyFormatType, self).__init__(
+                value, Tags.KEY_FORMAT_TYPE)
 
     def __init__(self,
                  unique_identifier=None,
                  key_format_type=None,
                  key_compression_type=None,
                  key_wrapping_specification=None):
-        super(self.__class__, self).__init__(tag=enums.Tags.REQUEST_PAYLOAD)
+        super(GetRequestPayload, self).__init__(tag=enums.Tags.REQUEST_PAYLOAD)
         self.unique_identifier = unique_identifier
         self.key_format_type = key_format_type
         self.key_compression_type = key_compression_type
@@ -58,7 +59,7 @@ class GetRequestPayload(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(GetRequestPayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
@@ -95,7 +96,7 @@ class GetRequestPayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(GetRequestPayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -112,7 +113,7 @@ class GetResponsePayload(Struct):
                  object_type=None,
                  unique_identifier=None,
                  secret=None):
-        super(self.__class__, self).__init__(tag=Tags.RESPONSE_PAYLOAD)
+        super(GetResponsePayload, self).__init__(tag=Tags.RESPONSE_PAYLOAD)
         self.object_type = object_type
         self.unique_identifier = unique_identifier
         self.secret = secret
@@ -120,7 +121,7 @@ class GetResponsePayload(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(GetResponsePayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
@@ -145,7 +146,7 @@ class GetResponsePayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(GetResponsePayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/locate.py
+++ b/kmip/core/messages/payloads/locate.py
@@ -33,25 +33,25 @@ class LocateRequestPayload(Struct):
         ENUM_TYPE = enums.ObjectGroupMember
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.OBJECT_GROUP_MEMBER)
+            super(LocateRequestPayload.ObjectGroupMember, self).__init__(
+                value, Tags.OBJECT_GROUP_MEMBER)
 
     class MaximumItems(Integer):
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.MAXIMUM_ITEMS)
+            super(LocateRequestPayload.MaximumItems, self).__init__(
+                value, Tags.MAXIMUM_ITEMS)
 
     # 9.1.3.3.2
     class StorageStatusMask(Enumeration):
         ENUM_TYPE = enums.StorageStatusMask
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.STORAGE_STATUS_MASK)
+            super(LocateRequestPayload.StorageStatusMask, self).__init__(
+                value, Tags.STORAGE_STATUS_MASK)
 
     def __init__(self, maximum_items=None, storage_status_mask=None,
                  object_group_member=None, attributes=None):
-        super(self.__class__, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(LocateRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
         self.maximum_items = maximum_items
         self.storage_status_mask = storage_status_mask
         self.object_group_member = object_group_member
@@ -59,7 +59,7 @@ class LocateRequestPayload(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(LocateRequestPayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
         if self.is_tag_next(Tags.MAXIMUM_ITEMS, tstream):
             self.maximum_items = LocateRequestPayload.MaximumItems()
@@ -89,7 +89,7 @@ class LocateRequestPayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(LocateRequestPayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -103,12 +103,13 @@ class LocateRequestPayload(Struct):
 class LocateResponsePayload(Struct):
 
     def __init__(self, unique_identifiers=[]):
-        super(self.__class__, self).__init__(enums.Tags.RESPONSE_PAYLOAD)
+        super(LocateResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD)
         self.unique_identifiers = unique_identifiers or []
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(LocateResponsePayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         while self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
@@ -127,7 +128,7 @@ class LocateResponsePayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(LocateResponsePayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -32,7 +32,7 @@ class RegisterRequestPayload(Struct):
                  object_type=None,
                  template_attribute=None,
                  secret=None):
-        super(self.__class__, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(RegisterRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
 
         self.secret_factory = SecretFactory()
         self.object_type = object_type
@@ -42,7 +42,7 @@ class RegisterRequestPayload(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(RegisterRequestPayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
@@ -73,7 +73,7 @@ class RegisterRequestPayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(RegisterRequestPayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -89,7 +89,7 @@ class RegisterResponsePayload(Struct):
     def __init__(self,
                  unique_identifier=None,
                  template_attribute=None):
-        super(self.__class__, self).__init__(Tags.RESPONSE_PAYLOAD)
+        super(RegisterResponsePayload, self).__init__(Tags.RESPONSE_PAYLOAD)
 
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute
@@ -97,7 +97,7 @@ class RegisterResponsePayload(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(RegisterResponsePayload, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
@@ -121,7 +121,7 @@ class RegisterResponsePayload(Struct):
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(RegisterResponsePayload, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -45,18 +45,20 @@ class Attribute(Struct):
     class AttributeName(TextString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.ATTRIBUTE_NAME)
+            super(Attribute.AttributeName, self).__init__(
+                value, Tags.ATTRIBUTE_NAME)
 
     class AttributeIndex(Integer):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.ATTRIBUTE_INDEX)
+            super(Attribute.AttributeIndex, self).__init__(
+                value, Tags.ATTRIBUTE_INDEX)
 
     def __init__(self,
                  attribute_name=None,
                  attribute_index=None,
                  attribute_value=None):
-        super(self.__class__, self).__init__(tag=Tags.ATTRIBUTE)
+        super(Attribute, self).__init__(tag=Tags.ATTRIBUTE)
 
         self.value_factory = AttributeValueFactory()
 
@@ -68,7 +70,7 @@ class Attribute(Struct):
             attribute_value.tag = Tags.ATTRIBUTE_VALUE
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(Attribute, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the name of the attribute
@@ -108,7 +110,7 @@ class Attribute(Struct):
 
         # Write the length and value of the attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(Attribute, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def __eq__(self, other):
@@ -136,26 +138,32 @@ class Credential(Struct):
         ENUM_TYPE = CredentialType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.CREDENTIAL_TYPE)
+            super(Credential.CredentialType, self).__init__(
+                value, Tags.CREDENTIAL_TYPE)
 
     class UsernamePasswordCredential(Struct):
 
         class Username(TextString):
             def __init__(self, value=None):
-                super(self.__class__, self).__init__(value, Tags.USERNAME)
+                super(Credential.UsernamePasswordCredential.Username,
+                      self).__init__(
+                    value, Tags.USERNAME)
 
         class Password(TextString):
             def __init__(self, value=None):
-                super(self.__class__, self).__init__(value, Tags.PASSWORD)
+                super(Credential.UsernamePasswordCredential.Password,
+                      self).__init__(
+                    value, Tags.PASSWORD)
 
         def __init__(self, username=None, password=None):
-            super(self.__class__, self).__init__(tag=Tags.CREDENTIAL_VALUE)
+            super(Credential.UsernamePasswordCredential, self).__init__(
+                tag=Tags.CREDENTIAL_VALUE)
             self.username = username
             self.password = password
             self.validate()
 
         def read(self, istream):
-            super(self.__class__, self).read(istream)
+            super(Credential.UsernamePasswordCredential, self).read(istream)
             tstream = BytearrayStream(istream.read(self.length))
 
             # Read the username of the credential
@@ -179,7 +187,7 @@ class Credential(Struct):
 
             # Write the length and value of the credential
             self.length = tstream.length()
-            super(self.__class__, self).write(ostream)
+            super(Credential.UsernamePasswordCredential, self).write(ostream)
             ostream.write(tstream.buffer)
 
         def validate(self):
@@ -230,7 +238,8 @@ class Credential(Struct):
                      network_identifier=None,
                      machine_identifier=None,
                      media_identifier=None):
-            super(self.__class__, self).__init__(tag=Tags.CREDENTIAL_VALUE)
+            super(Credential.DeviceCredential, self).__init__(
+                tag=Tags.CREDENTIAL_VALUE)
             super.device_serial_number = device_serial_number
             super.password = password
             super.device_identifier = device_identifier
@@ -239,7 +248,7 @@ class Credential(Struct):
             super.media_identifier = media_identifier
 
         def read(self, istream):
-            super(self.__class__, self).read(istream)
+            super(Credential.DeviceCredential, self).read(istream)
             tstream = BytearrayStream(istream.read(self.length))
 
             # Read the password if it is next
@@ -293,19 +302,19 @@ class Credential(Struct):
 
             # Write the length and value of the credential
             self.length = tstream.length()
-            super(self.__class__, self).write(ostream)
+            super(Credential.DeviceCredential, self).write(ostream)
             ostream.write(tstream.buffer)
 
         def validate(self):
             pass
 
     def __init__(self, credential_type=None, credential_value=None):
-        super(self.__class__, self).__init__(tag=Tags.CREDENTIAL)
+        super(Credential, self).__init__(tag=Tags.CREDENTIAL)
         self.credential_type = credential_type
         self.credential_value = credential_value
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(Credential, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the type of the credential
@@ -333,7 +342,7 @@ class Credential(Struct):
 
         # Write the length and value of the credential
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(Credential, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -347,8 +356,8 @@ class KeyBlock(Struct):
         ENUM_TYPE = enums.KeyCompressionType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value,
-                                                 Tags.KEY_COMPRESSION_TYPE)
+            super(KeyBlock.KeyCompressionType, self).__init__(
+                value, Tags.KEY_COMPRESSION_TYPE)
 
     def __init__(self,
                  key_format_type=None,
@@ -357,7 +366,7 @@ class KeyBlock(Struct):
                  cryptographic_algorithm=None,
                  cryptographic_length=None,
                  key_wrapping_data=None):
-        super(self.__class__, self).__init__(Tags.KEY_BLOCK)
+        super(KeyBlock, self).__init__(Tags.KEY_BLOCK)
         self.key_format_type = key_format_type
         self.key_compression_type = key_compression_type
         self.key_value = key_value
@@ -367,7 +376,7 @@ class KeyBlock(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(KeyBlock, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.key_format_type = KeyFormatType()
@@ -414,7 +423,7 @@ class KeyBlock(Struct):
 
         # Write the length and value of the credential
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(KeyBlock, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -435,7 +444,7 @@ class KeyBlock(Struct):
 class KeyMaterial(ByteString):
 
     def __init__(self, value=None):
-        super(self.__class__, self).__init__(value, Tags.KEY_MATERIAL)
+        super(KeyMaterial, self).__init__(value, Tags.KEY_MATERIAL)
 
 
 # TODO (peter-hamilton) Get rid of this and replace with a KeyMaterial factory.
@@ -478,7 +487,7 @@ class KeyValue(Struct):
     def __init__(self,
                  key_material=None,
                  attributes=None):
-        super(self.__class__, self).__init__(Tags.KEY_VALUE)
+        super(KeyValue, self).__init__(Tags.KEY_VALUE)
 
         if key_material is None:
             self.key_material = KeyMaterial()
@@ -493,7 +502,7 @@ class KeyValue(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(KeyValue, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         # TODO (peter-hamilton) Replace this with a KeyMaterial factory.
@@ -521,7 +530,7 @@ class KeyValue(Struct):
             attribute.write(tstream)
 
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(KeyValue, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -571,14 +580,14 @@ class KeyInformation(Struct):
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  tag=Tags.ENCRYPTION_KEY_INFORMATION):
-        super(self.__class__, self).\
-            __init__(tag=Tags.ENCRYPTION_KEY_INFORMATION)
+        super(KeyInformation, self).__init__(
+            tag=Tags.ENCRYPTION_KEY_INFORMATION)
         self.unique_identifier = unique_identifier
         self.cryptographic_parameters = cryptographic_parameters
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(KeyInformation, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
@@ -601,7 +610,7 @@ class KeyInformation(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(KeyInformation, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -618,8 +627,8 @@ class EncryptionKeyInformation(KeyInformation):
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  tag=Tags.ENCRYPTION_KEY_INFORMATION):
-        super(self.__class__, self).\
-            __init__(unique_identifier, cryptographic_parameters, tag)
+        super(EncryptionKeyInformation, self).__init__(
+            unique_identifier, cryptographic_parameters, tag)
 
     def validate(self):
         self.__validate()
@@ -635,8 +644,8 @@ class MACSignatureKeyInformation(KeyInformation):
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  tag=Tags.MAC_SIGNATURE_KEY_INFORMATION):
-        super(self.__class__, self).\
-            __init__(unique_identifier, cryptographic_parameters, tag)
+        super(MACSignatureKeyInformation, self).__init__(
+            unique_identifier, cryptographic_parameters, tag)
 
     def validate(self):
         self.__validate()
@@ -651,12 +660,14 @@ class KeyWrappingData(Struct):
     class MACSignature(ByteString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.MAC_SIGNATURE)
+            super(KeyWrappingData.MACSignature, self).__init__(
+                value, Tags.MAC_SIGNATURE)
 
     class IVCounterNonce(ByteString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.IV_COUNTER_NONCE)
+            super(KeyWrappingData.IVCounterNonce, self).__init__(
+                value, Tags.IV_COUNTER_NONCE)
 
     def __init__(self,
                  wrapping_method=None,
@@ -665,7 +676,7 @@ class KeyWrappingData(Struct):
                  mac_signature=None,
                  iv_counter_nonce=None,
                  encoding_option=None):
-        super(self.__class__, self).__init__(Tags.KEY_WRAPPING_DATA)
+        super(KeyWrappingData, self).__init__(Tags.KEY_WRAPPING_DATA)
         self.wrapping_method = wrapping_method
         self.encryption_key_information = encryption_key_information
         self.mac_signature_key_information = mac_signature_key_information
@@ -675,7 +686,7 @@ class KeyWrappingData(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(KeyWrappingData, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.wrapping_method = WrappingMethod()
@@ -723,7 +734,7 @@ class KeyWrappingData(Struct):
 
         # Write the length and value of the key wrapping data
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(KeyWrappingData, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -740,7 +751,8 @@ class KeyWrappingSpecification(Struct):
     class AttributeName(TextString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.ATTRIBUTE_NAME)
+            super(KeyWrappingSpecification.AttributeName, self).__init__(
+                value, Tags.ATTRIBUTE_NAME)
 
     def __init__(self,
                  wrapping_method=None,
@@ -748,8 +760,8 @@ class KeyWrappingSpecification(Struct):
                  mac_signature_key_information=None,
                  attribute_name=None,
                  encoding_option=None):
-        super(self.__class__, self).\
-            __init__(tag=Tags.KEY_WRAPPING_SPECIFICATION)
+        super(KeyWrappingSpecification, self).__init__(
+            tag=Tags.KEY_WRAPPING_SPECIFICATION)
         self.wrapping_method = wrapping_method
         self.encryption_key_information = encryption_key_information
         self.mac_signature_key_information = mac_signature_key_information
@@ -757,7 +769,7 @@ class KeyWrappingSpecification(Struct):
         self.encoding_option = encoding_option
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(KeyWrappingSpecification, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.wrapping_method = WrappingMethod()
@@ -799,7 +811,7 @@ class KeyWrappingSpecification(Struct):
 
         # Write the length and value of the key wrapping data
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(KeyWrappingSpecification, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/secrets.py
+++ b/kmip/core/secrets.py
@@ -172,7 +172,7 @@ class KeyBlockKey(Struct):
 class SymmetricKey(KeyBlockKey):
 
     def __init__(self, key_block=None):
-        super(self.__class__, self).__init__(key_block, Tags.SYMMETRIC_KEY)
+        super(SymmetricKey, self).__init__(key_block, Tags.SYMMETRIC_KEY)
         self.validate()
 
     def validate(self):
@@ -187,7 +187,7 @@ class SymmetricKey(KeyBlockKey):
 class PublicKey(KeyBlockKey):
 
     def __init__(self, key_block=None):
-        super(self.__class__, self).__init__(key_block, Tags.PUBLIC_KEY)
+        super(PublicKey, self).__init__(key_block, Tags.PUBLIC_KEY)
         self.validate()
 
     def validate(self):
@@ -202,7 +202,7 @@ class PublicKey(KeyBlockKey):
 class PrivateKey(KeyBlockKey):
 
     def __init__(self, key_block=None):
-        super(self.__class__, self).__init__(key_block, Tags.PRIVATE_KEY)
+        super(PrivateKey, self).__init__(key_block, Tags.PRIVATE_KEY)
         self.validate()
 
     def validate(self):
@@ -219,33 +219,33 @@ class SplitKey(Struct):
     class SplitKeyParts(Integer):
 
         def __init__(self, value=None):
-                super(self.__class__, self).__init__(value,
-                                                     Tags.SPLIT_KEY_PARTS)
+            super(SplitKey.SplitKeyParts, self).__init__(
+                value, Tags.SPLIT_KEY_PARTS)
 
     class KeyPartIdentifier(Integer):
 
         def __init__(self, value=None):
-                super(self.__class__, self).__init__(value,
-                                                     Tags.KEY_PART_IDENTIFIER)
+            super(SplitKey.KeyPartIdentifier, self).__init__(
+                value, Tags.KEY_PART_IDENTIFIER)
 
     class SplitKeyThreshold(Integer):
 
         def __init__(self, value=None):
-                super(self.__class__, self).__init__(value,
-                                                     Tags.SPLIT_KEY_THRESHOLD)
+            super(SplitKey.SplitKeyThreshold, self).__init__(
+                value, Tags.SPLIT_KEY_THRESHOLD)
 
     class SplitKeyMethod(Enumeration):
         ENUM_TYPE = enums.SplitKeyMethod
 
         def __init__(self, value=None):
-                super(self.__class__, self).__init__(value,
-                                                     Tags.SPLIT_KEY_METHOD)
+            super(SplitKey.SplitKeyMethod, self).__init__(
+                value, Tags.SPLIT_KEY_METHOD)
 
     class PrimeFieldSize(BigInteger):
 
         def __init__(self, value=None):
-                super(self.__class__, self).__init__(value,
-                                                     Tags.PRIME_FIELD_SIZE)
+            super(SplitKey.PrimeFieldSize, self).__init__(
+                value, Tags.PRIME_FIELD_SIZE)
 
     def __init__(self,
                  split_key_parts=None,
@@ -254,7 +254,7 @@ class SplitKey(Struct):
                  split_key_method=None,
                  prime_field_size=None,
                  key_block=None):
-        super(self.__class__, self).__init__(Tags.SPLIT_KEY)
+        super(SplitKey, self).__init__(Tags.SPLIT_KEY)
         self.split_key_parts = split_key_parts
         self.key_part_identifier = key_part_identifier
         self.split_key_threshold = split_key_threshold
@@ -264,7 +264,7 @@ class SplitKey(Struct):
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(SplitKey, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.split_key_parts = SplitKey.SplitKeyParts()
@@ -301,7 +301,7 @@ class SplitKey(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(SplitKey, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -316,12 +316,12 @@ class SplitKey(Struct):
 class Template(Struct):
 
     def __init__(self, attributes=None):
-        super(self.__class__, self).__init__(Tags.TEMPLATE)
+        super(Template, self).__init__(Tags.TEMPLATE)
         self.attributes = attributes
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(Template, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.attributes = list()
@@ -346,7 +346,7 @@ class Template(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(Template, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -364,18 +364,19 @@ class SecretData(Struct):
         ENUM_TYPE = enums.SecretDataType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.SECRET_DATA_TYPE)
+            super(SecretData.SecretDataType, self).__init__(
+                value, Tags.SECRET_DATA_TYPE)
 
     def __init__(self,
                  secret_data_type=None,
                  key_block=None):
-        super(self.__class__, self).__init__(Tags.SECRET_DATA)
+        super(SecretData, self).__init__(Tags.SECRET_DATA)
         self.secret_data_type = secret_data_type
         self.key_block = key_block
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(SecretData, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.secret_data_type = SecretData.SecretDataType()
@@ -395,7 +396,7 @@ class SecretData(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(SecretData, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -413,23 +414,25 @@ class OpaqueObject(Struct):
         ENUM_TYPE = enums.OpaqueDataType
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.OPAQUE_DATA_TYPE)
+            super(OpaqueObject.OpaqueDataType, self).__init__(
+                value, Tags.OPAQUE_DATA_TYPE)
 
     class OpaqueDataValue(ByteString):
 
         def __init__(self, value=None):
-            super(self.__class__, self).__init__(value, Tags.OPAQUE_DATA_VALUE)
+            super(OpaqueObject.OpaqueDataValue, self).__init__(
+                value, Tags.OPAQUE_DATA_VALUE)
 
     def __init__(self,
                  opaque_data_type=None,
                  opaque_data_value=None):
-        super(self.__class__, self).__init__(Tags.OPAQUE_OBJECT)
+        super(OpaqueObject, self).__init__(Tags.OPAQUE_OBJECT)
         self.opaque_data_type = opaque_data_type
         self.opaque_data_value = opaque_data_value
         self.validate()
 
     def read(self, istream):
-        super(self.__class__, self).read(istream)
+        super(OpaqueObject, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.opaque_data_type = OpaqueObject.OpaqueDataType()
@@ -449,7 +452,7 @@ class OpaqueObject(Struct):
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(self.__class__, self).write(ostream)
+        super(OpaqueObject, self).write(ostream)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/server.py
+++ b/kmip/core/server.py
@@ -89,7 +89,7 @@ class KMIP(object):
 class KMIPImpl(KMIP):
 
     def __init__(self):
-        super(self.__class__, self).__init__()
+        super(KMIPImpl, self).__init__()
         self.logger = logging.getLogger(__name__)
         self.key_factory = KeyFactory()
         self.secret_factory = SecretFactory()
@@ -393,5 +393,5 @@ class KMIPImpl(KMIP):
 class InvalidFieldException(Exception):
 
     def __init__(self, result):
-        super(self.__class__, self).__init__()
+        super(InvalidFieldException, self).__init__()
         self.result = result

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -75,7 +75,7 @@ class KMIPProxy(KMIP):
                  do_handshake_on_connect=None,
                  suppress_ragged_eofs=None,
                  username=None, password=None, config='client'):
-        super(self.__class__, self).__init__()
+        super(KMIPProxy, self).__init__()
         self.logger = logging.getLogger(__name__)
         self.credential_factory = CredentialFactory()
         self.config = config

--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -42,9 +42,8 @@ class CreateResult(OperationResult):
                  object_type=None,
                  uuid=None,
                  template_attribute=None):
-        super(self.__class__, self).__init__(result_status,
-                                             result_reason,
-                                             result_message)
+        super(CreateResult, self).__init__(
+            result_status, result_reason, result_message)
         if object_type is not None:
             self.object_type = object_type
         else:
@@ -87,9 +86,8 @@ class RegisterResult(OperationResult):
                  result_message=None,
                  uuid=None,
                  template_attribute=None):
-        super(self.__class__, self).__init__(result_status,
-                                             result_reason,
-                                             result_message)
+        super(RegisterResult, self).__init__(
+            result_status, result_reason, result_message)
         if uuid is not None:
             self.uuid = uuid
         else:
@@ -126,9 +124,8 @@ class GetResult(OperationResult):
                  object_type=None,
                  uuid=None,
                  secret=None):
-        super(self.__class__, self).__init__(result_status,
-                                             result_reason,
-                                             result_message)
+        super(GetResult, self).__init__(
+            result_status, result_reason, result_message)
         if object_type is not None:
             self.object_type = object_type
         else:
@@ -152,9 +149,8 @@ class DestroyResult(OperationResult):
                  result_reason=None,
                  result_message=None,
                  uuid=None):
-        super(self.__class__, self).__init__(result_status,
-                                             result_reason,
-                                             result_message)
+        super(DestroyResult, self).__init__(
+            result_status, result_reason, result_message)
         if uuid is not None:
             self.uuid = uuid
         else:
@@ -168,9 +164,8 @@ class LocateResult(OperationResult):
                  result_reason=None,
                  result_message=None,
                  uuids=None):
-        super(self.__class__, self).__init__(result_status,
-                                             result_reason,
-                                             result_message)
+        super(LocateResult, self).__init__(
+            result_status, result_reason, result_message)
         self.uuids = uuids
 
 

--- a/kmip/tests/unit/core/test_primitives.py
+++ b/kmip/tests/unit/core/test_primitives.py
@@ -36,7 +36,7 @@ from kmip.core.primitives import ByteString
 class TestBase(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestBase, self).setUp()
         self.stream = BytearrayStream()
         self.bad_init = 'Bad Base initialization: attribute {0} missing'
         self.bad_write = ErrorStrings.BAD_EXP_RECV.format('Base.{0}', 'write',
@@ -48,7 +48,7 @@ class TestBase(TestCase):
                                                           '{2}')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestBase, self).tearDown()
 
     def test_is_oversized(self):
         base = Base()
@@ -246,7 +246,7 @@ class TestBase(TestCase):
 class TestInteger(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestInteger, self).setUp()
         self.stream = BytearrayStream()
         self.max_byte_int = 4294967295
         self.max_int = 2147483647
@@ -258,7 +258,7 @@ class TestInteger(TestCase):
         self.bad_read = ('Bad Integer.value read: expected {0}, received {1}')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestInteger, self).tearDown()
 
     def test_init(self):
         i = Integer(0)
@@ -434,7 +434,7 @@ class TestInteger(TestCase):
 class TestLongInteger(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestLongInteger, self).setUp()
         self.stream = BytearrayStream()
         self.max_byte_long = 18446744073709551615
         self.max_long = 9223372036854775807
@@ -447,7 +447,7 @@ class TestLongInteger(TestCase):
                          '{1}')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestLongInteger, self).tearDown()
 
     def test_init(self):
         i = LongInteger(0)
@@ -616,7 +616,7 @@ class TestLongInteger(TestCase):
 class TestBigInteger(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestBigInteger, self).setUp()
         self.stream = BytearrayStream()
         self.max_byte_long = 18446744073709551615
         self.max_long = 9223372036854775807
@@ -629,7 +629,7 @@ class TestBigInteger(TestCase):
                          'received {1}')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestBigInteger, self).tearDown()
 
     def test_big_integer(self):
         self.skip('BigInteger implementation incomplete')
@@ -814,7 +814,7 @@ class TestBigInteger(TestCase):
 class TestEnumeration(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestEnumeration, self).setUp()
         self.stream = BytearrayStream()
         Enumeration.ENUM_TYPE = Types
         self.bad_type = ErrorStrings.BAD_EXP_RECV.format('Enumeration.{0}',
@@ -830,7 +830,7 @@ class TestEnumeration(TestCase):
                                                              'write')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestEnumeration, self).tearDown()
 
     def test_init(self):
         e = Enumeration(Types.DEFAULT)
@@ -909,11 +909,11 @@ class TestEnumeration(TestCase):
 class TestBoolean(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestBoolean, self).setUp()
         self.stream = BytearrayStream()
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestBoolean, self).tearDown()
 
     def test_init(self):
         self.skip('')
@@ -946,7 +946,7 @@ class TestBoolean(TestCase):
 class TestTextString(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestTextString, self).setUp()
         self.stream = BytearrayStream()
         self.bad_type = ErrorStrings.BAD_EXP_RECV.format('TextString.{0}',
                                                          'type', '{1}', '{2}')
@@ -965,7 +965,7 @@ class TestTextString(TestCase):
                                                            '{1} bytes')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestTextString, self).tearDown()
 
     def test_init(self):
         value = 'Hello World'
@@ -1129,7 +1129,7 @@ class TestTextString(TestCase):
 class TestByteString(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestByteString, self).setUp()
         self.stream = BytearrayStream()
         self.bad_type = ErrorStrings.BAD_EXP_RECV.format('ByteString.{0}',
                                                          'type', '{1}', '{2}')
@@ -1148,7 +1148,7 @@ class TestByteString(TestCase):
                                                            '{1} bytes')
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestByteString, self).tearDown()
 
     def test_init(self):
         value = b'\x01\x02\x03'
@@ -1331,11 +1331,11 @@ class TestByteString(TestCase):
 class TestDateTime(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestDateTime, self).setUp()
         self.stream = BytearrayStream()
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestDateTime, self).tearDown()
 
     def test_init(self):
         self.skip('')
@@ -1362,11 +1362,11 @@ class TestDateTime(TestCase):
 class TestInterval(TestCase):
 
     def setUp(self):
-        super(self.__class__, self).setUp()
+        super(TestInterval, self).setUp()
         self.stream = BytearrayStream()
 
     def tearDown(self):
-        super(self.__class__, self).tearDown()
+        super(TestInterval, self).tearDown()
 
     def test_init(self):
         self.skip('')


### PR DESCRIPTION
This change removes all references to self.__class__. In object hierarchies with multiple levels of inheritance, using self.__class__ can cause an infinite loop when resolving references to parent classes.