### PR TITLE
'Add Attribute', 'Get Attribute List' and demo 'Import PKCS#12'

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -13,6 +13,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import six
+
 from kmip.core import enums
 
 from kmip.core.enums import CertificateTypeEnum
@@ -625,6 +627,182 @@ class ObjectGroup(TextString):
 
     def __init__(self, value=None):
         super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
+
+
+# 3.35
+class Link(Struct):
+
+    class LinkType(Enumeration):
+
+        def __init__(self, value=None):
+            super(Link.LinkType, self).__init__(
+                enums.LinkType, value, Tags.LINK_TYPE)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkType):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkType):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    class LinkedObjectID(TextString):
+
+        def __init__(self, value=None):
+            if isinstance(value, int):
+                value = str(value)
+            super(Link.LinkedObjectID, self).__init__(
+                value,
+                Tags.LINKED_OBJECT_IDENTIFIER)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    def __init__(self, link_type=None, linked_oid=None):
+        super(Link, self).__init__(tag=Tags.LINK)
+        self.link_type = link_type
+        self.linked_oid = linked_oid
+        self.validate()
+
+    def read(self, istream):
+        super(Link, self).read(istream)
+        tstream = BytearrayStream(istream.read(self.length))
+
+        # Read the type of link and ID of linked object
+        self.link_type = Link.LinkType()
+        self.linked_oid = Link.LinkedObjectID()
+        self.link_type.read(tstream)
+        self.linked_oid.read(tstream)
+
+        self.is_oversized(tstream)
+
+    def write(self, ostream):
+        tstream = BytearrayStream()
+
+        # Write the type of link and ID of linked object
+        self.link_type.write(tstream)
+        self.linked_oid.write(tstream)
+
+        # Write the length and value of the template attribute
+        self.length = tstream.length()
+        super(Link, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        self.__validate()
+
+    def __validate(self):
+        name = Link.__name__
+        msg = ErrorStrings.BAD_EXP_RECV
+
+        oid = self.linked_oid
+        if oid and not isinstance(oid, Link.LinkedObjectID) and \
+                not isinstance(oid, str):
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid',
+                                       type(Link.LinkedObjectID),
+                                       type(self.linked_oid)))
+        ltype = self.link_type
+        if ltype and not isinstance(ltype, Link.LinkType) and \
+                not isinstance(ltype, str):
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(ltype)))
+
+    @classmethod
+    def create(cls, link_type, linked_oid):
+        if isinstance(link_type, Link.LinkType):
+            l_type = link_type
+        elif isinstance(link_type, Enum):
+            l_type = cls.LinkType(link_type)
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(link_type)))
+
+        if isinstance(linked_oid, six.text_type):
+            linked_oid = str(linked_oid)
+
+        if isinstance(linked_oid, Link.LinkedObjectID):
+            object_id = linked_oid
+        elif isinstance(linked_oid, str):
+            object_id = cls.LinkedObjectID(linked_oid)
+        elif isinstance(linked_oid, int):
+            object_id = cls.LinkedObjectID(str(linked_oid))
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid,',
+                                       type(Link.LinkedObjectID),
+                                       type(linked_oid)))
+
+        return Link(linked_oid=object_id, link_type=l_type)
+
+    def __repr__(self):
+        return "{0}(type={1},value={2})".format(
+                type(self).__name__,
+                repr(self.link_type.value),
+                repr(self.linked_oid.value))
+
+    def __str__(self):
+        return "{0}".format(self.linked_oid.value)
+
+    def __eq__(self, other):
+        if isinstance(other, Link):
+            if self.link_type != other.link_type:
+                return False
+            elif self.linked_oid != other.linked_oid:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, Link):
+            return not self == other
+        else:
+            return NotImplemented
 
 
 # 3.36

--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -499,6 +499,19 @@ class KeyRoleType(enum.Enum):
     PVKPVV    = 0x00000014
     PVKOTH    = 0x00000015
 
+#9.1.3.2.20
+class LinkType(enum.Enum):
+    CERTIFICATE_LINK            = 0x00000101
+    PUBLIC_KEY_LINK             = 0x00000102
+    PRIVATE_KEY_LINK            = 0x00000103
+    DERIVATION_BASE_OBJECT_LINK = 0x00000104
+    DERIVED_KEY_LINK            = 0x00000105
+    REPLACEMENT_OBJECT_LINK     = 0x00000106
+    REPLACED_OBJECT_LINK        = 0x00000107
+    PARENT_LINK                 = 0x00000108
+    CHILD_LINK                  = 0x00000109
+    PREVIOUS_LINK               = 0x0000010A
+    NEXT_LINK                   = 0x0000010B
 
 # 9.1.3.2.24
 class QueryFunction(enum.Enum):

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -93,7 +93,7 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.FRESH:
             return primitives.Boolean(value, enums.Tags.FRESH)
         elif name is enums.AttributeType.LINK:
-            raise NotImplementedError()
+            return self._create_link(value)
         elif name is enums.AttributeType.APPLICATION_SPECIFIC_INFORMATION:
             return self._create_application_specific_information(value)
         elif name is enums.AttributeType.CONTACT_INFORMATION:
@@ -214,3 +214,12 @@ class AttributeValueFactory(object):
                 raise TypeError(msg)
 
             return attributes.ContactInformation(info)
+
+    def _create_link(self, link):
+        if link is not None:
+            link_type = link[0]
+            linked_object_id = link[1]
+
+            return attributes.Link.create(link_type, linked_object_id)
+        else:
+            return attributes.Link()

--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -16,6 +16,7 @@
 from kmip.core.factories.payloads import PayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -30,6 +31,9 @@ from kmip.core.messages.payloads import revoke
 
 
 class RequestPayloadFactory(PayloadFactory):
+
+    def _create_add_attribute_payload(self):
+        return add_attribute.AddAttributeRequestPayload()
 
     def _create_create_payload(self):
         return create.CreateRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -16,6 +16,7 @@
 from kmip.core.factories.payloads import PayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -30,6 +31,9 @@ from kmip.core.messages.payloads import revoke
 
 
 class ResponsePayloadFactory(PayloadFactory):
+
+    def _create_add_attribute_payload(self):
+        return add_attribute.AddAttributeResponsePayload()
 
     def _create_create_payload(self):
         return create.CreateResponsePayload()

