### PR TITLE
Adding Travis CI and Coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+install:
+  - pip install tox
+  - pip install coveralls
+script:
+  - tox
+env:
+  - TOXENV=pep8
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+after_success:
+  - coveralls
+

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 ------
 PyKMIP
 ------
+|coverage-status|
+
 PyKMIP is a Python implementation of the Key Management Interoperability
 Protocol (KMIP). KMIP is a client/server communication protocol for the
 storage and maintenance of key, certificate, and secret objects. The standard
@@ -243,3 +245,7 @@ For more information on KMIP version 1.1, see the following documentation:
 .. _Python SSL library documentation: https://docs.python.org/dev/library/ssl.html#socket-creation
 .. _KMIP Wikipedia page: https://en.wikipedia.org/wiki/Key_Management_Interoperability_Protocol
 .. _KMIP Technical Committee home page: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=kmip
+.. |coverage-status| image:: https://coveralls.io/repos/OpenKMIP/PyKMIP/badge.svg
+  :target: https://coveralls.io/github/OpenKMIP/PyKMIP
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,11 @@
 envlist = pep8,py26,py27,py33,py34
 
 [testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+       coveralls
 
 commands =
     coverage run --source=kmip/ --omit=kmip/demos/*,kmip/tests/* -m pytest --strict kmip/tests/unit


### PR DESCRIPTION
This change adds Travis CI and Coveralls support to enable integration with third-party testing and coverage statistics reporting services.