### PR TITLE
Link attribute: pie: 'link' property for crypto objects

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -13,6 +13,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import six
+
 from kmip.core import enums
 
 from kmip.core.enums import CertificateTypeEnum
@@ -625,6 +627,187 @@ class ObjectGroup(TextString):
 
     def __init__(self, value=None):
         super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
+
+
+# 3.35
+class Link(Struct):
+
+    class LinkType(Enumeration):
+
+        def __init__(self, value=None):
+            super(Link.LinkType, self).__init__(
+                enums.LinkType, value, Tags.LINK_TYPE)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkType):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkType):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    class LinkedObjectID(TextString):
+
+        def __init__(self, value=None):
+            if isinstance(value, int):
+                value = str(value)
+            super(Link.LinkedObjectID, self).__init__(
+                value,
+                Tags.LINKED_OBJECT_IDENTIFIER)
+
+        def __eq__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                if self.value == other.value:
+                    return True
+                else:
+                    return False
+            else:
+                return NotImplemented
+
+        def __ne__(self, other):
+            if isinstance(other, Link.LinkedObjectID):
+                return not self == other
+            else:
+                return NotImplemented
+
+        def __repr__(self):
+            return "{0}(value={1})".format(
+                    type(self).__name__, repr(self.value))
+
+        def __str__(self):
+            return "{0}".format(self.value)
+
+    def __init__(self, link_type=None, linked_oid=None):
+        super(Link, self).__init__(tag=Tags.LINK)
+
+        if isinstance(link_type, enums.LinkType):
+            link_type = Link.LinkType(link_type)
+
+        if isinstance(linked_oid, str) or isinstance(linked_oid, int):
+            linked_oid = Link.LinkedObjectID(linked_oid)
+
+        self.link_type = link_type
+        self.linked_oid = linked_oid
+        self.validate()
+
+    def read(self, istream):
+        super(Link, self).read(istream)
+        tstream = BytearrayStream(istream.read(self.length))
+
+        # Read the type of link and ID of linked object
+        self.link_type = Link.LinkType()
+        self.linked_oid = Link.LinkedObjectID()
+        self.link_type.read(tstream)
+        self.linked_oid.read(tstream)
+
+        self.is_oversized(tstream)
+
+    def write(self, ostream):
+        tstream = BytearrayStream()
+
+        # Write the type of link and ID of linked object
+        self.link_type.write(tstream)
+        self.linked_oid.write(tstream)
+
+        # Write the length and value of the template attribute
+        self.length = tstream.length()
+        super(Link, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        self.__validate()
+
+    def __validate(self):
+        name = Link.__name__
+        msg = ErrorStrings.BAD_EXP_RECV
+
+        oid = self.linked_oid
+        if oid and not isinstance(oid, Link.LinkedObjectID):
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid',
+                                       type(Link.LinkedObjectID),
+                                       type(self.linked_oid)))
+        ltype = self.link_type
+        if ltype and not isinstance(ltype, Link.LinkType):
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(ltype)))
+
+    @classmethod
+    def create(cls, link_type, linked_oid):
+        if isinstance(link_type, Link.LinkType):
+            l_type = link_type
+        elif isinstance(link_type, Enum):
+            l_type = cls.LinkType(link_type)
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'link_type'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'link_type', type(Link.LinkType),
+                                       type(link_type)))
+
+        if isinstance(linked_oid, six.text_type):
+            linked_oid = str(linked_oid)
+
+        if isinstance(linked_oid, Link.LinkedObjectID):
+            object_id = linked_oid
+        elif isinstance(linked_oid, str):
+            object_id = cls.LinkedObjectID(linked_oid)
+        elif isinstance(linked_oid, int):
+            object_id = cls.LinkedObjectID(str(linked_oid))
+        else:
+            name = 'Link'
+            msg = ErrorStrings.BAD_EXP_RECV
+            member = 'linked_oid'
+            raise TypeError(msg.format('{0}.{1}'.format(name, member),
+                                       'linked_oid,',
+                                       type(Link.LinkedObjectID),
+                                       type(linked_oid)))
+
+        return Link(linked_oid=object_id, link_type=l_type)
+
+    def __repr__(self):
+        return "{0}(type={1},value={2})".format(
+                type(self).__name__,
+                repr(self.link_type.value),
+                repr(self.linked_oid.value))
+
+    def __str__(self):
+        return "{0}".format(self.linked_oid.value)
+
+    def __eq__(self, other):
+        if isinstance(other, Link):
+            if self.link_type != other.link_type:
+                return False
+            elif self.linked_oid != other.linked_oid:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, Link):
+            return not self == other
+        else:
+            return NotImplemented
 
 
 # 3.36

