### PR TITLE
Fixing relative path bug when looking up library version

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -17,7 +17,9 @@ import logging.config
 import os
 import sys
 
-exec(open('kmip/version.py').read())
+version = os.path.join(os.path.dirname(
+    os.path.realpath(__file__)), 'version.py')
+exec(open(version).read())
 
 path = os.path.join(os.path.dirname(__file__), 'logconfig.ini')
 

--- a/kmip/tests/unit/test_kmip.py
+++ b/kmip/tests/unit/test_kmip.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from testtools import TestCase
+
+
+class TestKMIP(TestCase):
+    """
+    A test suite for the overall `kmip` module.
+    """
+
+    def setUp(self):
+        super(TestKMIP, self).setUp()
+
+    def tearDown(self):
+        super(TestKMIP, self).tearDown()
+
+    def test_version(self):
+        """
+        Verify that the kmip module has a __version__ attribute and that it's
+        value is correct.
+        """
+        kmip = __import__('kmip')
+        self.assertTrue(hasattr(kmip, '__version__'))
+
+        version = __import__('kmip.version')
+        self.assertTrue(hasattr(version, '__version__'))
+
+        observed = getattr(kmip, '__version__')
+        expected = getattr(version, '__version__')
+        self.assertEqual(expected, observed)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import setuptools
 
-exec(open('kmip/version.py').read())
+version = os.path.join(os.path.dirname(
+    os.path.realpath(__file__)), 'kmip', 'version.py')
+exec(open(version).read())
 
 setuptools.setup(
     name='PyKMIP',


### PR DESCRIPTION
This change fixes the use of relative paths used to fetch the PyKMIP library version number in kmip/__init__.py and setup.py. The absolute path of the file is now dynamically generated and used instead.