### PR TITLE
Integer Primitive Allows Longs

### DIFF
--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -207,7 +207,9 @@ class Integer(Base):
     def __validate(self):
         if self.value is not None:
             data_type = type(self.value)
-            if data_type is not int:
+            if data_type is long:
+                self.value = int(self.value)
+            elif data_type is not int:
                 raise errors.StateTypeError(Integer.__name__, int,
                                             data_type)
             num_bytes = utils.count_bytes(self.value)


### PR DESCRIPTION
The Integer primitive in kmip core represents an integer value. There
was a bug when integrating with Barbican where the value was being set
by a long. The long value could have been represented by an int
because the value fit in that range, but it was a long. I believe the
long type was used because of interactions with a database, but the
root cause of why it is a long is unknown.

This change allows a long value to be used for the Integer primitive.
If a long value is used then the long value is simply cast to an int.
If the data happened to be larger than what can fit in an int then the
Python formatting rules apply and data are likely lost. In the future
there could be a check to verify that value is ok.