### PR TITLE
Fixing startup logic

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -17,7 +17,7 @@ import logging.config
 import os
 import sys
 
-exec(open('kmip/version.py').read())
+import version
 
 path = os.path.join(os.path.dirname(__file__), 'logconfig.ini')
 


### PR DESCRIPTION
Removed "exec(open('kmip/version.py').read())" it is unclear what
this was attempting to accomplish but opening a Python file and
executing its content is analogous to the "import" statement.
This was also attempting to open and execute a file using a path
relative to the folder of invocation, this is a security flaw
even if it succeeds in finding such a file.