--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -499,6 +499,19 @@ class KeyRoleType(enum.Enum):
     PVKPVV    = 0x00000014
     PVKOTH    = 0x00000015
 
+#9.1.3.2.20
+class LinkType(enum.Enum):
+    CERTIFICATE_LINK            = 0x00000101
+    PUBLIC_KEY_LINK             = 0x00000102
+    PRIVATE_KEY_LINK            = 0x00000103
+    DERIVATION_BASE_OBJECT_LINK = 0x00000104
+    DERIVED_KEY_LINK            = 0x00000105
+    REPLACEMENT_OBJECT_LINK     = 0x00000106
+    REPLACED_OBJECT_LINK        = 0x00000107
+    PARENT_LINK                 = 0x00000108
+    CHILD_LINK                  = 0x00000109
+    PREVIOUS_LINK               = 0x0000010A
+    NEXT_LINK                   = 0x0000010B
 
 # 9.1.3.2.24
 class QueryFunction(enum.Enum):

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -93,7 +93,7 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.FRESH:
             return primitives.Boolean(value, enums.Tags.FRESH)
         elif name is enums.AttributeType.LINK:
-            raise NotImplementedError()
+            return self._create_link(value)
         elif name is enums.AttributeType.APPLICATION_SPECIFIC_INFORMATION:
             return self._create_application_specific_information(value)
         elif name is enums.AttributeType.CONTACT_INFORMATION:
@@ -103,12 +103,12 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
         else:
-            if not isinstance(name, str):
-                raise ValueError('Unrecognized attribute type: '
-                                 '{0}'.format(name))
-            elif name.startswith('x-'):
+            if isinstance(name, str) and name.startswith('x-'):
                 # Custom attribute indicated
                 return attributes.CustomAttribute(value)
+            else:
+                raise ValueError('Unrecognized attribute type: '
+                                 '{0}'.format(name))
 
     def _create_name(self, name):
         if name is not None:
@@ -214,3 +214,12 @@ class AttributeValueFactory(object):
                 raise TypeError(msg)
 
             return attributes.ContactInformation(info)
+
+    def _create_link(self, link):
+        if link is not None:
+            link_type = link[0]
+            linked_object_id = link[1]
+
+            return attributes.Link.create(link_type, linked_object_id)
+        else:
+            return attributes.Link()

--- a/kmip/pie/factory.py
+++ b/kmip/pie/factory.py
@@ -21,6 +21,9 @@ from kmip.core import secrets
 
 from kmip.pie import objects as pobjects
 
+from kmip.core.factories.attributes import AttributeFactory \
+    as CoreAttributeFactory
+
 
 class ObjectFactory:
     """
@@ -155,3 +158,11 @@ class ObjectFactory:
         opaque_data_type = secrets.OpaqueObject.OpaqueDataType(opaque_type)
         opaque_data_value = secrets.OpaqueObject.OpaqueDataValue(value)
         return secrets.OpaqueObject(opaque_data_type, opaque_data_value)
+
+
+class AttributeFactory(CoreAttributeFactory):
+    """
+    PIE proxy to core attribute factory
+    """
+    def __init__(self):
+            CoreAttributeFactory.__init__(self)

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -152,6 +152,11 @@ class CryptographicObject(ManagedObject):
                                primary_key=True)
     cryptographic_usage_masks = Column('cryptographic_usage_mask',
                                        sql.UsageMaskType)
+
+    _links = relationship('CryptographicObjectLink', back_populates='co',
+                          cascade='all, delete-orphan')
+    links = association_proxy('_links', 'link')
+
     __mapper_args__ = {
         'polymorphic_identity': 'CryptographicObject'
     }
@@ -168,6 +173,7 @@ class CryptographicObject(ManagedObject):
         super(CryptographicObject, self).__init__()
 
         self.cryptographic_usage_masks = list()
+        self.links = list()
 
         # All remaining attributes are not considered part of the public API
         # and are subject to change.
@@ -182,7 +188,6 @@ class CryptographicObject(ManagedObject):
         self._destroy_date = None
         self._fresh = None
         self._lease_time = None
-        self._links = list()
         self._revocation_reason = None
         self._state = None
 

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -352,10 +352,30 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a Link attribute can be created.
         """
