### PR TITLE
Link attribute: factory support

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -13,6 +13,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import six
+
 from kmip.core import enums
 
 from kmip.core.enums import CertificateTypeEnum
@@ -625,6 +627,187 @@ class ObjectGroup(TextString):
 
     def __init__(self, value=None):
         super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
+
+
+# 3.35
+class Link(Struct):
+
+    class LinkType(Enumeration):
+
+        def __init__(self, value=None):
+            super(Link.LinkType, self).__init__(
+                enums.LinkType, value, Tags.LINK_TYPE)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkType):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkType):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    class LinkedObjectID(TextString):
+
+        def __init__(self, value=None):
+            if isinstance(value, int):
+                value = str(value)
+            super(Link.LinkedObjectID, self).__init__(
+                value,
+                Tags.LINKED_OBJECT_IDENTIFIER)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    def __init__(self, link_type=None, linked_oid=None):
+        super(Link, self).__init__(tag=Tags.LINK)
+
+        if isinstance(link_type, enums.LinkType):
+            link_type = Link.LinkType(link_type)
+
+        if isinstance(linked_oid, str) or isinstance(linked_oid, int):
+            linked_oid = Link.LinkedObjectID(linked_oid)
+
+        self.link_type = link_type
+        self.linked_oid = linked_oid
+        self.validate()
+
+    def read(self, istream):
+        super(Link, self).read(istream)
+        tstream = BytearrayStream(istream.read(self.length))
+
+        # Read the type of link and ID of linked object
+        self.link_type = Link.LinkType()
+        self.linked_oid = Link.LinkedObjectID()
+        self.link_type.read(tstream)
+        self.linked_oid.read(tstream)
+
+        self.is_oversized(tstream)
+
+    def write(self, ostream):
+        tstream = BytearrayStream()
+
+        # Write the type of link and ID of linked object
+        self.link_type.write(tstream)
+        self.linked_oid.write(tstream)
+
+        # Write the length and value of the template attribute
+        self.length = tstream.length()
+        super(Link, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        self.__validate()
+
+    def __validate(self):
+        name = Link.__name__
+        msg = ErrorStrings.BAD_EXP_RECV
+
+        oid = self.linked_oid
+        if oid and not isinstance(oid, Link.LinkedObjectID):
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid',
+                                       type(Link.LinkedObjectID),
+                                       type(self.linked_oid)))
+        ltype = self.link_type
+        if ltype and not isinstance(ltype, Link.LinkType):
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(ltype)))
+
+    @classmethod
+    def create(cls, link_type, linked_oid):
+        if isinstance(link_type, Link.LinkType):
+            l_type = link_type
+        elif isinstance(link_type, Enum):
+            l_type = cls.LinkType(link_type)
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(link_type)))
+
+        if isinstance(linked_oid, six.text_type):
+            linked_oid = str(linked_oid)
+
+        if isinstance(linked_oid, Link.LinkedObjectID):
+            object_id = linked_oid
+        elif isinstance(linked_oid, str):
+            object_id = cls.LinkedObjectID(linked_oid)
+        elif isinstance(linked_oid, int):
+            object_id = cls.LinkedObjectID(str(linked_oid))
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid,',
+                                       type(Link.LinkedObjectID),
+                                       type(linked_oid)))
+
+        return Link(linked_oid=object_id, link_type=l_type)
+
+    def __repr__(self):
+        return "{0}(type={1},value={2})".format(
+                type(self).__name__,
+                repr(self.link_type.value),
+                repr(self.linked_oid.value))
+
+    def __str__(self):
+        return "{0}".format(self.linked_oid.value)
+
+    def __eq__(self, other):
+        if isinstance(other, Link):
+            if self.link_type != other.link_type:
+                return False
+            elif self.linked_oid != other.linked_oid:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, Link):
+            return not self == other
+        else:
+            return NotImplemented
 
 
 # 3.36

--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -499,6 +499,19 @@ class KeyRoleType(enum.Enum):
     PVKPVV    = 0x00000014
     PVKOTH    = 0x00000015
 
