### PR TITLE
Linking the loggers for the different KmipServer components

### DIFF
--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -36,7 +36,8 @@ class CryptographyEngine(api.CryptographicEngine):
         """
         Construct a CryptographyEngine.
         """
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger('kmip.server.engine.cryptography')
+
         self._symmetric_key_algorithms = {
             enums.CryptographicAlgorithm.TRIPLE_DES: algorithms.TripleDES,
             enums.CryptographicAlgorithm.AES: algorithms.AES,

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -79,7 +79,7 @@ class KmipEngine(object):
         """
         Create a KmipEngine.
         """
-        self._logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger('kmip.server.engine')
 
         self._cryptography_engine = engine.CryptographyEngine()
 

--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -51,10 +51,9 @@ class KmipSession(threading.Thread):
             kwargs={}
         )
 
-        if name is None:
-            name = self.name
-
-        self._logger = logging.getLogger('.'.join((__name__, name)))
+        self._logger = logging.getLogger(
+            'kmip.server.session.{0}'.format(self.name)
+        )
 
         self._engine = engine
         self._connection = connection


### PR DESCRIPTION
This change renames the loggers for different KmipServer components, ensuring that all server logs are processed by the same kmip.server logger.