### PR TITLE
Adding opaque object examples for the ProxyKmipClient

### DIFF
--- a/kmip/demos/pie/register_opaque_object.py
+++ b/kmip/demos/pie/register_opaque_object.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+from kmip.pie import objects
+
+
+if __name__ == '__main__':
+    parser = utils.build_cli_parser()
+    logger = logging.getLogger(__name__)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+
+    value = b'\x53\x65\x63\x72\x65\x74\x50\x61\x73\x73\x77\x6F\x72\x64'
+    opaque_type = enums.OpaqueDataType.NONE
+    name = 'Demo Opaque Object'
+
+    obj = objects.OpaqueObject(value, opaque_type, name)
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(config=config) as client:
+        try:
+            uid = client.register(obj)
+            logger.info("Successfully registered opaque object with ID: "
+                        "{0}".format(uid))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -379,3 +379,28 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
                 exceptions.KmipOperationFailure, self.client.get, uid)
             self.assertRaises(
                 exceptions.KmipOperationFailure, self.client.destroy, uid)
+
+    def test_opaque_object_register_get_destroy(self):
+        """
+        Test that the ProxyKmipClient can register, retrieve, and destroy an
+        opaque object.
+        """
+        # Object encoding obtained from Section 3.1.5 of the KMIP 1.1 test
+        # documentation.
+        obj = objects.OpaqueObject(
+            b'\x53\x65\x63\x72\x65\x74\x50\x61\x73\x73\x77\x6F\x72\x64',
+            enums.OpaqueDataType.NONE)
+        uid = self.client.register(obj)
+        self.assertIsInstance(uid, six.string_types)
+
+        try:
+            result = self.client.get(uid)
+            self.assertIsInstance(result, objects.OpaqueObject)
+            self.assertEqual(
+                result, obj, "expected {0}\nobserved {1}".format(result, obj))
+        finally:
+            self.client.destroy(uid)
+            self.assertRaises(
+                exceptions.KmipOperationFailure, self.client.get, uid)
+            self.assertRaises(
+                exceptions.KmipOperationFailure, self.client.destroy, uid)


### PR DESCRIPTION
This change adds two examples showing how to use opaque objects with the ProxyKmipClient. The first is a unit demo showing how to register an opaque object using the register operation of the ProxyKmipClient. The second is an integration test showing how to register, get, and destroy an opaque object using the ProxyKmipClient.