### PR TITLE
Fixing bug terminating connection prematurely

### DIFF
--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -211,6 +211,14 @@ class ConfigurationError(Exception):
     pass
 
 
+class ConnectionClosed(Exception):
+    """
+    An exception generated when attempting to use a connection that has been
+    closed.
+    """
+    pass
+
+
 class NetworkingError(Exception):
     """
     An error generated when a problem occurs with client or server networking


### PR DESCRIPTION
This change fixes a bug with the KmipSession connection handling logic that would terminate the connection before actually receiving a termination from the client. The corresponding unit tests have been updated to reflect this fix.