### PR TITLE
Adding the ManagedObject base class

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+from six import add_metaclass
+
+
+@add_metaclass(ABCMeta)
+class ManagedObject:
+    """
+    The abstract base object of the simplified KMIP object hierarchy.
+
+    A ManagedObject is a core KMIP object that is the subject of key
+    management operations. It contains various attributes that are common to
+    all types of ManagedObjects, including keys, certificates, and various
+    types of secret or sensitive data.
+
+    For more information, see Section 2.2 of the KMIP 1.1 specification.
+
+    Attributes:
+        value: The value of the ManagedObject. Type varies, usually bytes.
+        unique_identifier: The string ID of the ManagedObject.
+        names: A list of names associated with the ManagedObject.
+        object_type: An enumeration associated with the type of ManagedObject.
+    """
+
+    @abstractmethod
+    def __init__(self):
+        """
+        Create a ManagedObject.
+        """
+        self.value = None
+
+        self.unique_identifier = None
+        self.names = list()
+        self._object_type = None
+
+        # All remaining attributes are not considered part of the public API
+        # and are subject to change.
+        self._application_specific_informations = list()
+        self._contact_information = None
+        self._object_groups = list()
+        self._operation_policy_name = None
+
+        # The following attributes are placeholders for attributes that are
+        # unsupported by kmip.core
+        self._archive_date = None
+        self._initial_date = None
+        self._last_change_date = None
+
+    @property
+    def object_type(self):
+        """
+        Accessor and property definition for the object type attribute.
+
+        Returns:
+            ObjectType: An ObjectType enumeration that corresponds to the
+                class of the object.
+        """
+        return self._object_type
+
+    @object_type.setter
+    def object_type(self, value):
+        """
+        Set blocker for the object type attribute.
+
+        Raises:
+            AttributeError: Always raised to block setting of attribute.
+        """
+        raise AttributeError("object type cannot be set")
+
+    @abstractmethod
+    def __repr__(self):
+        pass
+
+    @abstractmethod
+    def __str__(self):
+        pass
+
+    @abstractmethod
+    def __eq__(self, other):
+        pass
+
+    @abstractmethod
+    def __ne__(self, other):
+        pass

--- a/kmip/tests/unit/pie/__init__.py
+++ b/kmip/tests/unit/pie/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/kmip/tests/unit/pie/test_managed_object.py
+++ b/kmip/tests/unit/pie/test_managed_object.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from testtools import TestCase
+
+from kmip.pie.objects import ManagedObject
+
+
+class DummyManagedObject(ManagedObject):
+    """
+    A dummy ManagedObject subclass for testing purposes.
+    """
+
+    def __init__(self, object_type=None):
+        """
+        Create a DummyManagedObject
+
+        Args:
+            object_type (any): A value to test the setting of the object_type
+                attribute. Optional, defaults to None.
+        """
+        super(DummyManagedObject, self).__init__()
+
+        self._object_type = object_type
+
+    def __repr__(self):
+        super(DummyManagedObject, self).__repr__()
+        return ''
+
+    def __str__(self):
+        super(DummyManagedObject, self).__str__()
+        return ''
+
+    def __eq__(self, other):
+        super(DummyManagedObject, self).__eq__(other)
+        return True
+
+    def __ne__(self, other):
+        super(DummyManagedObject, self).__ne__(other)
+        return False
+
+
+class TestManagedObject(TestCase):
+    """
+    Test suite for ManagedObject.
+
+    Since ManagedObject is an ABC abstract class, all tests are run against a
+    dummy subclass defined above, DummyManagedObject.
+    """
+
+    def setUp(self):
+        super(TestManagedObject, self).setUp()
+
+    def tearDown(self):
+        super(TestManagedObject, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a complete subclass of ManagedObject can be instantiated.
+        """
+        DummyManagedObject()
+
+    def test_get_object_type(self):
+        """
+        Test that the object type can be retrieved from the ManagedObject.
+        """
+        expected = 'dummy'
+        dummy = DummyManagedObject(expected)
+        observed = dummy.object_type
+
+        self.assertEqual(expected, observed)
+
+    def test_set_object_type(self):
+        """
+        Test that an AttributeError is raised when attempting to change the
+        value of the object type.
+        """
+        dummy = DummyManagedObject()
+
+        def set_object_type():
+            dummy.object_type = 'placeholder'
+
+        self.assertRaises(AttributeError, set_object_type)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a ManagedObject.
+        """
+        dummy = DummyManagedObject()
+        repr(dummy)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a ManagedObject.
+        """
+        dummy = DummyManagedObject()
+        str(dummy)
+
+    def test_eq(self):
+        """
+        Test that equality can be applied to a ManagedObject.
+        """
+        dummy = DummyManagedObject()
+        self.assertTrue(dummy == dummy)
+
+    def test_ne(self):
+        """
+        Test that inequality can be applied to a ManagedObject.
+        """
+        dummy = DummyManagedObject()
+        self.assertFalse(dummy != dummy)


### PR DESCRIPTION
This change adds ManagedObject, the abstract base class of the simplified KMIP object hierarchy. It defines a set of attributes common to all KMIP objects and registers placeholder methods to be implemented by all subclasses. A basic test suite is included, using a dummy ManagedObject subclass for testing.