### PR TITLE
Fix BatchErrorContinuation message initialization

### DIFF
--- a/kmip/core/messages/contents.py
+++ b/kmip/core/messages/contents.py
@@ -240,7 +240,7 @@ class BatchErrorContinuationOption(Enumeration):
 
     def __init__(self, value=None):
         super(BatchErrorContinuationOption, self).__init__(
-            BatchErrorContinuationOption, value,
+            enums.BatchErrorContinuationOption, value,
             enums.Tags.BATCH_ERROR_CONTINUATION_OPTION)
 
 


### PR DESCRIPTION
Hi, since we've updated to 0.4.1, PyKMIP's server has been emitting some errors when we send it messages:

    kmip.services.server.kmip_server - ERROR - KMIPServer <class 'TypeError'> enumeration type <class 'kmip.core.messages.contents.BatchErrorContinuationOpt
ion'> must be of type EnumMeta

I traced it down and it looks like kmip.core.messages.contents.BatchErrorContinuationOpt is passing its parent class a reference to itself, instead of its counterpart from kmip.core.enums. I modified the call to more closely resemble the other message contents objects which pass enumerations in this file. This appears to solve the issue we've been experiencing.