--- a/kmip/core/messages/payloads/add_attribute.py
+++ b/kmip/core/messages/payloads/add_attribute.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import six
+
+from kmip.core import enums
+from kmip.core import exceptions
+from kmip.core import objects
+from kmip.core import primitives
+from kmip.core import utils
+
+
+class AddAttributeRequestPayload(primitives.Struct):
+    """
+    A request payload for the AddAttribute operation.
+
+    The payload can contain the ID of the managed object the attributes should
+    belong too. If omitted, the server will use the ID placeholder by default.
+    See Section 4.13 of the KMIP 1.1 specification for more information.
+
+    Attributes:
+        uid: The unique ID of the managed object with which the retrieved
+            attributes should be associated.
+    """
+    def __init__(self, uid=None, attribute=None):
+        """
+        Construct a AddAttribute request payload.
+
+        Args:
+            uid (string): The ID of the managed object with which the retrieved
+                attributes should be associated. Optional, defaults to None.
+        """
+        super(AddAttributeRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD)
+        self.uid = uid
+        self.attribute = attribute
+
+        self.validate()
+
+    def read(self, istream):
+        """
+        Read the data encoding the AddAttribute request payload and decode
+        it into its constituent parts.
+
+        Args:
+            istream (stream): A data stream containing encoded object data,
+                supporting a read method; usually a BytearrayStream object.
+        """
+        super(AddAttributeRequestPayload, self).read(istream)
+        tstream = utils.BytearrayStream(istream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+            uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.read(tstream)
+            self.uid = uid.value
+        else:
+            self.uid = None
+
+        if self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
+            self.attribute = objects.Attribute()
+            self.attribute.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        """
+        Write the data encoding the AddAttribute request payload to a
+        stream.
+
+        Args:
+            ostream (stream): A data stream in which to encode object data,
+                supporting a write method; usually a BytearrayStream object.
+        """
+        tstream = utils.BytearrayStream()
+
+        if self.uid:
+            uid = primitives.TextString(
+                value=self.uid, tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.write(tstream)
+
+        if self.attribute:
+            self.attribute.write(tstream)
+
+        self.length = tstream.length()
+        super(AddAttributeRequestPayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        """
+        Error check the attributes of the AddAttribute request payload.
+        """
+        if self.uid is not None:
+            if not isinstance(self.uid, six.string_types):
+                raise TypeError(
+                    "uid must be a string; "
+                    "expected (one of): {0}, observed: {1}".format(
+                        six.string_types, type(self.uid)))
+        if self.attribute is not None:
+            if not isinstance(self.attribute, objects.Attribute):
+                raise TypeError(
+                    "attribute must be a Attribute object, "
+                    "observed: {1}".format(type(self.attribute)))
+
+    def __repr__(self):
+        uid = "uid={0}".format(self.uid)
+        attribute = "attribute={0}".format(self.attribute)
+        return "AddAttributeRequestPayload({0},{1})".format(
+            uid,
+            attribute)
+
+    def __str__(self):
+        return str({'uid': self.uid, 'attribute': self.attribute})
+
+    def __eq__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            if self.uid != other.uid:
+                return False
+            elif self.attribute != other.attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented
+
+
+class AddAttributeResponsePayload(primitives.Struct):
+    """
+    A response payload for the AddAttribute operation.
+
+    The payload will contain the ID of the managed object with which the
+    attributes are associated. It will also contain a list of attribute names
+    identifying the types of attributes associated with the aforementioned
+    managed object. See Section 4.13 of the KMIP 1.1 specification for more
+    information.
+
+    Attributes:
+        uid: The unique ID of the managed object with which the retrieved
+            attributes should be associated.
+        attribute_names: The list of attribute names of the attributes
+            associated with managed object identified by the uid above.
+    """
+    def __init__(self, uid=None, attribute=None):
+        """
+        Construct a AddAttribute response payload.
+
+        Args:
+            uid (string): The ID of the managed object with which the retrieved
+                attributes should be associated. Optional, defaults to None.
+            attribute (Attribute): required, the added attribute
+                associated with the object
+        """
+        super(AddAttributeResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD)
+
+        self.uid = uid
+        self.attribute = attribute
+
+        self.validate()
+
+    def read(self, istream):
+        """
+        Read the data encoding the AddAttribute response payload and decode
+        it into its constituent parts.
+
+        Args:
+            istream (stream): A data stream containing encoded object data,
+                supporting a read method; usually a BytearrayStream object.
+        """
+        super(AddAttributeResponsePayload, self).read(istream)
+        tstream = utils.BytearrayStream(istream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+            uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.read(tstream)
+            self.uid = uid.value
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "expected uid encoding not found")
+
+        if self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
+            self.attribute = objects.Attribute()
+            self.attribute.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        """
+        Write the data encoding the AddAttribute response payload to a
+        stream.
+
+        Args:
+            ostream (stream): A data stream in which to encode object data,
+                supporting a write method; usually a BytearrayStream object.
+        """
+        tstream = utils.BytearrayStream()
+
+        uid = primitives.TextString(
+            value=self.uid, tag=enums.Tags.UNIQUE_IDENTIFIER)
+        uid.write(tstream)
+
+        if self.attribute:
+            self.attribute.write(tstream)
+
+        self.length = tstream.length()
+        super(AddAttributeResponsePayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        """
+        Error check the attributes of the AddAttribute response payload.
+        """
+        if self.uid is not None:
+            if not isinstance(self.uid, six.string_types):
+                raise TypeError(
+                    "uid must be a string; "
+                    "expected (one of): {0}, observed: {1}".format(
+                        six.string_types, type(self.uid)))
+
+        if self.attribute is not None:
+            if not isinstance(self.attribute, objects.Attribute):
+                raise TypeError(
+                    "attribute must be a Attribute object, "
+                    "observed: {1}".format(type(self.attribute)))
+
+    def __repr__(self):
+        uid = "uid={0}".format(self.uid)
+        attribute = "attribute={0}".format(self.attribute)
+        return "AddAttributeRequestPayload({0},{1})".format(
+            uid,
+            attribute)
+
+    def __str__(self):
+        return str({'uid': self.uid, 'attribute': self.attribute})
+
+    def __eq__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            if self.uid != other.uid:
+                return False
+            elif self.attribute != other.attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented

--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -145,6 +145,17 @@ class Attribute(Struct):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __repr__(self):
+        if self.attribute_index is not None:
+            return "Attribute({0}, idx:{1}, value:'{2}')".format(
+                self.attribute_name,
+                self.attribute_index,
+                repr(self.attribute_value))
+        else:
+            return "Attribute({0}, value:'{1}')".format(
+                self.attribute_name,
+                repr(self.attribute_value))
+
 
 # 2.1.2
 class Credential(Struct):

--- a/kmip/demos/pie/add_attribute.py
+++ b/kmip/demos/pie/add_attribute.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+from kmip.pie import client
+
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    # Build and parse arguments
+    parser = utils.build_cli_parser(enums.Operation.ADD_ATTRIBUTE)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    uid = opts.uuid
+    attribute_type = opts.attribute_type
+    attribute_sub_type = opts.attribute_sub_type
+    attribute_value = opts.attribute_value
+
+    if attribute_type not in enums.AttributeType.__members__:
+        logger.error("Invalid AttributeType provided: {0}".format(
+            attribute_type))
+        sys.exit()
+    else:
+        attribute_type = enums.AttributeType[attribute_type]
+
+    if attribute_type == enums.AttributeType.LINK:
+        if attribute_sub_type not in enums.LinkType.__members__:
+            logger.error("Invalid LinkType provided: {0}".format(
+                attribute_sub_type))
+            sys.exit()
+        else:
+            attribute_sub_type = enums.LinkType[attribute_sub_type]
+
+    # Exit early if the UUID is not specified
+    if uid is None:
+        logger.error('No ID provided, exiting early from demo')
+        sys.exit()
+
+    if attribute_type is None:
+        logger.error('No Attribute Type provided, exiting early from demo')
+        sys.exit()
+
+    attribute_value_list = list()
+    if attribute_sub_type is not None:
+        attribute_value_list.append(attribute_sub_type)
+    attribute_value_list.append(attribute_value)
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(config=config) as client:
+        try:
+            uid, attribute = client.add_attribute(
+                uid,
+                attribute_type,
+                attribute_value_list)
+            logger.info("Successfully added {0} to object {1}".format(
+                repr(attribute.attribute_value),
+                uid))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/pie/import_pkcs12.py
+++ b/kmip/demos/pie/import_pkcs12.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2015 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from OpenSSL.crypto import load_pkcs12
+from OpenSSL.crypto import dump_certificate, dump_privatekey, dump_publickey
+from OpenSSL.crypto import FILETYPE_ASN1, TYPE_RSA
+
+from pyasn1.type import univ
+from pyasn1.codec.ber import decoder
+
+from binascii import hexlify
+
+import logging
+import sys
+import io
+
+from kmip.core.enums import CryptographicUsageMask as UsageMask
+from kmip.core.enums import CryptographicAlgorithm as Algorithm
+from kmip.core.enums import LinkType, AttributeType, KeyFormatType
+from kmip.demos import utils
+
+from kmip.pie import client
+from kmip.pie import objects
+
+
+def _get_certificate_attributes(cert):
+    usage_mask_prv = []
+    usage_mask_pub = []
+    subject_key_id = None
+    authority_key_id = None
+
+    extensions_count = cert.get_extension_count()
+    for i in range(extensions_count):
+        extension = cert.get_extension(i)
+        short_name = extension.get_short_name()
+        if short_name == b'keyUsage':
+            data = extension.get_data()
+            key_usage = decoder.decode(data, asn1Spec=univ.BitString())
+            for usage in range(0, len(key_usage[0])):
+                if key_usage[0][usage]:
+                    if usage == 0:
+                        # digitalSignature (0)
+                        usage_mask_prv.append(UsageMask.SIGN)
+                        usage_mask_pub.append(UsageMask.VERIFY)
+                    elif usage == 2:
+                        # keyEncipherment  (2)
+                        usage_mask_prv.append(UsageMask.UNWRAP_KEY)
+                        usage_mask_pub.append(UsageMask.WRAP_KEY)
+                    elif usage == 3:
+                        # dataEncipherment (3)
+                        usage_mask_prv.append(UsageMask.DECRYPT)
+                        usage_mask_pub.append(UsageMask.ENCRYPT)
+                    elif usage == 4:
+                        # keyAgreement (4)
+                        usage_mask_prv.append(UsageMask.KEY_AGREEMENT)
+                        usage_mask_pub.append(UsageMask.KEY_AGREEMENT)
+                    elif usage == 5:
+                        # keyCertSign (5)
+                        usage_mask_prv.append(UsageMask.CERTIFICATE_SIGN)
+                        usage_mask_pub.append(UsageMask.CERTIFICATE_SIGN)
+                    elif usage == 6:
+                        # cRLSign (6)
+                        usage_mask_prv.append(UsageMask.CRL_SIGN)
+                        usage_mask_pub.append(UsageMask.CRL_SIGN)
+        elif short_name == b'subjectKeyIdentifier':
+            data = extension.get_data()
+            asn1_octets = decoder.decode(data, asn1Spec=univ.OctetString())
+            subject_key_id = hexlify(asn1_octets[0].asOctets())
+        elif short_name == b'authorityKeyIdentifier':
+            data = extension.get_data()
+            authority_key_id = hexlify(data)
+
+    setattr(cert, "commonName", cert.get_subject().commonName)
+    setattr(cert, "usage_mask_private", usage_mask_prv)
+    setattr(cert, "usage_mask_public", usage_mask_pub)
+    setattr(cert, "subjectKeyIdentifier", subject_key_id)
+    setattr(cert, "authorityKeyIdentifier", authority_key_id)
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    parser = utils.build_cli_parser(operation="Import PKCS#12")
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    pkcs12_file = opts.pkcs12_file
+    pkcs12_password = opts.pkcs12_password
+
+    if pkcs12_file is None or pkcs12_password is None:
+        logger.error("Missing mandatory arguments "
+                     "pkcs12-file and/or pkcs12-password")
+        sys.exit()
+
+    p12 = load_pkcs12(io.open(pkcs12_file, 'rb').read(), pkcs12_password)
+    if p12 is None:
+        logger.error("Cannot open/parse PKCS#12 file")
+        sys.exit()
+
+    cert = p12.get_certificate()
+    public_key = cert.get_pubkey()
+    private_key = p12.get_privatekey()
+    ca_certs = p12.get_ca_certificates()
+
+    _get_certificate_attributes(cert)
+
+    print("Subject {0}".format(cert.commonName))
+
+    algorithm = None
+    key_type = private_key.type()
+    if key_type == TYPE_RSA:
+        algorithm = Algorithm.RSA
+    else:
+        logger.error("Non supprted key type {0}".format(key_type))
+        sys.exit()
+
+    length = private_key.bits()
+
+    co_private_key = objects.PrivateKey(
+        algorithm,
+        length,
+        dump_privatekey(FILETYPE_ASN1, private_key),
+        KeyFormatType.PKCS_8,
+        cert.usage_mask_private,
+        cert.commonName)
+
+    co_public_key = objects.PublicKey(
+        algorithm,
+        length,
+        dump_publickey(FILETYPE_ASN1, public_key),
+        KeyFormatType.X_509,
+        cert.usage_mask_public,
+        cert.commonName)
+
+    setattr(
+        cert,
+        "cert_object",
+        objects.X509Certificate(
+            dump_certificate(FILETYPE_ASN1, cert),
+            cert.usage_mask_public,
+            cert.commonName))
+
+    for ca_cert in ca_certs:
+        _get_certificate_attributes(ca_cert)
+        setattr(
+            ca_cert,
+            "cert_object",
+            objects.X509Certificate(
+                dump_certificate(FILETYPE_ASN1, ca_cert),
+                ca_cert.usage_mask_public,
+                ca_cert.commonName))
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(config=config) as client:
+        try:
+            private_key_uid = client.register(co_private_key)
+            logger.info("Successfully registered private key with ID:"
+                        "{0}".format(private_key_uid))
+            public_key_uid = client.register(co_public_key)
+            logger.info("Successfully registered public key with ID:"
+                        "{0}".format(public_key_uid))
+            certificate_uid = client.register(cert.cert_object)
+            logger.info("Successfully registered certificate with ID:"
+                        "{0}".format(certificate_uid))
+            setattr(cert, "uid", certificate_uid)
+
+            public_key_link = [
+                AttributeType.LINK,
+                [
+                    LinkType.PUBLIC_KEY_LINK,
+                    public_key_uid
+                ]]
+            private_key_link = [
+                AttributeType.LINK,
+                [
+                    LinkType.PRIVATE_KEY_LINK,
+                    private_key_uid
+                ]]
+            certificate_link = [
+                AttributeType.LINK,
+                [
+                    LinkType.CERTIFICATE_LINK,
+                    certificate_uid
+                ]]
+
+            uid, attribute = client.add_attribute(
+                private_key_uid,
+                *public_key_link)
+            logger.info("Successfully added {0} to object {1}".format(
+                attribute, uid))
+
+            uid, attribute = client.add_attribute(
+                public_key_uid,
+                *private_key_link)
+            logger.info("Successfully added {0} to object {1}".format(
+                attribute, uid))
+
+            uid, attribute = client.add_attribute(
+                public_key_uid,
+                *certificate_link)
+            logger.info("Successfully added {0} to object {1}".format(
+                attribute, uid))
+
+            uid, attribute = client.add_attribute(
+                certificate_uid,
+                *public_key_link)
+            logger.info("Successfully added {0} to object {1}".format(
+                attribute, uid))
+
+            for ca_cert in ca_certs:
+                uid = client.register(ca_cert.cert_object)
+                setattr(ca_cert, "uid", uid)
+                logger.info("Successfully registered certificate with "
+                            "ID:{0}".format(uid))
+
+            for xx in ca_certs:
+                x_subject = xx.subjectKeyIdentifier
+                x_authority = xx.authorityKeyIdentifier
+
+                if cert.authorityKeyIdentifier.find(x_subject) != -1:
+                    certificate_link[1][1] = xx.uid
+                    uid, attribute = client.add_attribute(
+                        cert.uid,
+                        *certificate_link)
+                    logger.info("Successfully added {0} to object {1}".format(
+                        attribute, uid))
+
+                for yy in ca_certs:
+                    y_subject = yy.subjectKeyIdentifier
+                    y_authority = yy.authorityKeyIdentifier
+
+                    if xx == yy:
+                        continue
+
+                    if x_authority.find(y_subject) != -1:
+                        certificate_link[1][1] = yy.uid
+                        uid, attribute = client.add_attribute(
+                            xx.uid,
+                            *certificate_link)
+                        logger.info("Successfully added {0}to object "
+                                    "{1}".format(attribute, uid))
+
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -112,7 +112,7 @@ def build_cli_parser(operation=None):
             type="str",
             default=None,
             dest="algorithm",
-            help="Encryption algorithm for the secret (e.g., AES)")
+            help="Key type (e.g., RSA, EC)")
         parser.add_option(
             "-l",
             "--length",
@@ -120,7 +120,7 @@ def build_cli_parser(operation=None):
             type="int",
             default=None,
             dest="length",
-            help="Key length in bits (e.g., 128, 256)")
+            help="Key length in bits (e.g., 2048, 4096, 384, 521)")
         parser.add_option(
             "-n",
             "--name",

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -57,6 +57,7 @@ def build_console_logger(level):
 
 
 def build_cli_parser(operation=None):
+    print("Operation {0}".format(operation))
     # Build the argument parser and setup expected options
     parser = optparse.OptionParser(
         usage="%prog [options]",
@@ -86,7 +87,6 @@ def build_cli_parser(operation=None):
         default="client",
         dest="config",
         help="Client configuration group to load from configuration file")
-
     if operation is Operation.CREATE:
         parser.add_option(
             "-a",
@@ -266,7 +266,23 @@ def build_cli_parser(operation=None):
             default=None,
             dest="attribute_value",
             help="Attribute value")
-
+    elif operation == "Import PKCS#12":
+        parser.add_option(
+            "",
+            "--pkcs12-file",
+            action="store",
+            type="str",
+            default=None,
+            dest="pkcs12_file",
+            help="File with PKCS#12")
+        parser.add_option(
+            "",
+            "--pkcs12-password",
+            action="store",
+            type="str",
+            default=None,
+            dest="pkcs12_password",
+            help="PKCS#12 password")
     return parser
 
 

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -222,6 +222,50 @@ def build_cli_parser(operation=None):
                 dest="protocol_versions",
                 help=("Protocol versions supported by client. "
                       "ex. '1.1,1.2 1.3'"))
+    elif operation is Operation.QUERY:
+        parser.add_option(
+                "-q",
+                "--query-functions",
+                action="store",
+                type="str",
+                default=None,
+                dest="query_functions",
+                help=("Request query functions. Query functions include: "
+                      "OPERATIONS, OBJECT, SERVER_INFORMATION, "
+                      "APPLICATION_NAMESPACES, EXTENSION_LIST EXTENSION_MAP"))
+    elif operation is Operation.ADD_ATTRIBUTE:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
+        parser.add_option(
+            "",
+            "--attribute-type",
+            action="store",
+            type="str",
+            default=None,
+            dest="attribute_type",
+            help="Attribute type: 'Name', 'Link', 'State', etc")
+        parser.add_option(
+            "",
+            "--attribute-sub-type",
+            action="store",
+            type="str",
+            default=None,
+            dest="attribute_sub_type",
+            help="Attribute sub type. ex. 'LinkType's of attribute 'Link'")
+        parser.add_option(
+            "",
+            "--attribute-value",
+            action="store",
+            type="str",
+            default=None,
+            dest="attribute_value",
+            help="Attribute value")
 
     return parser
 

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -342,6 +342,43 @@ class ProxyKmipClient(api.KmipClient):
             message = result.result_message.value
             raise exceptions.KmipOperationFailure(status, reason, message)
 
+    def add_attribute(self, uid, attribute_type, attribute_value):
+        """
+        Add attribute to managed object
+
+        If the uid is not specified, the appliance will use the ID placeholder
+        by default.
+
+        Args:
+            attribute_value (list): attribute value members
+            uid (string): The unique ID of the managed object with which the
+                retrieved attribute names should be associated. Optional,
+                defaults to None.
+        """
+        # Check input
+        if uid is not None:
+            if not isinstance(uid, six.string_types):
+                raise TypeError("uid must be a string")
+
+        # Verify that operations can be given at this time
+        if not self._is_open:
+            raise exceptions.ClientConnectionNotOpen()
+
+        attribute = self.attribute_factory.create_attribute(
+            attribute_type, attribute_value)
+
+        # Get the list of attribute names for a managed object.
+        result = self.proxy.add_attribute(uid, attribute)
+
+        status = result.result_status.value
+        if status == enums.ResultStatus.SUCCESS:
+            attribute = result.attribute
+            return uid, attribute
+        else:
+            reason = result.result_reason.value
+            message = result.result_message.value
+            raise exceptions.KmipOperationFailure(status, reason, message)
+
     def destroy(self, uid):
         """
         Destroy a managed object stored by a KMIP appliance.

--- a/kmip/pie/factory.py
+++ b/kmip/pie/factory.py
@@ -21,6 +21,9 @@ from kmip.core import secrets
 
 from kmip.pie import objects as pobjects
 
+from kmip.core.factories.attributes import AttributeFactory \
+    as CoreAttributeFactory
+
 
 class ObjectFactory:
     """
@@ -155,3 +158,11 @@ class ObjectFactory:
         opaque_data_type = secrets.OpaqueObject.OpaqueDataType(opaque_type)
         opaque_data_value = secrets.OpaqueObject.OpaqueDataValue(value)
         return secrets.OpaqueObject(opaque_data_type, opaque_data_value)
+
+
+class AttributeFactory(CoreAttributeFactory):
+    """
+    PIE proxy to core attribute factory
+    """
+    def __init__(self):
+            CoreAttributeFactory.__init__(self)

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -98,6 +98,15 @@ class ManagedObject(sql.Base):
         """
         return self._object_type
 
+    def get_attribute_list(self):
+        names = list()
+        if len(self.names) > 0:
+            names.append(enums.AttributeType.NAME.value)
+        if self._object_type is not None:
+            names.append(enums.AttributeType.OBJECT_TYPE.value)
+
+        return names
+
     @object_type.setter
     def object_type(self, value):
         """
@@ -169,7 +178,6 @@ class CryptographicObject(ManagedObject):
         """
         Create a CryptographicObject.
         """
-
         super(CryptographicObject, self).__init__()
 
         self.cryptographic_usage_masks = list()
@@ -190,6 +198,16 @@ class CryptographicObject(ManagedObject):
         self._lease_time = None
         self._revocation_reason = None
         self._state = None
+
+    @abstractmethod
+    def get_attribute_list(self):
+        names = super(CryptographicObject, self).get_attribute_list()
+        if len(self.cryptographic_usage_masks) > 0:
+            names.append(enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK.value)
+        if len(self.links) > 0:
+            names.append(enums.AttributeType.LINK.value)
+
+        return names
 
     @abstractmethod
     def valid_link_types(self):
@@ -268,6 +286,15 @@ class Key(CryptographicObject):
         # The following attributes are placeholders for attributes that are
         # unsupported by kmip.core
         self._usage_limits = None
+
+    @abstractmethod
+    def get_attribute_list(self):
+        names = super(Key, self).get_attribute_list()
+        if self.cryptographic_algorithm is not None:
+            names.append(enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM.value)
+        if self.cryptographic_length is not None:
+            names.append(enums.AttributeType.CRYPTOGRAPHIC_LENGTH.value)
+        return names
 
 
 class SymmetricKey(Key):
@@ -815,6 +842,18 @@ class Certificate(CryptographicObject):
             enums.LinkType.REPLACED_OBJECT_LINK
         ]
 
