### PR TITLE
Fixing bug with dangling file handle when setting __version__

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -17,9 +17,11 @@ import logging.config
 import os
 import sys
 
-version = os.path.join(os.path.dirname(
+# Dynamically set __version__
+version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'version.py')
-exec(open(version).read())
+with open(version_path, 'r') as version_file:
+    exec(version_file.read())
 
 path = os.path.join(os.path.dirname(__file__), 'logconfig.ini')
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,11 @@
 import os
 import setuptools
 
-version = os.path.join(os.path.dirname(
+# Dynamically set __version__
+version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'kmip', 'version.py')
-exec(open(version).read())
+with open(version_path, 'r') as version_file:
+    exec(version_file.read())
 
 setuptools.setup(
     name='PyKMIP',


### PR DESCRIPTION
This change fixes a bug whereby a file handle was left unclosed after being used to dynamically set __version__.