### PR TITLE
server-engine: fix crypto-length in Create

### DIFF
--- a/kmip/pie/factory.py
+++ b/kmip/pie/factory.py
@@ -21,6 +21,9 @@ from kmip.core import secrets
 
 from kmip.pie import objects as pobjects
 
+from kmip.core.factories.attributes import AttributeFactory \
+    as CoreAttributeFactory
+
 
 class ObjectFactory:
     """
@@ -155,3 +158,11 @@ class ObjectFactory:
         opaque_data_type = secrets.OpaqueObject.OpaqueDataType(opaque_type)
         opaque_data_value = secrets.OpaqueObject.OpaqueDataValue(value)
         return secrets.OpaqueObject(opaque_data_type, opaque_data_value)
+
+
+class AttributeFactory(CoreAttributeFactory):
+    """
+    PIE proxy to core attribute factory
+    """
+    def __init__(self):
+            CoreAttributeFactory.__init__(self)

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -51,7 +51,7 @@ class CryptographyEngine(api.CryptographicEngine):
             enums.CryptographicAlgorithm.RSA: self._create_rsa_key_pair
         }
 
-    def create_symmetric_key(self, algorithm, length):
+    def create_symmetric_key(self, algorithm, length=None):
         """
         Create a symmetric key.
 
@@ -86,7 +86,13 @@ class CryptographyEngine(api.CryptographicEngine):
 
         cryptography_algorithm = self._symmetric_key_algorithms.get(algorithm)
 
-        if length not in cryptography_algorithm.key_sizes:
+        if length is None:
+            # If cryptograohic length is not defined,
+            #   the strongest allowed key size is used.
+            sizes = list(cryptography_algorithm.key_sizes)
+            sizes.sort()
+            length = sizes[-1]
+        elif length not in cryptography_algorithm.key_sizes:
             raise exceptions.InvalidField(
                 "The cryptographic length ({0}) is not valid for "
                 "the cryptographic algorithm ({1}).".format(
@@ -108,7 +114,10 @@ class CryptographyEngine(api.CryptographicEngine):
             raise exceptions.CryptographicFailure(
                 "Invalid bytes for the provided cryptographic algorithm.")
 
-        return {'value': key_bytes, 'format': enums.KeyFormatType.RAW}
+        return {
+            'value': key_bytes,
+            'format': enums.KeyFormatType.RAW,
+            'cryptographic_length': length}
 
     def create_asymmetric_key_pair(self, algorithm, length):
         """

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -29,6 +29,8 @@ from kmip.core import enums
 from kmip.core import exceptions
 from kmip.core.factories import secrets
 
+from kmip.core import objects as core_objects
+
 from kmip.core.messages import contents
 from kmip.core.messages import messages
 
@@ -116,6 +118,7 @@ class KmipEngine(object):
         }
 
         self._attribute_policy = policy.AttributePolicy(self._protocol_version)
+        self._attribute_factory = factory.AttributeFactory()
 
     def _kmip_version_supported(supported):
         def decorator(function):
@@ -670,17 +673,10 @@ class KmipEngine(object):
                 "attribute."
             )
 
-        length = object_attributes.get('Cryptographic Length')
-        if length:
-            length = length.value
-        else:
-            # TODO (peterhamilton) The cryptographic length is technically not
-            # required per the spec. Update the CryptographyEngine to accept a
-            # None length, allowing it to pick the length dynamically. Default
-            # to the strongest key size allowed for the algorithm type.
-            raise exceptions.InvalidField(
-                "The cryptographic length must be specified as an attribute."
-            )
+        length = None
+        requested_length = object_attributes.get('Cryptographic Length')
+        if requested_length is not None:
+            length = requested_length.value
 
         usage_mask = object_attributes.get('Cryptographic Usage Mask')
         if usage_mask is None:
@@ -693,6 +689,7 @@ class KmipEngine(object):
             algorithm,
             length
         )
+        length = result['cryptographic_length']
 
         managed_object = objects.SymmetricKey(
             algorithm,
@@ -720,12 +717,24 @@ class KmipEngine(object):
             )
         )
 
+        ret_attributes = []
+        template_attribute = None
+        if requested_length is None:
+            crypto_length_attribute = self._attribute_factory.create_attribute(
+                enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
+                length)
+            ret_attributes.append(crypto_length_attribute)
+
+        if len(ret_attributes) > 0:
+            template_attribute = core_objects.TemplateAttribute(
+                attributes=ret_attributes)
+
         response_payload = create.CreateResponsePayload(
             object_type=payload.object_type,
             unique_identifier=attributes.UniqueIdentifier(
                 str(managed_object.unique_identifier)
             ),
-            template_attribute=None
+            template_attribute=template_attribute
         )
 
         self._id_placeholder = str(managed_object.unique_identifier)

--- a/kmip/tests/unit/pie/test_factory.py
+++ b/kmip/tests/unit/pie/test_factory.py
@@ -562,3 +562,22 @@ class TestObjectFactory(testtools.TestCase):
         self.assertEqual(key.cryptographic_length, length)
         self.assertEqual(key.key_format_type, format_type)
         self.assertEqual(key.value, value)
+
+
+class TestCoreAttributeFactory(testtools.TestCase):
+    """
+    Test PIE proxy for the CoreAttributeFactory.
+    """
+
+    def setUp(self):
+        super(TestCoreAttributeFactory, self).setUp()
+        self.factory = factory.AttributeFactory()
+
+    def tearDown(self):
+        super(TestCoreAttributeFactory, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that an ObjectFactory can be constructed.
+        """
+        factory.AttributeFactory()

--- a/kmip/tests/unit/services/server/crypto/test_engine.py
+++ b/kmip/tests/unit/services/server/crypto/test_engine.py
@@ -49,7 +49,24 @@ class TestCryptographyEngine(testtools.TestCase):
 
         self.assertIn('value', key)
         self.assertIn('format', key)
+        self.assertIn('cryptographic_length', key)
         self.assertEqual(enums.KeyFormatType.RAW, key.get('format'))
+
+    def test_create_symmetric_key_without_length_specified(self):
+        """
+        Test that a symmetric key can be created without specified
+        CryptographicLength.
+        """
+        engine = crypto.CryptographyEngine()
+        key = engine.create_symmetric_key(
+            enums.CryptographicAlgorithm.AES
+        )
+
+        self.assertIn('value', key)
+        self.assertIn('format', key)
+        self.assertIn('cryptographic_length', key)
+        self.assertEqual(enums.KeyFormatType.RAW, key.get('format'))
+        self.assertEqual(256, key.get('cryptographic_length'))
 
     def test_create_symmetric_key_with_invalid_algorithm(self):
         """


### PR DESCRIPTION
replacement for #164

```
In request payload to create symmetric key the
length of cryptographic algorithm is optional.

As Peter suggested, in this case the strongest allowed key size
is used.
```

Difference with the previous PR:
- fixed use of _sizes[-1]_ instead of _sizes[len(sizes) -1]_
- _cryptographic_length_ is added to the crypto/engine result dict
- test for default maximal cryptographic length
- Link init() accepts _enum_ for link type and _str_ for _linked object ID_

Discutable point: introduced proxy to core/factories/attributes in pie/factory.
Motivation for that is to use in pie objects or engines only one pie/factory.
