### PR TITLE
Remove AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,3 +1,0 @@
-Nathan Reller <Nathan.Reller@jhuapl.edu>
-Peter Hamilton <peter.hamilton@jhuapl.edu>
-Kaitlin Farr <kaitlin.farr@jhuapl.edu>


### PR DESCRIPTION
The authors included in AUTHORS.txt hasn't been updated in nearly a
year and is outdated. Rather than tracking the authors explicitly, it
would be better to extract this information from Git's commit
history.

The following command can be used to retrieve a list of the authors
for all the patches contributed to PyKMIP:
    git log | grep ^Author | sort | uniq

Resolves #30