### PR TITLE
server-engine: fix crypto-length in Create

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,27 @@
-0.4.1
+0.5.0 - April 14, 2016
+* Add KmipServer server implementation
+* Add KmipSession to manage threaded client/server connections
+* Add KmipEngine for processing core server application logic
+* Add KmipEngine support for CRUD operations for managed objects
+* Add SQLAlchemy/SQLite support for KmipEngine data storage
+* Add CryptographyEngine component for cryptographic operations
+* Add pending deprecation warning for Python 2.6 support
+* Add pending deprecation warning for the KMIPServer implementation
+* Add support for building Sphinx documentation
+* Add support for SQLAlchemy tables to all Pie objects
+* Add Python magic methods to Attribute and Name objects
+* Add Attribute class unit tests
+* Add bin script to run the KmipServer
+* Add setup entry points to run the KmipServer
+* Update DiscoverVersions demo with optional versions argument
+* Update all demo scripts to setup their own logging infrastructure
+* Update README with information on the KmipServer implementation
+* Remove expired certificate files from the integration test suite
+* Remove default package log configuration and configuration file
+* Fix bug with Locate payload parsing optional values
+* Fix bug with DateTime string tests and move to UTC representation
+
+0.4.1 - December 2, 2015
 * Add support for the GetAttributeList operation
 * Add integration with Travis CI, Codecov/Coveralls, and Bandit
 * Add client/server failover support using multiple IP addresses

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -60,6 +60,8 @@ class CryptographyEngine(api.CryptographicEngine):
                 algorithm for which the created key will be compliant.
             length(int): The length of the key to be created. This value must
                 be compliant with the constraints of the provided algorithm.
+                Optional. If not specified, the key length is the maximal
+                allowed for a given cryptographic algorithm.
 
         Returns:
             dict: A dictionary containing the key data, with the following
@@ -86,7 +88,13 @@ class CryptographyEngine(api.CryptographicEngine):
 
         cryptography_algorithm = self._symmetric_key_algorithms.get(algorithm)
 
-        if length not in cryptography_algorithm.key_sizes:
+        if length is None:
+            # If cryptograohic length is not defined,
+            #   the strongest allowed key size is used.
+            sizes = list(cryptography_algorithm.key_sizes)
+            sizes.sort()
+            length = sizes[len(sizes) - 1]
+        elif length not in cryptography_algorithm.key_sizes:
             raise exceptions.InvalidField(
                 "The cryptographic length ({0}) is not valid for "
                 "the cryptographic algorithm ({1}).".format(

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -29,6 +29,8 @@ from kmip.core import enums
 from kmip.core import exceptions
 from kmip.core.factories import secrets
 
+from kmip.core import objects as core_objects
+
 from kmip.core.messages import contents
 from kmip.core.messages import messages
 
@@ -670,17 +672,10 @@ class KmipEngine(object):
                 "attribute."
             )
 
-        length = object_attributes.get('Cryptographic Length')
-        if length:
-            length = length.value
-        else:
-            # TODO (peterhamilton) The cryptographic length is technically not
-            # required per the spec. Update the CryptographyEngine to accept a
-            # None length, allowing it to pick the length dynamically. Default
-            # to the strongest key size allowed for the algorithm type.
-            raise exceptions.InvalidField(
-                "The cryptographic length must be specified as an attribute."
-            )
+        length = None
+        requested_length = object_attributes.get('Cryptographic Length')
+        if requested_length is not None:
+            length = requested_length.value
 
         usage_mask = object_attributes.get('Cryptographic Usage Mask')
         if usage_mask is None:
@@ -693,6 +688,9 @@ class KmipEngine(object):
             algorithm,
             length
         )
+
+        if length is None:
+            length = len(result.get('value')) * 8
 
         managed_object = objects.SymmetricKey(
             algorithm,
@@ -707,7 +705,6 @@ class KmipEngine(object):
         )
 
         # TODO (peterhamilton) Set additional server-only attributes.
-
         self._data_session.add(managed_object)
 
         # NOTE (peterhamilton) SQLAlchemy will *not* assign an ID until
@@ -720,12 +717,24 @@ class KmipEngine(object):
             )
         )
 
+        ret_attributes = []
+        template_attribute = None
+        if requested_length is None:
+            crypto_length_attribute = self._attribute_factory.create_attribute(
+                enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
+                length)
+            ret_attributes.append(crypto_length_attribute)
+
+        if len(ret_attributes) > 0:
+            template_attribute = core_objects.TemplateAttribute(
+                attributes=ret_attributes)
+
         response_payload = create.CreateResponsePayload(
             object_type=payload.object_type,
             unique_identifier=attributes.UniqueIdentifier(
                 str(managed_object.unique_identifier)
             ),
-            template_attribute=None
+            template_attribute=template_attribute
         )
 
         self._id_placeholder = str(managed_object.unique_identifier)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -1607,51 +1607,6 @@ class TestKmipEngine(testtools.TestCase):
         )
         e._logger.reset_mock()
 
-        # Test the error for omitting the Cryptographic Length
-        object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
-        template_attribute = objects.TemplateAttribute(
-            attributes=[
-                attribute_factory.create_attribute(
-                    enums.AttributeType.NAME,
-                    attributes.Name.create(
-                        'Test Symmetric Key',
-                        enums.NameType.UNINTERPRETED_TEXT_STRING
-                    )
-                ),
-                attribute_factory.create_attribute(
-                    enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
-                    enums.CryptographicAlgorithm.AES
-                ),
-                attribute_factory.create_attribute(
-                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
-                    [
-                        enums.CryptographicUsageMask.ENCRYPT,
-                        enums.CryptographicUsageMask.DECRYPT
-                    ]
-                )
-            ]
-        )
-        payload = create.CreateRequestPayload(
-            object_type,
-            template_attribute
-        )
-
-        args = (payload, )
-        regex = (
-            "The cryptographic length must be specified as an attribute."
-        )
-        self.assertRaisesRegexp(
-            exceptions.InvalidField,
-            regex,
-            e._process_create,
-            *args
-        )
-
-        e._logger.info.assert_any_call(
-            "Processing operation: Create"
-        )
-        e._logger.reset_mock()
-
         # Test the error for omitting the Cryptographic Usage Mask
         object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
         template_attribute = objects.TemplateAttribute(

--- a/kmip/version.py
+++ b/kmip/version.py
@@ -13,4 +13,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'


### PR DESCRIPTION
In request paylod to create symmetric key the
length of cryptographic algorithm is optional.

As Peter suggested, in this case the strongest allowed key size
is used.