### PR TITLE
Updating Travis CI configuration to invoke Bandit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 install:
   - pip install tox
+  - pip install bandit
   - pip install coveralls
 script:
   - tox
@@ -10,6 +11,7 @@ env:
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=bandit
 after_success:
   - coveralls
 


### PR DESCRIPTION
This change updates the Travis CI configuration to invoke the tox Bandit environment when running PyKMIP test suites.