+    @abstractmethod
+    def get_attribute_list(self):
+        names = super(Certificate, self).get_attribute_list()
+        if self.certificate_type is not None:
+            names.append(enums.AttributeType.CERTIFICATE_TYPE.value)
+        '''
+        TODO: parse certificate value and supply
+              other CERTIFICATE_* attributes
+        '''
+
+        return names
+
     def validate(self):
         """
         Verify that the contents of the Certificate object are valid.
@@ -900,6 +939,16 @@ class X509Certificate(Certificate):
         self._x509_certificate_issuer = None
 
         self.validate()
+
+    @abstractmethod
+    def get_attribute_list(self):
+        names = super(X509Certificate, self).get_attribute_list()
+        '''
+        TODO: parse certificate value and supply
+              X_509_* attributes
+        '''
+
+        return names
 
     def __repr__(self):
         certificate_type = "certificate_type={0}".format(self.certificate_type)

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -219,8 +219,10 @@ class CryptographicObject(ManagedObject):
         ]
 
     def validate_link(self, in_link):
-        allowed_link_types = self.valid_link_types()
+        if in_link in self.links:
+            return
 
+        allowed_link_types = self.valid_link_types()
         if in_link.link_type.value not in allowed_link_types:
             raise exceptions.InvalidField(
                 "Attribute {0} not allowed for {1} object".format(

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -23,6 +23,7 @@ import six
 
 from kmip.core import enums
 from kmip.pie import sqltypes as sql
+from kmip.core import exceptions
 
 
 class ManagedObject(sql.Base):
@@ -152,6 +153,10 @@ class CryptographicObject(ManagedObject):
                                primary_key=True)
     cryptographic_usage_masks = Column('cryptographic_usage_mask',
                                        sql.UsageMaskType)
+    _links = relationship('CryptographicObjectLink', back_populates='co',
+                          cascade='all, delete-orphan')
+    links = association_proxy('_links', 'link')
+
     __mapper_args__ = {
         'polymorphic_identity': 'CryptographicObject'
     }
@@ -168,6 +173,7 @@ class CryptographicObject(ManagedObject):
         super(CryptographicObject, self).__init__()
 
         self.cryptographic_usage_masks = list()
+        self.links = list()
 
         # All remaining attributes are not considered part of the public API
         # and are subject to change.
@@ -182,9 +188,31 @@ class CryptographicObject(ManagedObject):
         self._destroy_date = None
         self._fresh = None
         self._lease_time = None
-        self._links = list()
         self._revocation_reason = None
         self._state = None
+
+    @abstractmethod
+    def valid_link_types(self):
+        return [
+            enums.LinkType.PARENT_LINK,
+            enums.LinkType.CHILD_LINK,
+            enums.LinkType.PREVIOUS_LINK,
+            enums.LinkType.NEXT_LINK,
+        ]
+
+    def validate_link(self, in_link):
+        allowed_link_types = self.valid_link_types()
+
+        if in_link.link_type.value not in allowed_link_types:
+            raise exceptions.InvalidField(
+                "Attribute {0} not allowed for {1} object".format(
+                    in_link.link_type, self._object_type))
+
+        existing_link_types = [x.link_type for x in self.links]
+        if in_link.link_type in existing_link_types:
+            raise exceptions.InvalidField(
+                "Only one {0} link allowed".format(in_link.link_type)
+            )
 
 
 class Key(CryptographicObject):
@@ -309,6 +337,14 @@ class SymmetricKey(Key):
         self._protect_stop_date = None
 
         self.validate()
+
+    def valid_link_types(self):
+        return super(SymmetricKey, self).get_valid_link_types() + [
+            enums.LinkType.DERIVATION_BASE_OBJECT_LINK,
+            enums.LinkType.DERIVED_KEY_LINK,
+            enums.LinkType.REPLACEMENT_OBJECT_LINK,
+            enums.LinkType.REPLACED_OBJECT_LINK
+        ]
 
     def validate(self):
         """
