### PR TITLE
Updating version handling

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -15,13 +15,15 @@
 
 import logging.config
 import os
+import re
 import sys
 
 # Dynamically set __version__
 version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'version.py')
 with open(version_path, 'r') as version_file:
-    exec(version_file.read())
+    mo = re.search(r"^.*= '(\d\.\d\.\d)'$", version_file.read(), re.MULTILINE)
+    __version__ = mo.group(1)
 
 path = os.path.join(os.path.dirname(__file__), 'logconfig.ini')
 

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,15 @@
 # limitations under the License.
 
 import os
+import re
 import setuptools
 
 # Dynamically set __version__
 version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'kmip', 'version.py')
 with open(version_path, 'r') as version_file:
-    exec(version_file.read())
+    mo = re.search(r"^.*= '(\d\.\d\.\d)'$", version_file.read(), re.MULTILINE)
+    __version__ = mo.group(1)
 
 setuptools.setup(
     name='PyKMIP',


### PR DESCRIPTION
This change updates how the library version number is dynamically loaded. It removes the use of exec in favor of a regular expression.