### PR TITLE
'protocol-versions' option for 'discover-versions' demo

### DIFF
--- a/kmip/demos/units/discover_versions.py
+++ b/kmip/demos/units/discover_versions.py
@@ -16,6 +16,8 @@
 from kmip.core.enums import Operation
 from kmip.core.enums import ResultStatus
 
+from kmip.core.messages.contents import ProtocolVersion
+
 from kmip.demos import utils
 
 from kmip.services.kmip_client import KMIPProxy
@@ -23,6 +25,7 @@ from kmip.services.kmip_client import KMIPProxy
 import logging
 import os
 import sys
+import re
 
 
 if __name__ == '__main__':
@@ -34,6 +37,13 @@ if __name__ == '__main__':
     password = opts.password
     config = opts.config
 
+    protocol_versions = list()
+    if opts.protocol_versions is not None:
+        for version in re.split(',| ', opts.protocol_versions):
+            mm = re.split('\.', version)
+            protocol_versions.append(ProtocolVersion.create(int(mm[0]),
+                                                            int(mm[1])))
+
     # Build and setup logging
     f_log = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
                          'logconfig.ini')
@@ -44,7 +54,7 @@ if __name__ == '__main__':
     client = KMIPProxy(config=config)
     client.open()
 
-    result = client.discover_versions()
+    result = client.discover_versions(protocol_versions=protocol_versions)
     client.close()
 
     # Display operation results

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -199,6 +199,16 @@ def build_cli_parser(operation=None):
             help=("Type of the object to register. Supported types include: "
                   "CERTIFICATE, PRIVATE_KEY, PUBLIC_KEY, SYMMETRIC_KEY, "
                   "SECRET_DATA"))
+    elif operation is Operation.DISCOVER_VERSIONS:
+        parser.add_option(
+                "-v",
+                "--protocol-versions",
+                action="store",
+                type="str",
+                default=None,
+                dest="protocol_versions",
+                help=("Protocol versions supported by client. "
+                      "ex. '1.1,1.2 1.3'"))
 
     return parser
 


### PR DESCRIPTION
For 'discover-versions' demo the _protocol-versions_ used to specify the protocol versions supported by client.

This PR comes in pair with PR #128 