@@ -456,6 +492,14 @@ class PublicKey(Key):
         self._cryptographic_domain_parameters = list()
 
         self.validate()
+
+    def valid_link_types(self):
+        return super(PublicKey, self).valid_link_types() + [
+            enums.LinkType.CERTIFICATE_LINK,
+            enums.LinkType.PRIVATE_KEY_LINK,
+            enums.LinkType.REPLACEMENT_OBJECT_LINK,
+            enums.LinkType.REPLACED_OBJECT_LINK
+        ]
 
     def validate(self):
         """
@@ -609,6 +653,13 @@ class PrivateKey(Key):
 
         self.validate()
 
+    def valid_link_types(self):
+        return super(PrivateKey, self).valid_link_types() + [
+            enums.LinkType.PUBLIC_KEY_LINK,
+            enums.LinkType.REPLACEMENT_OBJECT_LINK,
+            enums.LinkType.REPLACED_OBJECT_LINK
+        ]
+
     def validate(self):
         """
         Verify that the contents of the PrivateKey object are valid.
@@ -755,6 +806,14 @@ class Certificate(CryptographicObject):
         self._digital_signature_algorithm = list()
 
         self.validate()
+
+    def valid_link_types(self):
+        return super(Certificate, self).valid_link_types() + [
+            enums.LinkType.PUBLIC_KEY_LINK,
+            enums.LinkType.CERTIFICATE_LINK,
+            enums.LinkType.REPLACEMENT_OBJECT_LINK,
+            enums.LinkType.REPLACED_OBJECT_LINK
+        ]
 
     def validate(self):
         """
@@ -924,6 +983,12 @@ class SecretData(CryptographicObject):
         # unsupported by kmip.core
 
         self.validate()
+
+    def valid_link_types(self):
+        return super(SecretData, self).valid_link_types() + [
+            enums.LinkType.DERIVATION_BASE_OBJECT_LINK,
+            enums.LinkType.DERIVED_KEY_LINK
+        ]
 
     def validate(self):
         """

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -14,6 +14,7 @@
 # under the License.
 
 from kmip.services.results import ActivateResult
