### PR TITLE
Fixing line break style error

### DIFF
--- a/kmip/core/messages/contents.py
+++ b/kmip/core/messages/contents.py
@@ -103,10 +103,9 @@ class ProtocolVersion(Struct):
     def __eq__(self, other):
         if isinstance(other, ProtocolVersion):
             if ((self.protocol_version_major ==
-                    other.protocol_version_major)
-                    and
-                    (self.protocol_version_minor ==
-                     other.protocol_version_minor)):
+                 other.protocol_version_major) and
+                (self.protocol_version_minor ==
+                 other.protocol_version_minor)):
                 return True
             else:
                 return False


### PR DESCRIPTION
This change fixes a minor style error where a line break was used before a binary operator in an if-statement.