### PR TITLE
fix: session: 'expected str instance, NoneType found'

### DIFF
--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -51,6 +51,9 @@ class KmipSession(threading.Thread):
             kwargs={}
         )
 
+        if name is None:
+            name = self.name
+
         self._logger = logging.getLogger('.'.join((__name__, name)))
 
         self._engine = engine

--- a/kmip/tests/unit/services/server/test_session.py
+++ b/kmip/tests/unit/services/server/test_session.py
@@ -38,6 +38,12 @@ class TestKmipSession(testtools.TestCase):
         """
         session.KmipSession(None, None, 'name')
 
+    def test_init_without_name(self):
+        """
+        Test that a KmipSession without 'name' can be created without errors.
+        """
+        session.KmipSession(None, None, None)
+
     def test_run(self):
         """
         Test that the message handling loop is handled properly on normal


### PR DESCRIPTION
When KmipSession instantiated without session name there is error:
File ".../PyKMIP/kmip/services/server/session.py", line 57, in __init__
    self._logger = logging.getLogger('.'.join((__name__, name)))
TypeError: sequence item 1: expected str instance, NoneType found