### PR TITLE
Adding the pie package for the simplified PyKMIP API

### DIFF
--- a/kmip/pie/__init__.py
+++ b/kmip/pie/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
This change adds the pie package, which will be used for the simplified PyKMIP API, which will be officially known as the Pie API.