### PR TITLE
KMIPServer serve log exceptions

### DIFF
--- a/kmip/services/kmip_server.py
+++ b/kmip/services/kmip_server.py
@@ -69,7 +69,8 @@ class KMIPServer(object):
             try:
                 while True:
                     self._processor.process(protocol, protocol)
-            except Exception:
+            except Exception as e:
+                self.logger.error('KMIPServer {0} {1}'.format(type(e),e))
                 connection.close()
 
     def _set_variables(self, host, port, keyfile, certfile, cert_reqs,


### PR DESCRIPTION
The Exception handler discards all errors, would be nice to log them
to the error logger before closing the connection.

It is very useful to get some notice about the NotImplementedErrors when interfacing with the server