+from kmip.services.results import AddAttributeResult
 from kmip.services.results import CreateResult
 from kmip.services.results import CreateKeyPairResult
 from kmip.services.results import DestroyResult
@@ -47,6 +48,7 @@ from kmip.core.messages.contents import ProtocolVersion
 from kmip.core.messages import messages
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -312,6 +314,14 @@ class KMIPProxy(KMIP):
         results = self._process_batch_items(response)
         return results[0]
 
+    def add_attribute(self, uid, attribute):
+        batch_item = self._build_add_attribute_batch_item(uid, attribute)
+
+        request = self._build_request_message(None, [batch_item])
+        response = self._send_and_receive_message(request)
+        results = self._process_batch_items(response)
+        return results[0]
+
     def revoke(self, uuid, reason, message=None, credential=None):
         return self._revoke(unique_identifier=uuid,
                             revocation_code=reason,
@@ -473,6 +483,13 @@ class KMIPProxy(KMIP):
             operation=operation, request_payload=payload)
         return batch_item
 
+    def _build_add_attribute_batch_item(self, uid=None, attribute=None):
+        operation = Operation(OperationEnum.ADD_ATTRIBUTE)
+        payload = add_attribute.AddAttributeRequestPayload(uid, attribute)
+        batch_item = messages.RequestBatchItem(
+            operation=operation, request_payload=payload)
+        return batch_item
+
     def _build_discover_versions_batch_item(self, protocol_versions=None):
         operation = Operation(OperationEnum.DISCOVER_VERSIONS)
 
@@ -497,6 +514,8 @@ class KMIPProxy(KMIP):
     def _get_batch_item_processor(self, operation):
         if operation is None:
             return self._process_response_error
+        elif operation == OperationEnum.ADD_ATTRIBUTE:
+            return self._process_add_attribute_batch_item
         elif operation == OperationEnum.CREATE_KEY_PAIR:
             return self._process_create_key_pair_batch_item
         elif operation == OperationEnum.GET_ATTRIBUTE_LIST:
@@ -510,6 +529,23 @@ class KMIPProxy(KMIP):
         else:
             raise ValueError("no processor for operation: {0}".format(
                 operation))
+
+    def _process_add_attribute_batch_item(self, batch_item):
+        payload = batch_item.response_payload
+
+        uid = None
+        attribute = None
+
+        if payload:
+            uid = payload.uid
+            attribute = payload.attribute
+
+        return AddAttributeResult(
+            batch_item.result_status,
+            batch_item.result_reason,
+            batch_item.result_message,
+            uid,
+            attribute)
 
     def _process_get_attribute_list_batch_item(self, batch_item):
         payload = batch_item.response_payload

--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -33,6 +33,20 @@ class OperationResult(object):
             self.result_message = None
 
 
+class AddAttributeResult(OperationResult):
+
+    def __init__(
+            self,
+            result_status,
+            result_reason=None,
+            result_message=None,
+            uid=None,
+            attribute=None):
+        super(AddAttributeResult, self).__init__(
+            result_status, result_reason, result_message)
+        self.uid = uid
+        self.attribute = attribute
+
 class CreateResult(OperationResult):
 
     def __init__(self,

--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -47,6 +47,7 @@ class AddAttributeResult(OperationResult):
         self.uid = uid
         self.attribute = attribute
 
+
 class CreateResult(OperationResult):
 
     def __init__(self,

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -16,6 +16,7 @@
 import logging
 import os
 
+from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -211,3 +212,11 @@ class CryptographyEngine(api.CryptographicEngine):
         }
 
         return public_key, private_key
+
+    def X509_get_public_key(self, value, encoding=serialization.Encoding.DER):
+            # from certificate get blob of public key
+            cert = x509.load_der_x509_certificate(value, default_backend())
+            pub_key_blob = cert.public_key().public_bytes(
+                encoding=encoding,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo)
+            return pub_key_blob

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -597,7 +597,19 @@ class KmipEngine(object):
                             "Cannot set duplicate name values."
                         )
             elif attribute_name == 'Link':
