### PR TITLE
PyKMIP - Release 0.4.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,18 @@
+0.4.0 - August 14, 2015
+* Add the official Pie API for a simpler KMIP interface
+* Add the ProxyKmipClient implementation of the Pie API
+* Add key, secret, and opaque objects to the Pie object hierarchy
+* Add unit demos for all ProxyKmipClient operations
+* Add complete unit and integration test suites for the Pie package
+* Add KMIPProxy client support/demos for the Activate and Revoke operations
+* Add KMIPProxy client connection timeout support
+* Add KMIPProxy integration tests for asymmetric key and secret/opaque objects
+* Add improved request error logging for the KMIPServer
+* Update README with additional information about the clients and Pie API
+* Remove AUTHORS in favor of Git commit history
+* Fix bug with dangling file handle when setting __version__
+* Fix bug with dangling socket connection upon client destruction
+
 0.3.3 - June 25, 2015
 * Add the core ManagedObject class hierarchy for the new Pie API
 * Add updated Boolean primitive implementation and test suite

--- a/kmip/version.py
+++ b/kmip/version.py
@@ -13,4 +13,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '0.3.3'
+__version__ = '0.4.0'


### PR DESCRIPTION
This update includes several new features and bug fixes:
* Add the official Pie API for a simpler KMIP interface
* Add the ProxyKmipClient implementation of the Pie API
* Add key, secret, and opaque objects to the Pie object hierarchy
* Add unit demos for all ProxyKmipClient operations
* Add complete unit and integration test suites for the Pie package
* Add KMIPProxy client support for the Activate and Revoke operations
* Add KMIPProxy client connection timeout support
* Add KMIPProxy integration tests for asymm. key/secret/opaque objects
* Add improved request error logging for the KMIPServer
* Update README with more information about the clients and Pie API
* Remove AUTHORS in favor of Git commit history
* Fix bug with dangling file handle when setting __version__
* Fix bug with dangling socket connection upon client destruction