+#9.1.3.2.20
+class LinkType(enum.Enum):
+    CERTIFICATE_LINK            = 0x00000101
+    PUBLIC_KEY_LINK             = 0x00000102
+    PRIVATE_KEY_LINK            = 0x00000103
+    DERIVATION_BASE_OBJECT_LINK = 0x00000104
+    DERIVED_KEY_LINK            = 0x00000105
+    REPLACEMENT_OBJECT_LINK     = 0x00000106
+    REPLACED_OBJECT_LINK        = 0x00000107
+    PARENT_LINK                 = 0x00000108
+    CHILD_LINK                  = 0x00000109
+    PREVIOUS_LINK               = 0x0000010A
+    NEXT_LINK                   = 0x0000010B
 
 # 9.1.3.2.24
 class QueryFunction(enum.Enum):

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -93,7 +93,7 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.FRESH:
             return primitives.Boolean(value, enums.Tags.FRESH)
         elif name is enums.AttributeType.LINK:
-            raise NotImplementedError()
+            return self._create_link(value)
         elif name is enums.AttributeType.APPLICATION_SPECIFIC_INFORMATION:
             return self._create_application_specific_information(value)
         elif name is enums.AttributeType.CONTACT_INFORMATION:
@@ -103,12 +103,12 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
         else:
-            if not isinstance(name, str):
-                raise ValueError('Unrecognized attribute type: '
-                                 '{0}'.format(name))
-            elif name.startswith('x-'):
+            if isinstance(name, str) and name.startswith('x-'):
                 # Custom attribute indicated
                 return attributes.CustomAttribute(value)
+            else:
+                raise ValueError('Unrecognized attribute type: '
+                                 '{0}'.format(name))
 
     def _create_name(self, name):
         if name is not None:
@@ -214,3 +214,12 @@ class AttributeValueFactory(object):
                 raise TypeError(msg)
 
             return attributes.ContactInformation(info)
+
+    def _create_link(self, link):
+        if link is not None:
+            link_type = link[0]
+            linked_object_id = link[1]
+
+            return attributes.Link.create(link_type, linked_object_id)
+        else:
+            return attributes.Link()

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -352,10 +352,30 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a Link attribute can be created.
         """
-        kwargs = {'name': enums.AttributeType.LINK,
-                  'value': None}
-        self.assertRaises(
-            NotImplementedError, self.factory.create_attribute_value, **kwargs)
+        link = self.factory.create_attribute_value(
+            enums.AttributeType.LINK,
+            [
+                enums.LinkType.PUBLIC_KEY_LINK,
+                attributes.Link.LinkedObjectID(12)
+            ])
+
+        link_empty = self.factory.create_attribute_value(
+            enums.AttributeType.LINK,
+            None)
+
+        self.assertIsInstance(link, attributes.Link)
+        self.assertIsInstance(link.link_type, attributes.Link.LinkType)
+        self.assertIsInstance(link.linked_oid, attributes.Link.LinkedObjectID)
+
+        self.assertEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PUBLIC_KEY_LINK))
+        self.assertEqual(link.linked_oid, attributes.Link.LinkedObjectID(12))
+        self.assertNotEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PRIVATE_KEY_LINK))
+
+        self.assertIsInstance(link_empty, attributes.Link)
 
     def test_create_application_specific_information(self):
         """
@@ -386,3 +406,11 @@ class TestAttributeValueFactory(testtools.TestCase):
         custom = self.factory.create_attribute_value(
             enums.AttributeType.CUSTOM_ATTRIBUTE, None)
         self.assertIsInstance(custom, attributes.CustomAttribute)
+
+    def test_invalid_attribute_type(self):
+        """
+        Test that an exception is raised when invalid attribute type used.
+        """
+        args = {'name': 'invalid', 'value': None}
+        self.assertRaises(
+            ValueError, self.factory.create_attribute_value, **args)


### PR DESCRIPTION
Part of the split PR #167:

Added factory support to create _Link_ core attribute.

Depends on PR #171, where _Link_ core attribute implemented
