### PR TITLE
Deleting broken server script

### DIFF
--- a/bin/run_server.sh
+++ b/bin/run_server.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-python ../kmip/demos/server.py


### PR DESCRIPTION
This change removes an old and out-of-date script used to run the PyKMIP software server.