### PR TITLE
Fixing bug with DateTime str test

### DIFF
--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -977,7 +977,7 @@ class DateTime(LongInteger):
         return "DateTime(value={0}, tag={1})".format(self.value, self.tag)
 
     def __str__(self):
-        return time.ctime(self.value)
+        return time.asctime(time.gmtime(self.value))
 
 
 class Interval(Base):

--- a/kmip/tests/unit/core/primitives/test_date_time.py
+++ b/kmip/tests/unit/core/primitives/test_date_time.py
@@ -14,7 +14,6 @@
 # under the License.
 
 import testtools
-import time
 
 from kmip.core import primitives
 from kmip.core import utils
@@ -90,8 +89,7 @@ class TestDateTime(testtools.TestCase):
         Test that the string representation of a DateTime is formatted
         properly.
         """
-        t = (2015, 8, 11, 9, 18, 55, 1, 223, 1)
-        s = "Tue Aug 11 09:18:55 2015"
+        expected = 'Tue Aug 11 13:18:55 2015'
+        date_time = primitives.DateTime(1439299135)
 
-        date_time = primitives.DateTime(int(time.mktime(t)))
-        self.assertEqual(s, str(date_time))
+        self.assertEqual(expected, str(date_time))


### PR DESCRIPTION
An issue with local daylight savings time causes a comparison error in some locales when checking against a hard-coded expected time string. The hard-coded value has been replaced with a dynamic value that accounts for locale variances.

Fixes #124