### PR TITLE
Updating integration tests to ignore software server

### DIFF
--- a/kmip/tests/integration/services/test_kmip_client.py
+++ b/kmip/tests/integration/services/test_kmip_client.py
@@ -13,6 +13,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import pytest
+
 from testtools import TestCase
 
 from subprocess import Popen
@@ -55,6 +57,7 @@ from kmip.services.kmip_client import KMIPProxy
 import kmip.core.utils as utils
 
 
+@pytest.mark.ignore
 class TestKMIPClientIntegration(TestCase):
     STARTUP_TIME = 1.0
     SHUTDOWN_TIME = 0.1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    ignore: skip the given test object

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = flake8 kmip/
 deps = {[testenv]deps}
 basepython=python2.7
 commands =
-    py.test --strict kmip/tests/integration {posargs}
+    py.test --strict kmip/tests/integration -m "not ignore" {posargs}
 
 [flake8]
 exclude = .git,.tox,dist,rpmbuild,*.egg-info


### PR DESCRIPTION
This change adds a new pytest marker, ignore. It is used to silently skip the software server integration test suite, which is now broken from a recent ssl update. A pytest ini configuration file is also added to register the new marker.