-        kwargs = {'name': enums.AttributeType.LINK,
-                  'value': None}
-        self.assertRaises(
-            NotImplementedError, self.factory.create_attribute_value, **kwargs)
+        link = self.factory.create_attribute_value(
+            enums.AttributeType.LINK,
+            [
+                enums.LinkType.PUBLIC_KEY_LINK,
+                attributes.Link.LinkedObjectID(12)
+            ])
+
+        link_empty = self.factory.create_attribute_value(
+            enums.AttributeType.LINK,
+            None)
+
+        self.assertIsInstance(link, attributes.Link)
+        self.assertIsInstance(link.link_type, attributes.Link.LinkType)
+        self.assertIsInstance(link.linked_oid, attributes.Link.LinkedObjectID)
+
+        self.assertEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PUBLIC_KEY_LINK))
+        self.assertEqual(link.linked_oid, attributes.Link.LinkedObjectID(12))
+        self.assertNotEqual(
+            link.link_type,
+            attributes.Link.LinkType(enums.LinkType.PRIVATE_KEY_LINK))
+
+        self.assertIsInstance(link_empty, attributes.Link)
 
     def test_create_application_specific_information(self):
         """
@@ -386,3 +406,11 @@ class TestAttributeValueFactory(testtools.TestCase):
         custom = self.factory.create_attribute_value(
             enums.AttributeType.CUSTOM_ATTRIBUTE, None)
         self.assertIsInstance(custom, attributes.CustomAttribute)
+
+    def test_invalid_attribute_type(self):
+        """
+        Test that an exception is raised when invalid attribute type used.
+        """
+        args = {'name': 'invalid', 'value': None}
+        self.assertRaises(
+            ValueError, self.factory.create_attribute_value, **args)

--- a/kmip/tests/unit/pie/objects/test_certificate.py
+++ b/kmip/tests/unit/pie/objects/test_certificate.py
@@ -16,6 +16,8 @@
 import testtools
 
 from kmip.core import enums
+from kmip.core.enums import LinkType
+
 from kmip.pie import objects
 
 
@@ -289,3 +291,23 @@ class TestCertificate(testtools.TestCase):
         """
         dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
         self.assertFalse(dummy != dummy)
+
+    def test_valid_link_types(self):
+        """
+        Test valid Link types associated with Certificate object.
+        """
+        dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        valid_types = dummy.valid_link_types()
+
+        base = "expected {0}, received {1}"
+        msg = base.format(list, valid_types)
+        self.assertIsInstance(valid_types, list, msg)
+        self.assertEqual(8, len(valid_types))
+        self.assertIn(LinkType.PARENT_LINK, valid_types)
+        self.assertIn(LinkType.CHILD_LINK, valid_types)
+        self.assertIn(LinkType.PREVIOUS_LINK, valid_types)
+        self.assertIn(LinkType.NEXT_LINK, valid_types)
+        self.assertIn(LinkType.CERTIFICATE_LINK, valid_types)
+        self.assertIn(LinkType.PUBLIC_KEY_LINK, valid_types)
+        self.assertIn(LinkType.REPLACEMENT_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.REPLACED_OBJECT_LINK, valid_types)

--- a/kmip/tests/unit/pie/objects/test_private_key.py
+++ b/kmip/tests/unit/pie/objects/test_private_key.py
@@ -31,8 +31,11 @@ import binascii
 import testtools
 
 from kmip.core import enums
