### PR TITLE
Adding test case for bug with unsigned Enumeration encoding

### DIFF
--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -415,10 +415,9 @@ class Enumeration(Integer):
 
     def __validate(self):
         if self.enum is not None:
-            if type(self.enum) is not self.ENUM_TYPE:
-                msg = ErrorStrings.BAD_EXP_RECV
-                raise TypeError(msg.format(Enumeration.__name__, 'value',
-                                           Enum, type(self.enum)))
+            if not isinstance(self.enum, Enum):
+                raise TypeError("expected {0}, observed {1}".format(
+                    type(self.enum), Enum))
 
     def __repr__(self):
         return "{0}(value={1})".format(type(self).__name__, self.enum)

--- a/kmip/tests/unit/core/primitives/test_primitives.py
+++ b/kmip/tests/unit/core/primitives/test_primitives.py
@@ -18,6 +18,7 @@ from testtools import TestCase
 
 from kmip.core.enums import Tags
 from kmip.core.enums import Types
+from kmip.core.enums import OpaqueDataType
 
 from kmip.core.utils import BytearrayStream
 
@@ -904,6 +905,20 @@ class TestEnumeration(TestCase):
         self.assertEqual(len_exp, len_rcv, self.bad_write.format(len_exp,
                                                                  len_rcv))
         self.assertEqual(encoding, result, self.bad_encoding)
+
+    def test_write_unsigned(self):
+        """
+        Test that a large enumeration value is written correctly as an
+        unsigned integer.
+        """
+        encoding = (b'\x42\x00\x00\x05\x00\x00\x00\x04\x80\x00\x00\x00\x00\x00'
+                    b'\x00\x00')
+        e = Enumeration(OpaqueDataType.NONE)
+        e.write(self.stream)
+        result = self.stream.read()
+
+        self.assertEqual(len(encoding), len(result))
+        self.assertEqual(encoding, result)
 
 
 class TestBoolean(TestCase):


### PR DESCRIPTION
This change adds a test case that verifies a fix for a bug with how Enumerations were encoded as signed instead of unsigned integers. The validation check for Enumerations has also been updated to be more concise.