### PR TITLE
Adding customizable timeout support to the KMIP client

### DIFF
--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -36,6 +36,9 @@ class ConfigHelper(object):
     DEFAULT_USERNAME = None
     DEFAULT_PASSWORD = None
 
+    # Timeout measured in seconds
+    DEFAULT_TIMEOUT = 30
+
     def __init__(self):
         self.logger = logging.getLogger(__name__)
 
@@ -78,6 +81,7 @@ class ConfigHelper(object):
                 return_value = default_value
                 self.logger.debug(DEFAULT_MSG.format(default_value,
                                                      config_option_name))
+        # TODO (peter-hamilton): Think about adding better value validation
         if return_value == self.NONE_VALUE:
             return None
         else:

--- a/kmip/kmipconfig.ini
+++ b/kmip/kmipconfig.ini
@@ -10,6 +10,7 @@ do_handshake_on_connect=True
 suppress_ragged_eofs=True
 username=None
 password=None
+timeout=30
 
 [server]
 host=127.0.0.1


### PR DESCRIPTION
This change adds support for a customizable timeout option for the KMIP client. The client will stop attempting connections or operations once the timeout is exceeded instead of waiting for the default system timeout. The default timeouts is 30 seconds.