### PR TITLE
Fixing bug with in-memory SQLite storage

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -84,7 +84,7 @@ class KmipEngine(object):
         self._cryptography_engine = engine.CryptographyEngine()
 
         self._data_store = sqlalchemy.create_engine(
-            'sqlite:///:memory:',
+            'sqlite:////tmp/pykmip.database',
             echo=False
         )
         sqltypes.Base.metadata.create_all(self._data_store)


### PR DESCRIPTION
This change swaps out the in-memory SQLite database for file-based data storage. SQLAlchemy support for in-memory SQLite storage does not work across threads. The new storage scheme stores all PyKMIP server data in /tmp.