### PR TITLE
Fix a few bugs in Credential object

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -216,7 +216,7 @@ class Credential(Struct):
         class NetworkIdentifier(TextString):
 
             def __init__(self, value=None):
-                super(Credential.DeviceCredential.NetworkIdetifier, self).\
+                super(Credential.DeviceCredential.NetworkIdentifier, self).\
                     __init__(value, Tags.NETWORK_IDENTIFIER)
 
         class MachineIdentifier(TextString):
@@ -240,12 +240,12 @@ class Credential(Struct):
                      media_identifier=None):
             super(Credential.DeviceCredential, self).__init__(
                 tag=Tags.CREDENTIAL_VALUE)
-            super.device_serial_number = device_serial_number
-            super.password = password
-            super.device_identifier = device_identifier
-            super.network_identifier = network_identifier
-            super.machine_identifier = machine_identifier
-            super.media_identifier = media_identifier
+            self.device_serial_number = device_serial_number
+            self.password = password
+            self.device_identifier = device_identifier
+            self.network_identifier = network_identifier
+            self.machine_identifier = machine_identifier
+            self.media_identifier = media_identifier
 
         def read(self, istream):
             super(Credential.DeviceCredential, self).read(istream)


### PR DESCRIPTION
This was causing the PyKMIP server to fail silently when given valid requests with a Device Credential in the Request Header; maybe some logging should also be added?