### PR TITLE
GetAttributeList: process payloads in server engine

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -97,6 +97,19 @@ class ManagedObject(sql.Base):
         """
         return self._object_type
 
+    @abstractmethod
+    def get_attribute_list(self):
+        """
+        Returns the list of attribute names attached to Managed Object
+        """
+        attr_names = list()
+        if len(self.names) > 0:
+            attr_names.append(enums.AttributeType.NAME.value)
+        if self._object_type is not None:
+            attr_names.append(enums.AttributeType.OBJECT_TYPE.value)
+
+        return attr_names
+
     @object_type.setter
     def object_type(self, value):
         """
@@ -164,7 +177,6 @@ class CryptographicObject(ManagedObject):
         """
         Create a CryptographicObject.
         """
-
         super(CryptographicObject, self).__init__()
 
         self.cryptographic_usage_masks = list()
@@ -185,6 +197,22 @@ class CryptographicObject(ManagedObject):
         self._links = list()
         self._revocation_reason = None
         self._state = None
+
+    @abstractmethod
+    def get_attribute_list(self):
+        """
+        Returns the list of attribute names attached to Cryptographic Object
+        """
+        attr_names = super(CryptographicObject, self).get_attribute_list()
+        if len(self.cryptographic_usage_masks) > 0:
+            attr_names.append(
+                enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK.value)
+
+        # VTA: Uncomment after (and if) 'Link Attribute' PRs accepted
+        # if len(self.links) > 0:
+        #    attr_names.append(enums.AttributeType.LINK.value)
+
+        return attr_names
 
 
 class Key(CryptographicObject):
@@ -240,6 +268,20 @@ class Key(CryptographicObject):
         # The following attributes are placeholders for attributes that are
         # unsupported by kmip.core
         self._usage_limits = None
+
+    @abstractmethod
+    def get_attribute_list(self):
+        """
+        Returns the list of attribute names attached to Key object
+        """
+        attr_names = super(Key, self).get_attribute_list()
+        if self.cryptographic_algorithm is not None:
+            attr_names.append(
+                enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM.value)
+        if self.cryptographic_length is not None:
+            attr_names.append(
+                enums.AttributeType.CRYPTOGRAPHIC_LENGTH.value)
+        return attr_names
 
 
 class SymmetricKey(Key):
@@ -756,6 +798,21 @@ class Certificate(CryptographicObject):
 
         self.validate()
 
+    @abstractmethod
+    def get_attribute_list(self):
+        """
+        Returns the list of attribute names attached to Certificate object
+        """
+        attr_names = super(Certificate, self).get_attribute_list()
+        if self.certificate_type is not None:
+            attr_names.append(enums.AttributeType.CERTIFICATE_TYPE.value)
+        '''
+        TODO: parse certificate value and supply
+              other CERTIFICATE_* attributes
+        '''
+
+        return attr_names
+
     def validate(self):
         """
         Verify that the contents of the Certificate object are valid.
@@ -841,6 +898,19 @@ class X509Certificate(Certificate):
         self._x509_certificate_issuer = None
 
         self.validate()
+
+    @abstractmethod
+    def get_attribute_list(self):
+        """
+        Returns the list of attribute names attached to X509 Certificate object
+        """
+        attr_names = super(X509Certificate, self).get_attribute_list()
+        '''
+        TODO: parse certificate value and supply
+              X_509_* attributes
+        '''
+
+        return attr_names
 
     def __repr__(self):
         certificate_type = "certificate_type={0}".format(self.certificate_type)

--- a/kmip/tests/unit/pie/objects/test_certificate.py
+++ b/kmip/tests/unit/pie/objects/test_certificate.py
@@ -289,3 +289,22 @@ class TestCertificate(testtools.TestCase):
         """
         dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
         self.assertFalse(dummy != dummy)
+
+    def test_get_attribute_list(self):
+        """
+        Test list of names of attributes attached to Certificate object.
+        """
+        usage_mask = [enums.CryptographicUsageMask.ENCRYPT,
+                      enums.CryptographicUsageMask.VERIFY]
+        certificate = DummyCertificate(
+            enums.CertificateTypeEnum.X_509,
+            self.bytes_a,
+            masks=usage_mask)
+        attr_names = certificate.get_attribute_list()
+
+        self.assertEqual(4, len(attr_names))
+        self.assertIn(enums.AttributeType.NAME.value, attr_names)
+        self.assertIn(enums.AttributeType.OBJECT_TYPE.value, attr_names)
+        self.assertIn(enums.AttributeType.CERTIFICATE_TYPE.value, attr_names)
+        self.assertIn(enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK.value,
+                      attr_names)

