### PR TITLE
Adding version module to improve version handling

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -17,6 +17,8 @@ import logging.config
 import os
 import sys
 
+exec(open('kmip/version.py').read())
+
 path = os.path.join(os.path.dirname(__file__), 'logconfig.ini')
 
 if os.path.exists(path):

--- a/kmip/version.py
+++ b/kmip/version.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+__version__ = '0.3.2'

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,11 @@
 
 import setuptools
 
+exec(open('kmip/version.py').read())
+
 setuptools.setup(
     name='PyKMIP',
-    version='0.3.2',
+    version=__version__,
     description='KMIP v1.1 library',
     keywords='KMIP',
     author='Peter Hamilton',


### PR DESCRIPTION
This change adds a top-level version module to hold the version definition for the library. This is then used in both kmip/__init__.py and setup.py, allowing version inspection on import of the library and automatic syncing of the version across the project.