### PR TITLE
Adding ProxyKmipClient support for the GetAttributeList operation

### DIFF
--- a/kmip/demos/pie/get_attribute_list.py
+++ b/kmip/demos/pie/get_attribute_list.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+from kmip.pie import client
+
+
+if __name__ == '__main__':
+    # Build and parse arguments
+    parser = utils.build_cli_parser(enums.Operation.GET_ATTRIBUTE_LIST)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    uid = opts.uuid
+
+    # Exit early if the UUID is not specified
+    if uid is None:
+        logging.debug('No ID provided, exiting early from demo')
+        sys.exit()
+
+    # Build and setup logging and needed factories
+    f_log = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
+                         'logconfig.ini')
+    logging.config.fileConfig(f_log)
+    logger = logging.getLogger(__name__)
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(config=config) as client:
+        try:
+            attribute_names = client.get_attribute_list(uid)
+            logger.info("Successfully retrieved {0} attribute names:".format(
+                len(attribute_names)))
+            for attribute_name in attribute_names:
+                logger.info("Attribute name: {0}".format(attribute_name))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -161,6 +161,15 @@ def build_cli_parser(operation=None):
             dest="format",
             help=("Format in which to retrieve the secret. Supported formats "
                   "include: RAW, PKCS_1, PKCS_8, X_509"))
+    elif operation is Operation.GET_ATTRIBUTE_LIST:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
     elif operation is Operation.LOCATE:
         parser.add_option(
             "-n",

--- a/kmip/pie/api.py
+++ b/kmip/pie/api.py
@@ -71,6 +71,17 @@ class KmipClient:
         pass
 
     @abc.abstractmethod
+    def get_attribute_list(self, uid):
+        """
+        Get a list of attribute names for a managed object on a KMIP appliance.
+
+        Args:
+            uid (string): The unique ID of the managed object whose attribute
+                names should be retrieved.
+        """
+        pass
+
+    @abc.abstractmethod
     def destroy(self, uid):
         """
         Destroy a managed object stored by a KMIP appliance.

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -309,6 +309,39 @@ class ProxyKmipClient(api.KmipClient):
             message = result.result_message.value
             raise exceptions.KmipOperationFailure(status, reason, message)
 
+    def get_attribute_list(self, uid=None):
+        """
+        Get the names of the attributes associated with a managed object.
+
+        If the uid is not specified, the appliance will use the ID placeholder
+        by default.
+
+        Args:
+            uid (string): The unique ID of the managed object with which the
+                retrieved attribute names should be associated. Optional,
+                defaults to None.
+        """
+        # Check input
+        if uid is not None:
+            if not isinstance(uid, six.string_types):
+                raise TypeError("uid must be a string")
+
+        # Verify that operations can be given at this time
+        if not self._is_open:
+            raise exceptions.ClientConnectionNotOpen()
+
+        # Get the list of attribute names for a managed object.
+        result = self.proxy.get_attribute_list(uid)
+
+        status = result.result_status.enum
+        if status == enums.ResultStatus.SUCCESS:
+            attribute_names = sorted(result.names)
+            return attribute_names
+        else:
+            reason = result.result_reason.enum
+            message = result.result_message.value
+            raise exceptions.KmipOperationFailure(status, reason, message)
+
     def destroy(self, uid):
         """
         Destroy a managed object stored by a KMIP appliance.

--- a/kmip/tests/unit/pie/test_api.py
+++ b/kmip/tests/unit/pie/test_api.py
@@ -38,6 +38,9 @@ class DummyKmipClient(api.KmipClient):
     def get(self, uid, *args, **kwargs):
         super(DummyKmipClient, self).get(uid)
 
+    def get_attribute_list(self, uid, *args, **kwargs):
+        super(DummyKmipClient, self).get_attribute_list(uid)
+
     def destroy(self, uid):
         super(DummyKmipClient, self).destroy(uid)
 
@@ -89,6 +92,13 @@ class TestKmipClient(testtools.TestCase):
         """
         dummy = DummyKmipClient()
         dummy.get('uid')
+
+    def test_get_attribute_list(self):
+        """
+        Test that the get_attribute_list method can be called without error.
+        """
+        dummy = DummyKmipClient()
+        dummy.get_attribute_list('uid')
 
     def test_destroy(self):
         """


### PR DESCRIPTION
This change adds support for the GetAttributeList operation to the ProxyKmipClient. It updates the Pie client API and provides a demo showing how to use the operation. All relevant test suites are updated accordingly.