### PR TITLE
Adding KMIPProxy support for the GetAttributeList operation

### DIFF
--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -158,6 +158,21 @@ class GetResult(OperationResult):
             self.secret = None
 
 
+class GetAttributeListResult(OperationResult):
+
+    def __init__(
+            self,
+            result_status,
+            result_reason=None,
+            result_message=None,
+            uid=None,
+            names=None):
+        super(GetAttributeListResult, self).__init__(
+            result_status, result_reason, result_message)
+        self.uid = uid
+        self.names = names
+
+
 class DestroyResult(OperationResult):
 
     def __init__(self,


### PR DESCRIPTION
This change adds support for the GetAttributeList operation to the KMIPProxy client. It adds a new result object for the operation along with an integration test demonstrating how the operation can be used. Client unit test cases are also included.