### PR TITLE
Added Documentation for No Database Migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,14 @@ The KMIP server provides basic support for the following operations:
 * ``Get``
 * ``Destroy``
 
+The provided software server is for testing and demonstration purposes. It does
+provide the ability to store managed objects. The current implementation stores
+the managed objects in memory, and in the future there is likely to be support
+for persistent storage via a database. If persistent storage is added in the
+future then the current plan is not to implement database migration scripts.
+This in part because the server is for testing and demonstration purposes and
+in part because there is no demand for such a feature.
+
 Configuration
 *************
 The KMIP software server also pulls settings from the PyKMIP configuration


### PR DESCRIPTION
Added documentation to the README to indicate that database migration
scripts will not be provided in future versions.