+                attributes = attribute_value
                 for attr in attribute_value:
+                    # ignore already existing link
+                    if attr in managed_object.links:
+                        self._logger.info(
+                            "For {0}:{1} ignoring already existing"
+                            "link {2}".format(
+                                managed_object.object_type.name,
+                                managed_object.unique_identifier,
+                                repr(attr)))
+                        attributes.remove(attr)
+                        continue
+
                     # Check if new link is compatible with the object type;
                     # check if object already has link of the same type
                     managed_object.validate_link(attr)
@@ -611,7 +623,7 @@ class KmipEngine(object):
                                 attr.linked_oid.value))
 
                 managed_object.links.extend(
-                    [x for x in attribute_value]
+                    [x for x in attributes]
                 )
             else:
                 # TODO (peterhamilton) Remove when all attributes are supported

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -116,6 +116,7 @@ class KmipEngine(object):
         }
 
         self._attribute_policy = policy.AttributePolicy(self._protocol_version)
+        self._attribute_factory = factory.AttributeFactory()
 
     def _kmip_version_supported(supported):
         def decorator(function):
@@ -396,6 +397,18 @@ class KmipEngine(object):
 
         return response_batch
 
+    def _is_object_exists(self, oid):
+        obj = self._data_session.query(
+            objects.ManagedObject._object_type
+        ).filter(
+            objects.ManagedObject.unique_identifier == oid
+        ).one_or_none()
+
+        if obj is None:
+            return False
+        else:
+            return True
+
     def _get_object_type(self, unique_identifier):
         try:
             object_type = self._data_session.query(
@@ -581,6 +594,23 @@ class KmipEngine(object):
                         raise exceptions.InvalidField(
                             "Cannot set duplicate name values."
                         )
+            elif attribute_name == 'Link':
+                for attr in attribute_value:
+                    # Check if new link is compatible with the object type;
+                    # check if object already has link of the same type
+                    managed_object.validate_link(attr)
+
+                    # Check if linked-oid points to the existing object
+                    linked_object_exists = self._is_object_exists(
+                        attr.linked_oid.value)
+                    if not linked_object_exists:
+                        raise exceptions.InvalidField(
+                            "Trying to link non-existing object {0}".format(
+                                attr.linked_oid.value))
+
+                managed_object.links.extend(
+                    [x for x in attribute_value]
+                )
             else:
                 # TODO (peterhamilton) Remove when all attributes are supported
                 raise exceptions.InvalidField(
@@ -617,6 +647,80 @@ class KmipEngine(object):
                 raise exceptions.InvalidField(
                     "The {0} attribute is unsupported.".format(attribute_name)
                 )
+
+    def _set_links_for_certificate(self, certificate):
+        if not isinstance(certificate, objects.Certificate):
+            raise exceptions.OperationNotSupported(
+                "Link attribute not supported for the {0} object".format(
+                    certificate.object_type.name)
+            )
+
+        # return if crypto-object already contains the link to public key
+        links = list(filter(
+            lambda x: x.link_type.value == enums.LinkType.PUBLIC_KEY_LINK,
+            certificate.links))
+        if len(links) == 1:
+            return
+
+        # get from certificate the blob of public key
+        pub_key_blob = self._cryptography_engine.X509_get_public_key(
+            certificate.value)
+
+        # search public key by key blob
+        m_public_key = self._data_session.query(
+            objects.PublicKey
+        ).filter(
+            objects.PublicKey.value == pub_key_blob
+        ).one_or_none()
+
+        if m_public_key is None:
+            self._logger.info(
+                "No public key to link with Certificate:{0}".format(
+                    certificate.unique_identifier))
+            return
+
+        self._logger.info(
+            "For Certificate:{0} set link to PublicKey:{1}".format(
+                certificate.unique_identifier,
+                m_public_key.unique_identifier))
+
+        # For Private Key object set link to Public Key
+        link_to_pubkey = self._attribute_factory.create_attribute(
+                enums.AttributeType.LINK,
+                [
+                    enums.LinkType.PUBLIC_KEY_LINK,
+                    m_public_key.unique_identifier
+                ])
+        certificate_server_attributes = {
+            link_to_pubkey.attribute_name.value: [
+                link_to_pubkey.attribute_value
+            ]
+        }
+        self._set_attributes_on_managed_object(
+            certificate,
+            certificate_server_attributes
+        )
+
+    def _set_links_for_public_key(self, public_key):
+        if not isinstance(public_key, objects.PublicKey):
+            raise exceptions.OperationNotSupported(
+                "Link attribute not supported for the {0} object".format(
+                    public_key.object_type.name)
+            )
+
+    def _set_links(self, crypto_object):
+        self._logger.debug("Set links for {0}".format(
+            crypto_object.object_type.name))
+        if not isinstance(crypto_object, objects.CryptographicObject):
+            raise exceptions.OperationNotSupported(
+                "Link attribute not supported for the {0} object".format(
+                    crypto_object.object_type.name)
+            )
+
+        if isinstance(crypto_object, objects.Certificate):
+            return self._set_links_for_certificate(crypto_object)
+        elif isinstance(crypto_object, objects.PublicKey):
+            return self._set_links_for_public_key(crypto_object)
 
     def _process_operation(self, operation, payload):
         if operation == enums.Operation.CREATE:
@@ -881,6 +985,42 @@ class KmipEngine(object):
         # commit is called. This makes future support for UNDO problematic.
         self._data_session.commit()
 
+        # For Private Key object set link to Public Key
+        link_to_pubkey = self._attribute_factory.create_attribute(
+                enums.AttributeType.LINK,
+                [
+                    enums.LinkType.PUBLIC_KEY_LINK,
+                    public_key.unique_identifier
+                ])
+        private_key_server_attributes = {
+            link_to_pubkey.attribute_name.value: [
+                link_to_pubkey.attribute_value
+            ]
+        }
+        self._set_attributes_on_managed_object(
+            private_key,
+            private_key_server_attributes
+        )
+
+        # For Public Key object set link to Private Key
+        link_to_prvkey = self._attribute_factory.create_attribute(
+                enums.AttributeType.LINK,
+                [
+                    enums.LinkType.PRIVATE_KEY_LINK,
+                    private_key.unique_identifier
+                ])
+        public_key_server_attributes = {
+            link_to_prvkey.attribute_name.value: [
+                link_to_prvkey.attribute_value
+            ]
+        }
+        self._set_attributes_on_managed_object(
+            public_key,
+            public_key_server_attributes
+        )
+
+        self._data_session.commit()
+
         self._logger.info(
             "Created a PublicKey with ID: {0}".format(
                 public_key.unique_identifier
@@ -948,6 +1088,9 @@ class KmipEngine(object):
         # TODO (peterhamilton) Set additional server-only attributes.
 
         self._data_session.add(managed_object)
+
+        if isinstance(managed_object, objects.CryptographicObject):
+            self._set_links(managed_object)
 
         # NOTE (peterhamilton) SQLAlchemy will *not* assign an ID until
         # commit is called. This makes future support for UNDO problematic.

--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -20,8 +20,7 @@ import threading
 
 from kmip.core import enums
 from kmip.core import exceptions
-from kmip.core.messages import contents
-from kmip.core.messages import messages
+from kmip.core.messages import contents, messages
 from kmip.core import utils
 
 
@@ -146,6 +145,14 @@ class KmipSession(threading.Thread):
             response.write(response_data)
 
         self._send_response(response_data.buffer)
+
+    def _build_fail_response(self, reason, message):
+        protocol_version = contents.ProtocolVersion.create(1, 1)
+        status = enums.ResultStatus.OPERATION_FAILED
+        return self._engine.build_error_response(protocol_version,
+                                                 status,
+                                                 reason,
+                                                 message)
 
     def _receive_request(self):
         header = self._receive_bytes(8)

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -21,10 +21,12 @@ from kmip.core.attributes import CertificateType
 from kmip.core.attributes import CryptographicParameters
 from kmip.core.attributes import DigestValue
 from kmip.core.attributes import HashingAlgorithm
+from kmip.core.attributes import Link
 from kmip.core.attributes import Name
 from kmip.core.attributes import OperationPolicyName
 from kmip.core.attributes import Tags
 
+from kmip.core.factories.attributes import AttributeFactory
 from kmip.core.factories.attribute_values import AttributeValueFactory
 
 from kmip.core.enums import AttributeType
@@ -32,8 +34,9 @@ from kmip.core.enums import BlockCipherMode
 from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import HashingAlgorithm as HashingAlgorithmEnum
 from kmip.core.enums import KeyRoleType
-from kmip.core.enums import PaddingMethod
+from kmip.core.enums import LinkType
 from kmip.core.enums import NameType
+from kmip.core.enums import PaddingMethod
 
 from kmip.core.utils import BytearrayStream
 
@@ -570,3 +573,198 @@ class TestCryptographicParameters(TestCase):
         bad_obj = Name.create(name_value, name_type)
 
         self.assertNotEqual(NotImplemented, bad_obj)
+
+
+class TestLinkType(TestCase):
+
+    def setUp(self):
+        super(TestLinkType, self).setUp()
+        self.enum_pubkey_link = LinkType.PUBLIC_KEY_LINK
+        self.enum_prvkey_link = LinkType.PRIVATE_KEY_LINK
+
+    def tearDown(self):
+        super(TestLinkType, self).tearDown()
+
+    def test__eq(self):
+        link_type = Link.LinkType(self.enum_pubkey_link)
+        same_link_type = Link.LinkType(self.enum_pubkey_link)
+        other_link_type = Link.LinkType(self.enum_prvkey_link)
+
+        self.assertTrue(link_type == same_link_type)
+        self.assertFalse(same_link_type == other_link_type)
+        self.assertFalse(link_type == 'invalid')
+
+    def test__str(self):
+        link_type = Link.LinkType(self.enum_pubkey_link)
+        str_link = "{0}".format(self.enum_pubkey_link)
+        repr_link = "LinkType(value=<{0}: {1}>)".format(
+                self.enum_pubkey_link,
+                self.enum_pubkey_link.value)
+
+        self.assertEqual(str_link, str(link_type))
+        self.assertEqual(repr_link, repr(link_type))
+
+
+class TestLinkedObjectID(TestCase):
+
+    def setUp(self):
+        super(TestLinkedObjectID, self).setUp()
+        self.linked_oid1 = '12'
+        self.linked_oid2 = '13'
+
+    def tearDown(self):
+        super(TestLinkedObjectID, self).tearDown()
+
+    def test__eq(self):
+        linked_oid = Link.LinkedObjectID(self.linked_oid1)
+        same_linked_oid = Link.LinkedObjectID(self.linked_oid1)
+        other_linked_oid = Link.LinkedObjectID(self.linked_oid2)
+
+        self.assertTrue(linked_oid == same_linked_oid)
+        self.assertFalse(linked_oid == other_linked_oid)
+        self.assertFalse(linked_oid == 'invalid')
+
+    def test__str(self):
+        linked_oid = Link.LinkedObjectID(self.linked_oid1)
+        repr_linked_oid = "LinkedObjectID(value='{0}')".format(
+            self.linked_oid1)
+
+        self.assertEqual(self.linked_oid1, str(linked_oid))
+        self.assertEqual(repr_linked_oid, repr(linked_oid))
+
+
+class TestLink(TestCase):
+    def setUp(self):
+        super(TestLink, self).setUp()
+        self.linked_oid1_int = 12
+        self.linked_oid1 = str(12)
+        self.linked_oid2 = str(13)
+        self.linked_oid_bad_format = 13
+        self.link_type_bad_format = 13
+        self.enum_pubkey_link = LinkType.PUBLIC_KEY_LINK
+        self.enum_prvkey_link = LinkType.PRIVATE_KEY_LINK
+
+        self.value_factory = AttributeValueFactory()
+        self.attribute_factory = AttributeFactory()
+
+        self.link_attribute = self.attribute_factory.create_attribute(
+            AttributeType.LINK,
+            [LinkType.PRIVATE_KEY_LINK, str(12)]
+        )
+
+        #   <Attribute>
+        #       <AttributeName type="TextString" value="Link"/>
+        #       <AttributeValue>
+        #           <LinkType type="Enumeration" value="PrivateKeyLink"/>
+        #           <LinkedObjectIdentifier type="TextString" value="12"/>
+        #       </AttributeValue>
+        #   </Attribute>
+        self.blob_attribute_link = BytearrayStream((
+            b'\x42\x00\x08\x01\x00\x00\x00\x38'
+            b'\x42\x00\x0a\x07\x00\x00\x00\x04\x4c\x69\x6e\x6b\x00\x00\x00\x00'
+            b'\x42\x00\x0b\x01\x00\x00\x00\x20'
+            b'\x42\x00\x4b\x05\x00\x00\x00\x04\x00\x00\x01\x03\x00\x00\x00\x00'
+            b'\x42\x00\x4c\x07\x00\x00\x00\x02\x31\x32\x00\x00\x00\x00\x00\x00'
+        ))
+
+    def tearDown(self):
+        super(TestLink, self).tearDown()
+
+    def test_invalid_attribute_type(self):
+        """
+        Test that exception is raised when unknown attribute type is requested
+        """
+        args = (1, None)
+        self.assertRaises(
+            ValueError,
+            self.value_factory.create_attribute_value, *args)
+
+    def test_empty_link(self):
+        """
+        Test empty link value
+        """
+        link = self.value_factory.create_attribute_value(
+            AttributeType.LINK, None)
+
+        self.assertIsInstance(link, Link)
+        self.assertTrue(link.link_type is None)
+        self.assertTrue(link.linked_oid is None)
+
+    def test_bad_link_type_format(self):
+        """
+         Test that an error is raised for an incorrectly formatted link type
+        """
+        link_obj = Link()
+        link_obj.link_type = self.link_type_bad_format
+        link_obj.linked_oid = self.linked_oid1
+
+        self.assertRaises(TypeError, link_obj.validate)
+
+    def test_bad_linked_OID_value_format(self):
+        """
+         Test that an error is raised in for an incorrectly formatted
+         value of linked object ID
+        """
+        link_obj = Link()
+        link_obj.link_type = self.enum_pubkey_link
+        link_obj.linked_oid = self.linked_oid_bad_format
+        self.assertRaises(TypeError, link_obj.validate)
+
+        args = ('invalid', self.linked_oid1)
+        self.assertRaises(TypeError, Link.create, *args)
+
+        args = (self.enum_pubkey_link, None)
+        self.assertRaises(TypeError, Link.create, *args)
+
+    def test_link_create(self):
+        """
+          Test the creation of link to the object of given type
+          and with a given OID
+        """
+        link_obj = Link.create(self.enum_pubkey_link, self.linked_oid1)
+        self.assertIsInstance(link_obj.link_type, Link.LinkType)
+        self.assertIsInstance(link_obj.linked_oid, Link.LinkedObjectID)
+        self.assertEqual(self.linked_oid1, link_obj.linked_oid.value)
+
+        link_obj_bis = Link.create(
+            Link.LinkType(self.enum_pubkey_link),
+            self.linked_oid1_int)
+        self.assertEqual(link_obj, link_obj_bis)
+
+        link_obj_ter = Link.create(
+            Link.LinkType(self.enum_pubkey_link),
+            Link.LinkedObjectID(self.linked_oid1_int)
+        )
+        self.assertEqual(link_obj, link_obj_ter)
+
+    def test__eq(self):
+        link_obj = Link.create(self.enum_pubkey_link, self.linked_oid1)
+        same_link_obj = Link.create(self.enum_pubkey_link, self.linked_oid1)
+        other_type = Link.create(self.enum_prvkey_link, self.linked_oid1)
+        other_linked_oid = Link.create(self.enum_pubkey_link, self.linked_oid2)
+
+        self.assertTrue(link_obj == same_link_obj)
+        self.assertFalse(link_obj == other_type)
+        self.assertFalse(link_obj == other_linked_oid)
+        self.assertFalse(link_obj == 'invalid')
+
+    def test__str(self):
+        link_obj = Link.create(self.enum_pubkey_link, self.linked_oid1)
+        repr_link_obj = (
+            "Link(type=<LinkType.PUBLIC_KEY_LINK: {0}>,value='{1}')"
+            ).format(self.enum_pubkey_link.value, self.linked_oid1)
+
+        self.assertEqual(self.linked_oid1, str(link_obj))
+        self.assertEqual(repr_link_obj, repr(link_obj))
+
+    def test_write(self):
+        ostream = BytearrayStream()
+        self.link_attribute.write(ostream)
+        self.assertEqual(self.blob_attribute_link, ostream)
+
+    def test_read(self):
+        link = self.attribute_factory.create_attribute(
+            AttributeType.LINK,
+            None)
+        link.read(self.blob_attribute_link)
+        self.assertEqual(link, self.link_attribute)

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -19,6 +19,7 @@ from kmip.core.enums import Operation
 from kmip.core.factories.payloads.request import RequestPayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -99,8 +100,9 @@ class TestRequestPayloadFactory(testtools.TestCase):
             payload, get_attribute_list.GetAttributeListRequestPayload)
 
     def test_create_add_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+        payload = self.factory.create(Operation.ADD_ATTRIBUTE)
+        self._test_payload_type(
+            payload, add_attribute.AddAttributeRequestPayload)
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -19,6 +19,7 @@ from kmip.core.enums import Operation
 from kmip.core.factories.payloads.response import ResponsePayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -99,8 +100,9 @@ class TestResponsePayloadFactory(testtools.TestCase):
             payload, get_attribute_list.GetAttributeListResponsePayload)
 
     def test_create_add_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+        payload = self.factory.create(Operation.ADD_ATTRIBUTE)
+        self._test_payload_type(
+            payload, add_attribute.AddAttributeResponsePayload)
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -352,10 +352,22 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a Link attribute can be created.
         """
-        kwargs = {'name': enums.AttributeType.LINK,
-                  'value': None}
-        self.assertRaises(
-            NotImplementedError, self.factory.create_attribute_value, **kwargs)
+        link = self.factory.create_attribute_value(
+            enums.AttributeType.LINK,
+            [
+                enums.LinkType.PUBLIC_KEY_LINK,
+                attributes.Link.LinkedObjectID(12)
+            ])
+        self.assertIsInstance(link, attributes.Link)
+        self.assertIsInstance(link.link_type, attributes.Link.LinkType)
+        self.assertIsInstance(link.linked_oid, attributes.Link.LinkedObjectID)
+        self.assertEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PUBLIC_KEY_LINK))
+        self.assertEqual(link.linked_oid, attributes.Link.LinkedObjectID(12))
+        self.assertNotEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PRIVATE_KEY_LINK))
 
     def test_create_application_specific_information(self):
         """

--- a/kmip/tests/unit/pie/objects/test_sqltypes.py
+++ b/kmip/tests/unit/pie/objects/test_sqltypes.py
@@ -16,7 +16,10 @@
 import testtools
 
 from kmip.core import enums
+from kmip.core import attributes
+from kmip.pie.objects import CryptographicObject
 from kmip.pie.sqltypes import ManagedObjectName
+from kmip.pie.sqltypes import CryptographicObjectLink
 
 
 class TestSqlTypesManagedObjectName(testtools.TestCase):
@@ -130,3 +133,140 @@ class TestSqlTypesManagedObjectName(testtools.TestCase):
         """
         a = ManagedObjectName('a', 0, enums.NameType.UNINTERPRETED_TEXT_STRING)
         repr(a)
+
+
+class TestSqlTypesCryptographicObjectLink(testtools.TestCase):
+    """
+    Test suite for CryptographicObjectLink in sqltypes.py.
+    """
+    def setUp(self):
+        super(TestSqlTypesCryptographicObjectLink, self).setUp()
+        """
+        TODO:
+        Without import of CryptographicObject (or ManagedObject)
+            from kmip.pie.objects,
+        when running only test of current test-file,
+        there is an sqlalchemy exception:
+            sqlalchemy.exc.InvalidRequestError: One or more mappers failed to
+            initialize - can't proceed with initialization of other mappers.
+            Original exception was: When initializing mapper
+            Mapper|ManagedObjectName|managed_object_names, expression
+            'ManagedObject' failed to locate a name ("name 'ManagedObject'
+            is not defined"). If this is a class name, consider adding this
+            relationship() to the <class 'kmip.pie.sqltypes.ManagedObjectName'>
+            class after both dependent classes have been defined.
+
+        Here below instantiating CryptographicObject object to satisfy
+        style check.
+        """
+        self.crypto_object = CryptographicObject()
+
+    def test_empty_object(self):
+        """
+        Test epmty CryptographicObjectLink object.
+        """
+        a = CryptographicObjectLink()
+        self.assertTrue(a.link_type is None)
+        self.assertTrue(a.linked_oid is None)
+
+    def test_invalid_init_parameters(self):
+        """
+        Test the exception raised when instantiating
+        CryptographicObjectLink object with invalid link data
+        """
+        args = ('invalid', 0)
+        self.assertRaises(TypeError, CryptographicObjectLink, *args)
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        CryptographicObjectLink objects with the same data.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 0)
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicObjectLink objects with different link types and
+        linked object ID.
+        """
+        link_aa = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        link_ab = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 13)
+        link_ba = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 12)
+        link_bb = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 13)
+        aa = CryptographicObjectLink(link_aa, 0)
+        ab = CryptographicObjectLink(link_ab, 0)
+        ba = CryptographicObjectLink(link_ba, 0)
+        bb = CryptographicObjectLink(link_bb, 0)
+        self.assertFalse(aa == ab)
+        self.assertFalse(ba == aa)
+        self.assertFalse(aa == bb)
+        self.assertFalse(aa == 'invalid')
+
+    def test_equal_on_not_equal_index(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicObjectLink objects with different indices.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 1)
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the not equal operator returns False when comparing two
+        CryptographicObjectLink objects with the same data.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 0)
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal(self):
+        """
+        Test that the not equal operator returns True when comparing two
+        CryptographicObjectLink objects with different link types and
+        linked object ID.
+        """
+        link_aa = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        link_ab = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 13)
+        link_ba = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 12)
+        link_bb = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 13)
+        aa = CryptographicObjectLink(link_aa, 0)
+        ab = CryptographicObjectLink(link_ab, 0)
+        ba = CryptographicObjectLink(link_ba, 0)
+        bb = CryptographicObjectLink(link_bb, 0)
+        self.assertTrue(aa != ab)
+        self.assertTrue(ba != aa)
+        self.assertTrue(aa != bb)
+        self.assertTrue(aa != 'invalid')
+
+    def test_not_equal_on_not_equal_index(self):
+        """
+        Test that the not equal operator returns True when comparing two
+        CryptographicObjectLink objects with different indices.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 1)
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that __repr__ is implemented.
+        """
+        repr_expected = (
+            "<CryptographicObjectLink(type='%s', "
+            "linked-oid='%s', index='%d')>")
+
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        self.assertTrue(repr(a) == repr_expected)


### PR DESCRIPTION
Implemented 'add-attribute' and 'get-attribute-list'

Added demo with import PKCS#12.
This part largely uses the LINK attributes, implemented in dependent PR.
This demo creates mutual links between private, public keys and certificate, as well as links for CA certificate chain.
 
It's not final version, but rather the invitation to the rapid review and general consideration.

Q: in demo the pyasn1 and pyOpenSSL is used, is it acceptable? If not, are there any alternatives?
