### PR TITLE
Adding a demo for the Activate operation

### DIFF
--- a/kmip/demos/units/activate.py
+++ b/kmip/demos/units/activate.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from kmip.core.enums import Operation
+from kmip.core.enums import ResultStatus
+
+from kmip.demos import utils
+
+from kmip.services.kmip_client import KMIPProxy
+
+import logging
+import os
+import sys
+
+
+if __name__ == '__main__':
+    # Build and parse arguments
+    parser = utils.build_cli_parser(Operation.ACTIVATE)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    uuid = opts.uuid
+
+    # Exit early if the UUID is not specified
+    if uuid is None:
+        logging.debug('No UUID provided, exiting early from demo')
+        sys.exit()
+
+    # Build and setup logging and needed factories
+    f_log = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                         'logconfig.ini')
+    logging.config.fileConfig(f_log)
+    logger = logging.getLogger(__name__)
+
+    # Build the client and connect to the server
+    client = KMIPProxy(config=config)
+    client.open()
+
+    # Activate the object
+    result = client.activate(uuid)
+    client.close()
+
+    # Display operation results
+    logger.info('activate() result status: {0}'.format(
+        result.result_status.enum))
+
+    if result.result_status.enum == ResultStatus.SUCCESS:
+        logger.info('activated UUID: {0}'.format(result.uuid.value))
+    else:
+        logger.info('activate() result reason: {0}'.format(
+            result.result_reason.enum))
+        logger.info('activate() result message: {0}'.format(
+            result.result_message.value))

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -125,6 +125,15 @@ def build_cli_parser(operation):
             default=None,
             dest="uuid",
             help="UUID of secret to delete from the KMIP server")
+    elif operation is Operation.ACTIVATE:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UUID of secret to activate on the KMIP server")
     elif operation is Operation.GET:
         parser.add_option(
             "-i",


### PR DESCRIPTION
This change adds a unit demo for the Activate operation. The operation accepts the UID of a KMIP managed object that needs to be activated for future use.