+from kmip.core.enums import LinkType
+
 from kmip.pie import sqltypes
 from kmip.pie.objects import ManagedObject, PrivateKey
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -767,3 +770,24 @@ class TestPrivateKey(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_valid_link_types(self):
+        """
+        Test valid Link types associated with PrivateKey object.
+        """
+        key = PrivateKey(
+            enums.CryptographicAlgorithm.RSA, 2048, self.bytes_2048,
+            enums.KeyFormatType.PKCS_1)
+        valid_types = key.valid_link_types()
+
+        base = "expected {0}, received {1}"
+        msg = base.format(list, valid_types)
+        self.assertIsInstance(valid_types, list, msg)
+        self.assertEqual(7, len(valid_types))
+        self.assertIn(LinkType.PARENT_LINK, valid_types)
+        self.assertIn(LinkType.CHILD_LINK, valid_types)
+        self.assertIn(LinkType.PREVIOUS_LINK, valid_types)
+        self.assertIn(LinkType.NEXT_LINK, valid_types)
+        self.assertIn(LinkType.PUBLIC_KEY_LINK, valid_types)
+        self.assertIn(LinkType.REPLACEMENT_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.REPLACED_OBJECT_LINK, valid_types)

--- a/kmip/tests/unit/pie/objects/test_public_key.py
+++ b/kmip/tests/unit/pie/objects/test_public_key.py
@@ -17,8 +17,11 @@ import binascii
 import testtools
 
 from kmip.core import enums
+from kmip.core.enums import LinkType
+
 from kmip.pie import sqltypes
 from kmip.pie.objects import ManagedObject, PublicKey
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -665,3 +668,25 @@ class TestPublicKey(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_valid_link_types(self):
+        """
+        Test valid Link types associated with PublicKey object.
+        """
+        key = PublicKey(
+            enums.CryptographicAlgorithm.RSA, 2048, self.bytes_2048,
+            enums.KeyFormatType.PKCS_1)
+        valid_types = key.valid_link_types()
+
+        base = "expected {0}, received {1}"
+        msg = base.format(list, valid_types)
+        self.assertIsInstance(valid_types, list, msg)
+        self.assertEqual(8, len(valid_types))
+        self.assertIn(LinkType.PARENT_LINK, valid_types)
+        self.assertIn(LinkType.CHILD_LINK, valid_types)
+        self.assertIn(LinkType.PREVIOUS_LINK, valid_types)
+        self.assertIn(LinkType.NEXT_LINK, valid_types)
+        self.assertIn(LinkType.PRIVATE_KEY_LINK, valid_types)
+        self.assertIn(LinkType.CERTIFICATE_LINK, valid_types)
+        self.assertIn(LinkType.REPLACEMENT_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.REPLACED_OBJECT_LINK, valid_types)

--- a/kmip/tests/unit/pie/objects/test_secret_data.py
+++ b/kmip/tests/unit/pie/objects/test_secret_data.py
@@ -17,8 +17,11 @@ import binascii
 import testtools
 
 from kmip.core import enums
+from kmip.core.enums import LinkType
+
 from kmip.pie.objects import ManagedObject, SecretData
 from kmip.pie import sqltypes
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -491,3 +494,21 @@ class TestSecretData(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_valid_link_types(self):
+        """
+        Test valid Link types associated with SecretData object.
+        """
+        obj = SecretData(self.bytes_a, enums.SecretDataType.PASSWORD)
+        valid_types = obj.valid_link_types()
+
+        base = "expected {0}, received {1}"
+        msg = base.format(list, valid_types)
+        self.assertIsInstance(valid_types, list, msg)
+        self.assertEqual(6, len(valid_types))
+        self.assertIn(LinkType.PARENT_LINK, valid_types)
+        self.assertIn(LinkType.CHILD_LINK, valid_types)
+        self.assertIn(LinkType.PREVIOUS_LINK, valid_types)
+        self.assertIn(LinkType.NEXT_LINK, valid_types)
+        self.assertIn(LinkType.DERIVATION_BASE_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.DERIVED_KEY_LINK, valid_types)

--- a/kmip/tests/unit/pie/objects/test_sqltypes.py
+++ b/kmip/tests/unit/pie/objects/test_sqltypes.py
@@ -16,7 +16,9 @@
 import testtools
 
 from kmip.core import enums
+from kmip.core import attributes
 from kmip.pie.sqltypes import ManagedObjectName
+from kmip.pie.sqltypes import CryptographicObjectLink
 
 
 class TestSqlTypesManagedObjectName(testtools.TestCase):
@@ -130,3 +132,129 @@ class TestSqlTypesManagedObjectName(testtools.TestCase):
         """
         a = ManagedObjectName('a', 0, enums.NameType.UNINTERPRETED_TEXT_STRING)
         repr(a)
+
+
+class TestSqlTypesCryptographicObjectLink(testtools.TestCase):
+    """
+    Test suite for CryptographicObjectLink in sqltypes.py.
+    """
+    def setUp(self):
+        super(TestSqlTypesCryptographicObjectLink, self).setUp()
+
+    def test_empty_object(self):
+        """
+        Test epmty CryptographicObjectLink object.
+        """
+        a = CryptographicObjectLink()
+        self.assertTrue(a.link_type is None)
+        self.assertTrue(a.linked_oid is None)
+
+    def test_invalid_init_parameters(self):
+        """
+        Test the exception raised when instantiating
+        CryptographicObjectLink object with invalid link data
+        """
+        args = ('invalid', 0)
+        self.assertRaises(TypeError, CryptographicObjectLink, *args)
+
+    def test_link_property(self):
+        """
+        Test CryptographicObject 'link' property
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        self.assertEqual(link, a.link)
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        CryptographicObjectLink objects with the same data.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 0)
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicObjectLink objects with different link types and
+        linked object ID.
+        """
+        link_aa = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        link_ab = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 13)
+        link_ba = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 12)
+        link_bb = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 13)
+        aa = CryptographicObjectLink(link_aa, 0)
+        ab = CryptographicObjectLink(link_ab, 0)
+        ba = CryptographicObjectLink(link_ba, 0)
+        bb = CryptographicObjectLink(link_bb, 0)
+        self.assertFalse(aa == ab)
+        self.assertFalse(ba == aa)
+        self.assertFalse(aa == bb)
+        self.assertFalse(aa == 'invalid')
+
+    def test_equal_on_not_equal_index(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicObjectLink objects with different indices.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 1)
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the not equal operator returns False when comparing two
+        CryptographicObjectLink objects with the same data.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 0)
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal(self):
+        """
+        Test that the not equal operator returns True when comparing two
+        CryptographicObjectLink objects with different link types and
+        linked object ID.
+        """
+        link_aa = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        link_ab = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 13)
+        link_ba = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 12)
+        link_bb = attributes.Link.create(enums.LinkType.PRIVATE_KEY_LINK, 13)
+        aa = CryptographicObjectLink(link_aa, 0)
+        ab = CryptographicObjectLink(link_ab, 0)
+        ba = CryptographicObjectLink(link_ba, 0)
+        bb = CryptographicObjectLink(link_bb, 0)
+        self.assertTrue(aa != ab)
+        self.assertTrue(ba != aa)
+        self.assertTrue(aa != bb)
+        self.assertTrue(aa != 'invalid')
+
+    def test_not_equal_on_not_equal_index(self):
+        """
+        Test that the not equal operator returns True when comparing two
+        CryptographicObjectLink objects with different indices.
+        """
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        b = CryptographicObjectLink(link, 1)
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that __repr__ is implemented.
+        """
+        repr_expected = (
+            "<CryptographicObjectLink(type='%s', "
+            "linked-oid='%s', index='%d')>")
+
+        link = attributes.Link.create(enums.LinkType.PUBLIC_KEY_LINK, 12)
+        a = CryptographicObjectLink(link, 0)
+        self.assertTrue(repr(a) == repr_expected)

--- a/kmip/tests/unit/pie/objects/test_symmetric_key.py
+++ b/kmip/tests/unit/pie/objects/test_symmetric_key.py
@@ -17,8 +17,11 @@ import binascii
 import testtools
 
 from kmip.core import enums
+from kmip.core.enums import LinkType
+
 from kmip.pie import sqltypes
 from kmip.pie.objects import ManagedObject, SymmetricKey
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -98,6 +101,27 @@ class TestSymmetricKey(testtools.TestCase):
         observed = key.object_type
 
         self.assertEqual(expected, observed)
+
+    def test_valid_link_types(self):
+        """
+        Test valid Link types associated with SymmetricKey object.
+        """
+        key = SymmetricKey(
+            enums.CryptographicAlgorithm.AES, 128, self.bytes_128a)
+        valid_types = key.valid_link_types()
+
+        base = "expected {0}, received {1}"
+        msg = base.format(list, valid_types)
+        self.assertIsInstance(valid_types, list, msg)
+        self.assertEqual(8, len(valid_types))
+        self.assertIn(LinkType.PARENT_LINK, valid_types)
+        self.assertIn(LinkType.CHILD_LINK, valid_types)
+        self.assertIn(LinkType.PREVIOUS_LINK, valid_types)
+        self.assertIn(LinkType.NEXT_LINK, valid_types)
+        self.assertIn(LinkType.DERIVATION_BASE_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.DERIVED_KEY_LINK, valid_types)
+        self.assertIn(LinkType.REPLACEMENT_OBJECT_LINK, valid_types)
+        self.assertIn(LinkType.REPLACED_OBJECT_LINK, valid_types)
 
     def test_validate_on_invalid_algorithm(self):
         """


### PR DESCRIPTION
Part of the split PR #167:

Implemented method to validate link property for pie cryptographic object,
method to return valid link types for the objects derived from CryptographicObject.

Depends on PRs #173 , #172 and #171, where _Link_ core attribute and factory are implemented, as well as related pie SQL type