--- a/kmip/tests/unit/pie/objects/test_opaque_object.py
+++ b/kmip/tests/unit/pie/objects/test_opaque_object.py
@@ -472,3 +472,14 @@ class TestOpaqueObject(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_get_attribute_list(self):
+        """
+        Test list of names of attributes attached to OpaqueData object.
+        """
+        obj = OpaqueObject(self.bytes_a, enums.OpaqueDataType.NONE)
+        attr_names = obj.get_attribute_list()
+
+        self.assertEqual(2, len(attr_names))
+        self.assertIn(enums.AttributeType.NAME.value, attr_names)
+        self.assertIn(enums.AttributeType.OBJECT_TYPE.value, attr_names)

--- a/kmip/tests/unit/pie/objects/test_secret_data.py
+++ b/kmip/tests/unit/pie/objects/test_secret_data.py
@@ -491,3 +491,14 @@ class TestSecretData(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_get_attribute_list(self):
+        """
+        Test list of names of attributes attached to SecretData object.
+        """
+        obj = SecretData(self.bytes_a, enums.SecretDataType.PASSWORD)
+        attr_names = obj.get_attribute_list()
+
+        self.assertEqual(2, len(attr_names))
+        self.assertIn(enums.AttributeType.NAME.value, attr_names)
+        self.assertIn(enums.AttributeType.OBJECT_TYPE.value, attr_names)

--- a/kmip/tests/unit/pie/objects/test_symmetric_key.py
+++ b/kmip/tests/unit/pie/objects/test_symmetric_key.py
@@ -614,3 +614,28 @@ class TestSymmetricKey(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_get_attribute_list(self):
+        """
+        Test list of names of attributes attached to SymmetricKey object.
+        """
+        usage_mask = [enums.CryptographicUsageMask.ENCRYPT,
+                      enums.CryptographicUsageMask.DECRYPT]
+        key = SymmetricKey(
+            enums.CryptographicAlgorithm.AES,
+            128,
+            self.bytes_128a,
+            masks=usage_mask)
+        attr_names = key.get_attribute_list()
+
+        self.assertEqual(5, len(attr_names))
+        self.assertIn(enums.AttributeType.NAME.value,
+                      attr_names)
+        self.assertIn(enums.AttributeType.OBJECT_TYPE.value,
+                      attr_names)
+        self.assertIn(enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK.value,
+                      attr_names)
+        self.assertIn(enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM.value,
+                      attr_names)
+        self.assertIn(enums.AttributeType.CRYPTOGRAPHIC_LENGTH.value,
+                      attr_names)

--- a/kmip/tests/unit/pie/objects/test_x509_certificate.py
+++ b/kmip/tests/unit/pie/objects/test_x509_certificate.py
@@ -562,3 +562,21 @@ class TestX509Certificate(testtools.TestCase):
         session.commit()
         self.assertEquals(expected_names, get_obj.names)
         self.assertEquals(expected_mo_names, get_obj._names)
+
+    def test_get_attribute_list(self):
+        """
+        Test list of names of attributes attached to X509Certificate object.
+        """
+        usage_mask = [enums.CryptographicUsageMask.ENCRYPT,
+                      enums.CryptographicUsageMask.VERIFY]
+        certificate = X509Certificate(
+            self.bytes_a,
+            masks=usage_mask)
+        attr_names = certificate.get_attribute_list()
+
+        self.assertEqual(4, len(attr_names))
+        self.assertIn(enums.AttributeType.NAME.value, attr_names)
+        self.assertIn(enums.AttributeType.OBJECT_TYPE.value, attr_names)
+        self.assertIn(enums.AttributeType.CERTIFICATE_TYPE.value, attr_names)
+        self.assertIn(enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK.value,
+                      attr_names)


### PR DESCRIPTION
part of split #169 

In server engine process the GetAttributeList payloads

depends on #176 where dedicated method is introduced to pie _ManagedObject_ and childs
