### PR TITLE
AddAttribute: services: kmip client

### DIFF
--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -16,6 +16,7 @@
 from kmip.core.factories.payloads import PayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -48,6 +49,9 @@ class RequestPayloadFactory(PayloadFactory):
 
     def _create_get_payload(self):
         return get.GetRequestPayload()
+
+    def _create_add_attribute_payload(self):
+        return add_attribute.AddAttributeRequestPayload()
 
     def _create_get_attribute_list_payload(self):
         return get_attribute_list.GetAttributeListRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -16,6 +16,7 @@
 from kmip.core.factories.payloads import PayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -48,6 +49,9 @@ class ResponsePayloadFactory(PayloadFactory):
 
     def _create_get_payload(self):
         return get.GetResponsePayload()
+
+    def _create_add_attribute_payload(self):
+        return add_attribute.AddAttributeResponsePayload()
 
     def _create_get_attribute_list_payload(self):
         return get_attribute_list.GetAttributeListResponsePayload()

--- a/kmip/core/messages/payloads/add_attribute.py
+++ b/kmip/core/messages/payloads/add_attribute.py
@@ -1,0 +1,275 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import six
+
+from kmip.core import enums
+from kmip.core import exceptions
+from kmip.core import objects
+from kmip.core import primitives
+from kmip.core import utils
+
+
+class AddAttributeRequestPayload(primitives.Struct):
+    """
+    A request payload for the AddAttribute operation.
+
+    The payload can contain the ID of the managed object the new attribute
+    should be added. If omitted, the server will use the ID placeholder by
+    default.
+    See Section 4.14 of the KMIP 1.1 specification for more information.
+
+    Attributes:
+        uid: The unique ID of the managed object with which a new attribute
+            has to be associated.
+        attribute: New attribute to be associated with managed object
+    """
+    def __init__(self, uid=None, attribute=None):
+        """
+        Construct a AddAttribute request payload.
+
+        Args:
+            uid (string): The ID of the managed object with which a new
+                attribute should be associated. Optional, defaults to None.
+            attribute(Attribute): required, a new attribute to be associated
+                with managed object.
+        """
+        super(AddAttributeRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD)
+        self.uid = uid
+        self.attribute = attribute
+
+        self.validate()
+
+    def read(self, istream):
+        """
+        Read the data encoding the AddAttribute request payload and decode
+        it into its constituent parts.
+
+        Args:
+            istream (stream): A data stream containing encoded object data,
+                supporting a read method; usually a BytearrayStream object.
+        """
+        super(AddAttributeRequestPayload, self).read(istream)
+        tstream = utils.BytearrayStream(istream.read(self.length))
+
+        self.uid = None
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+            uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.read(tstream)
+            self.uid = uid.value
+
+        if self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
+            self.attribute = objects.Attribute()
+            self.attribute.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        """
+        Write the data encoding the AddAttribute request payload to a
+        stream.
+
+        Args:
+            ostream (stream): A data stream in which to encode object data,
+                supporting a write method; usually a BytearrayStream object.
+        """
+        tstream = utils.BytearrayStream()
+
+        if self.uid:
+            uid = primitives.TextString(
+                value=self.uid, tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.write(tstream)
+
+        if self.attribute:
+            self.attribute.write(tstream)
+
+        self.length = tstream.length()
+        super(AddAttributeRequestPayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        """
+        Error check the attributes of the AddAttribute request payload.
+        """
+        if self.uid is not None:
+            if not isinstance(self.uid, six.string_types):
+                raise TypeError(
+                    "uid must be a string; "
+                    "expected (one of): {0}, observed: {1}".format(
+                        six.string_types, type(self.uid)))
+        if self.attribute is not None:
+            if not isinstance(self.attribute, objects.Attribute):
+                raise TypeError(
+                    "attribute must be a Attribute object, "
+                    "observed: {0}".format(type(self.attribute)))
+
+    def __repr__(self):
+        uid = "uid={0}".format(self.uid)
+        attribute = "attribute={0}".format(self.attribute)
+        if self.attribute is not None:
+            attribute = "attribute=({0}:{1})".format(
+                self.attribute.attribute_name,
+                self.attribute.attribute_value)
+        return "AddAttributeRequestPayload({0}, {1})".format(
+            uid,
+            attribute)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            if self.uid != other.uid:
+                return False
+            elif self.attribute != other.attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, AddAttributeRequestPayload):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented
+
+
+class AddAttributeResponsePayload(primitives.Struct):
+    """
+    A response payload for the AddAttribute operation.
+
+    The payload will contain the ID of the managed object with which a
+    new attribute has been associated. It will also contain this new attribute.
+    See Section 4.14 of the KMIP 1.1 specification for more information.
+
+    Attributes:
+        uid: The unique ID of the managed object with which a new attribute
+            has been associated.
+        attribute: New attribute associated with the managed object.
+    """
+    def __init__(self, uid=None, attribute=None):
+        """
+        Construct a AddAttribute response payload.
+
+        Args:
+            uid (string): required, the ID of the managed object with which a
+                new attribute has been associated.
+            attribute (Attribute): required, the added attribute
+                associated with the object
+        """
+        super(AddAttributeResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD)
+
+        self.uid = uid
+        self.attribute = attribute
+
+        self.validate()
+
+    def read(self, istream):
+        """
+        Read the data encoding the AddAttribute response payload and decode
+        it into its constituent parts.
+
+        Args:
+            istream (stream): A data stream containing encoded object data,
+                supporting a read method; usually a BytearrayStream object.
+        """
+        super(AddAttributeResponsePayload, self).read(istream)
+        tstream = utils.BytearrayStream(istream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+            uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
+            uid.read(tstream)
+            self.uid = uid.value
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "expected uid encoding not found")
+
+        if self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
+            self.attribute = objects.Attribute()
+            self.attribute.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        """
+        Write the data encoding the AddAttribute response payload to a
+        stream.
+
+        Args:
+            ostream (stream): A data stream in which to encode object data,
+                supporting a write method; usually a BytearrayStream object.
+        """
+        tstream = utils.BytearrayStream()
+
+        uid = primitives.TextString(
+            value=self.uid, tag=enums.Tags.UNIQUE_IDENTIFIER)
+        uid.write(tstream)
+
+        if self.attribute:
+            self.attribute.write(tstream)
+
+        self.length = tstream.length()
+        super(AddAttributeResponsePayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        """
+        Error check the attributes of the AddAttribute response payload.
+        """
+        if self.uid is not None:
+            if not isinstance(self.uid, six.string_types):
+                raise TypeError(
+                    "uid must be a string; "
+                    "expected (one of): {0}, observed: {1}".format(
+                        six.string_types, type(self.uid)))
+
+        if self.attribute is not None:
+            if not isinstance(self.attribute, objects.Attribute):
+                raise TypeError(
+                    "attribute must be a Attribute object, "
+                    "observed: {0}".format(type(self.attribute)))
+
+    def __repr__(self):
+        uid = "uid={0}".format(self.uid)
+        attribute = "attribute={0}".format(self.attribute)
+        if self.attribute is not None:
+            attribute = "attribute=({0}:{1})".format(
+                self.attribute.attribute_name,
+                self.attribute.attribute_value)
+        return "AddAttributeResponsePayload({0}, {1})".format(
+            uid,
+            attribute)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        if isinstance(other, AddAttributeResponsePayload):
+            if self.uid != other.uid:
+                return False
+            elif self.attribute != other.attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, AddAttributeResponsePayload):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented

--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -13,6 +13,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
+
+from kmip.core.messages.contents import ResultStatus
+from kmip.core.messages.contents import ResultReason
+from kmip.core.messages.contents import ResultMessage
+
 
 class OperationResult(object):
 
@@ -31,6 +37,33 @@ class OperationResult(object):
             self.result_message = result_message
         else:
             self.result_message = None
+
+    def validate(self):
+        if not isinstance(self.result_status, ResultStatus):
+            raise TypeError(
+                "Invalid ResultStatus type; "
+                "expected {0}; observed {1}".format(
+                    ResultStatus, type(self.result_status)))
+
+        if self.result_reason is not None:
+            if not isinstance(self.result_reason, ResultReason):
+                raise TypeError(
+                    "Invalid ResultReason type; "
+                    "expected {0}; observed {1}".format(
+                        ResultReason, type(self.result_reason)))
+
+        if self.result_status.value != enums.ResultStatus.SUCCESS:
+            if self.result_reason is None:
+                raise TypeError(
+                    "ResultReason is mandatory for the non "
+                    "SUCCESS ResultStatus")
+
+        if self.result_message is not None:
+            if not isinstance(self.result_message, ResultMessage):
+                raise TypeError(
+                    "Invalid ResultMessage type; "
+                    "expected {0}; observed {1}".format(
+                        ResultMessage, type(self.result_message)))
 
 
 class CreateResult(OperationResult):
@@ -276,3 +309,31 @@ class RevokeResult(OperationResult):
         super(RevokeResult, self).__init__(
             result_status, result_reason, result_message)
         self.unique_identifier = unique_identifier
+
+
+class AddAttributeResult(OperationResult):
+
+    def __init__(
+            self,
+            result_status,
+            result_reason=None,
+            result_message=None,
+            uid=None,
+            attribute=None):
+        super(AddAttributeResult, self).__init__(
+            result_status, result_reason, result_message)
+        self.uid = uid
+        self.attribute = attribute
+
+        self.validate()
+
+    def validate(self):
+        super(AddAttributeResult, self).validate()
+
+        if self.result_status.value == enums.ResultStatus.SUCCESS:
+            if self.uid is None:
+                raise TypeError(
+                    "UID is mandatory for result with SUCCESS status")
+            if self.attribute is None:
+                raise TypeError(
+                    "Attribute is mandatory for result with SUCCESS status")

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -19,6 +19,7 @@ from kmip.core.enums import Operation
 from kmip.core.factories.payloads.request import RequestPayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -99,8 +100,9 @@ class TestRequestPayloadFactory(testtools.TestCase):
             payload, get_attribute_list.GetAttributeListRequestPayload)
 
     def test_create_add_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+        payload = self.factory.create(Operation.ADD_ATTRIBUTE)
+        self._test_payload_type(
+            payload, add_attribute.AddAttributeRequestPayload)
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -19,6 +19,7 @@ from kmip.core.enums import Operation
 from kmip.core.factories.payloads.response import ResponsePayloadFactory
 
 from kmip.core.messages.payloads import activate
+from kmip.core.messages.payloads import add_attribute
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -99,8 +100,9 @@ class TestResponsePayloadFactory(testtools.TestCase):
             payload, get_attribute_list.GetAttributeListResponsePayload)
 
     def test_create_add_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+        payload = self.factory.create(Operation.ADD_ATTRIBUTE)
+        self._test_payload_type(
+            payload, add_attribute.AddAttributeResponsePayload)
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/messages/payloads/test_add_attribute.py
+++ b/kmip/tests/unit/core/messages/payloads/test_add_attribute.py
@@ -1,0 +1,334 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import binascii
+
+from testtools import TestCase
+
+from kmip.core import objects
+from kmip.core import utils
+from kmip.core import exceptions
+
+from kmip.core.attributes import Name
+from kmip.core.attributes import ContactInformation
+
+from kmip.core.factories.attributes import AttributeFactory
+
+from kmip.core.enums import AttributeType
+from kmip.core.enums import NameType
+
+from kmip.core.messages.payloads import add_attribute
+
+
+class TestAddAttributePayload(TestCase):
+
+    def setUp(self):
+        super(TestAddAttributePayload, self).setUp()
+
+        self.attr_factory = AttributeFactory()
+        self.name_uid = 'b4faee10-aa2a-4446-8ad4-0881f3422959'
+        self.ci_uid = '3'
+        self.ci_label = AttributeType.CONTACT_INFORMATION.value
+        self.ci_value = 'https://github.com/OpenKMIP/PyKMIP'
+        self.ci_uid_bis = '4'
+        self.ci_value_bis = 'https://github.com/OpenSC/OpenSC'
+
+        attr_name = Name.create(
+            Name.NameValue(value='TESTNAME'),
+            Name.NameType(value=NameType.UNINTERPRETED_TEXT_STRING))
+        self.attr_name = self.attr_factory.create_attribute(
+            AttributeType.NAME,
+            attr_name)
+
+        self.attr_contact_information = self.attr_factory.create_attribute(
+            AttributeType.CONTACT_INFORMATION,
+            self.ci_value)
+        self.attr_contact_information_bis = self.attr_factory.create_attribute(
+            AttributeType.CONTACT_INFORMATION,
+            self.ci_value_bis)
+
+        self.uid_invalid = 1234
+        self.attr_invalid = "invalid"
+
+        '''
+        <RequestPayload>
+          <UniqueIdentifier type="TextString" value="3"/>
+          <Attribute>
+            <AttributeName type="TextString" value="Contact Information"/>
+            <AttributeValue type="TextString" value="https://github.com/Ope...
+          </Attribute>
+        </RequestPayload>
+        '''
+        self.blob_request = binascii.unhexlify(
+            '4200790100000068420094070000000133000000000000004200080100000050'
+            '42000a0700000013436f6e7461637420496e666f726d6174696f6e0000000000'
+            '42000b070000002268747470733a2f2f6769746875622e636f6d2f4f70656e4b'
+            '4d49502f50794b4d4950000000000000'
+        )
+
+        '''
+        <ResponsePayload>
+          <UniqueIdentifier type="TextString" value="3"/>
+          <Attribute>
+            <AttributeName type="TextString" value="Contact Information"/>
+            <AttributeValue type="TextString" value="https://github.com/Ope...
+          </Attribute>
+        </ResponsePayload>
+        '''
+        self.blob_response = binascii.unhexlify(
+            '42007c0100000068420094070000000133000000000000004200080100000050'
+            '42000a0700000013436f6e7461637420496e666f726d6174696f6e0000000000'
+            '42000b070000002268747470733a2f2f6769746875622e636f6d2f4f70656e4b'
+            '4d49502f50794b4d4950000000000000'
+        )
+
+        '''
+        Response payload without 'Vendor Identification' instead of 'UID'
+        '''
+        self.blob_invalid_response = binascii.unhexlify(
+            '42007c010000006842009C070000000133000000000000004200080100000050'
+            '42000a0700000013436f6e7461637420496e666f726d6174696f6e0000000000'
+            '42000b070000002268747470733a2f2f6769746875622e636f6d2f4f70656e4b'
+            '4d49502f50794b4d4950000000000000'
+        )
+
+
+class TestAddAttributeRequestPayload(TestAddAttributePayload):
+
+    def setUp(self):
+        super(TestAddAttributeRequestPayload, self).setUp()
+
+    def tearDown(self):
+        super(TestAddAttributeRequestPayload, self).tearDown()
+
+    def test_init_with_none(self):
+        add_attribute.AddAttributeRequestPayload()
+
+    def test_init_with_args(self):
+        add_attribute.AddAttributeRequestPayload(
+            self.name_uid,
+            self.attr_name)
+        add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+    def test_validate_with_invalid_uid(self):
+        args = [self.uid_invalid, self.attr_name]
+        self.assertRaises(
+            TypeError,
+            add_attribute.AddAttributeRequestPayload,
+            *args)
+
+    def test_validate_with_invalid_attribute(self):
+        args = [self.name_uid, self.attr_invalid]
+        error_msg = ("attribute must be a Attribute object, "
+                     "observed: {0}").format(
+                        type(self.attr_invalid))
+        self.assertRaisesRegexp(
+            TypeError,
+            error_msg,
+            add_attribute.AddAttributeRequestPayload,
+            *args)
+
+    def test_read(self):
+        stream = utils.BytearrayStream((self.blob_request))
+
+        payload = add_attribute.AddAttributeRequestPayload()
+        payload.read(stream)
+        self.assertIsInstance(payload.attribute, objects.Attribute)
+        self.assertEqual(
+            payload.attribute.attribute_name.value,
+            "Contact Information")
+        self.assertIsInstance(
+            payload.attribute.attribute_value,
+            ContactInformation)
+        self.assertEqual(
+            payload.attribute.attribute_value.value,
+            self.ci_value)
+
+    def test_write(self):
+        stream = utils.BytearrayStream()
+        expected = self.blob_request
+
+        payload = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+        payload.write(stream)
+
+        length_expected = len(expected)
+        length_received = len(stream)
+
+        msg = "encoding lengths not equal"
+        msg += "; expected {0}, received {1}".format(
+            length_expected, length_received)
+        self.assertEqual(length_expected, length_received, msg)
+        print("length_expected {0}; length_received {1}".format(
+            length_expected, length_received))
+
+        msg = "encoding mismatch"
+        msg += ";\nexpected:\n{0}\nreceived:\n{1}".format(expected, stream)
+        self.assertEqual(expected, stream.buffer, msg)
+
+    def test_repr_str(self):
+        payload = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+        expected = "AddAttributeRequestPayload(uid={0}".format(self.ci_uid)
+        expected += ", attribute=('{0}':'{1}'))".format(
+            self.ci_label, self.ci_value)
+
+        self.assertEqual(expected, repr(payload))
+        self.assertEqual(expected, str(payload))
+
+    def test__eq(self):
+        payload = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+        payload_same = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+        payload_other_uid = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid_bis,
+            attribute=self.attr_contact_information)
+        payload_other_value = add_attribute.AddAttributeRequestPayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information_bis)
+
+        self.assertTrue(payload == payload_same)
+        self.assertTrue(payload != payload_other_value)
+        self.assertTrue(payload != payload_other_uid)
+        self.assertTrue(payload != 'invalid')
+        self.assertFalse(payload != payload_same)
+        self.assertFalse(payload == payload_other_value)
+        self.assertFalse(payload == payload_other_uid)
+        self.assertFalse(payload == 'invalid')
+
+
+class TestAddAttributeResponsePayload(TestAddAttributePayload):
+
+    def setUp(self):
+        super(TestAddAttributeResponsePayload, self).setUp()
+
+    def tearDown(self):
+        super(TestAddAttributeResponsePayload, self).tearDown()
+
+    def test_init_with_none(self):
+        add_attribute.AddAttributeResponsePayload()
+
+    def test_init_with_args(self):
+        add_attribute.AddAttributeResponsePayload(
+            self.name_uid,
+            self.attr_name)
+        add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+    def test_validate_with_invalid_uid(self):
+        args = [self.uid_invalid, self.attr_name]
+        self.assertRaises(
+            TypeError,
+            add_attribute.AddAttributeResponsePayload,
+            *args)
+
+    def test_validate_with_invalid_attribute(self):
+        args = [self.name_uid, self.attr_invalid]
+        error_msg = ("attribute must be a Attribute object, "
+                     "observed: {0}").format(type(self.attr_invalid))
+        self.assertRaisesRegexp(
+            TypeError,
+            error_msg,
+            add_attribute.AddAttributeResponsePayload,
+            *args)
+
+    def test_read(self):
+        stream = utils.BytearrayStream((self.blob_response))
+
+        payload = add_attribute.AddAttributeResponsePayload()
+        payload.read(stream)
+        self.assertIsInstance(payload.attribute, objects.Attribute)
+        self.assertEqual(
+            payload.attribute.attribute_name.value,
+            "Contact Information")
+        self.assertIsInstance(
+            payload.attribute.attribute_value,
+            ContactInformation)
+        self.assertEqual(
+            payload.attribute.attribute_value.value,
+            self.ci_value)
+
+    def test_read_invalid_response(self):
+        stream = utils.BytearrayStream((self.blob_invalid_response))
+        payload = add_attribute.AddAttributeResponsePayload()
+
+        args = [stream]
+        self.assertRaises(exceptions.InvalidKmipEncoding, payload.read, *args)
+
+    def test_write(self):
+        stream = utils.BytearrayStream()
+        expected = self.blob_response
+
+        payload = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+        payload.write(stream)
+
+        length_expected = len(expected)
+        length_received = len(stream)
+
+        msg = "encoding lengths not equal"
+        msg += "; expected {0}, received {1}".format(
+            length_expected, length_received)
+        self.assertEqual(length_expected, length_received, msg)
+        print("length_expected {0}; length_received {1}".format(
+            length_expected, length_received))
+
+        msg = "encoding mismatch"
+        msg += ";\nexpected:\n{0}\nreceived:\n{1}".format(expected, stream)
+        self.assertEqual(expected, stream.buffer, msg)
+
+    def test_repr_str(self):
+        payload = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+
+        expected = "AddAttributeResponsePayload(uid={0}".format(self.ci_uid)
+        expected += ", attribute=('{0}':'{1}'))".format(
+            self.ci_label, self.ci_value)
+
+        self.assertEqual(expected, repr(payload))
+        self.assertEqual(expected, str(payload))
+
+    def test__eq(self):
+        payload = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+        payload_same = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information)
+        payload_other_uid = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid_bis,
+            attribute=self.attr_contact_information)
+        payload_other_value = add_attribute.AddAttributeResponsePayload(
+            uid=self.ci_uid,
+            attribute=self.attr_contact_information_bis)
+
+        self.assertTrue(payload == payload_same)
+        self.assertTrue(payload != payload_other_value)
+        self.assertTrue(payload != payload_other_uid)
+        self.assertTrue(payload != 'invalid')
+        self.assertFalse(payload != payload_same)
+        self.assertFalse(payload == payload_other_value)
+        self.assertFalse(payload == payload_other_uid)
+        self.assertFalse(payload == 'invalid')

--- a/kmip/tests/unit/services/test_result.py
+++ b/kmip/tests/unit/services/test_result.py
@@ -1,0 +1,119 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from testtools import TestCase
+
+from kmip.core.objects import Attribute
+from kmip.core.factories.attributes import AttributeFactory
+
+from kmip.core import enums
+from kmip.services import results
+
+from kmip.core.messages.contents import ResultStatus
+from kmip.core.messages.contents import ResultReason
+from kmip.core.messages.contents import ResultMessage
+
+
+class TestServiceResult(TestCase):
+
+    def setUp(self):
+        super(TestServiceResult, self).setUp()
+
+        self.uid = '3'
+        self.attr_factory = AttributeFactory()
+        self.attr_contact_information = self.attr_factory.create_attribute(
+            enums.AttributeType.CONTACT_INFORMATION,
+            'https://github.com/OpenKMIP/PyKMIP')
+
+        self.status_success = ResultStatus(enums.ResultStatus.SUCCESS)
+        self.status_failed = ResultStatus(enums.ResultStatus.OPERATION_FAILED)
+        self.reason_not_found = ResultReason(enums.ResultReason.ITEM_NOT_FOUND)
+        self.message = ResultMessage("message")
+        self.invalid = 'invalid'
+
+    def tearDown(self):
+        super(TestServiceResult, self).tearDown()
+
+    def test_add_attribute_init_with_success(self):
+        result = results.AddAttributeResult(
+            self.status_success,
+            result_reason=None,
+            result_message=None,
+            uid=self.uid,
+            attribute=self.attr_contact_information)
+
+        self.assertIsInstance(result, results.AddAttributeResult)
+        self.assertEqual(result.result_status, self.status_success)
+        self.assertIsNone(result.result_reason)
+        self.assertIsNone(result.result_message)
+        self.assertEqual(result.uid, self.uid)
+        self.assertIsInstance(result.attribute, Attribute)
+
+    def test_add_attribute_init_with_failure(self):
+        result = results.AddAttributeResult(
+            self.status_failed,
+            result_reason=self.reason_not_found,
+            result_message=self.message)
+
+        self.assertIsInstance(result, results.AddAttributeResult)
+        self.assertEqual(result.result_status, self.status_failed)
+        self.assertEqual(result.result_reason, self.reason_not_found)
+        self.assertEqual(result.result_message, self.message)
+
+    def test_add_attribute_validate_fails_on_status(self):
+        error_msg = (
+            "Invalid ResultStatus type; expected {0}; observed {1}".format(
+                ResultStatus, type(self.invalid)))
+        args = [self.invalid]
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args)
+
+    def test_add_attribute_validate_fails_on_reason_invalid(self):
+        error_msg = (
+            "Invalid ResultReason type; expected {0}; observed {1}".format(
+                ResultReason, type(self.invalid)))
+        args = [self.status_failed]
+        kwargs = {'result_reason': self.invalid}
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args, **kwargs)
+
+    def test_add_attribute_validate_fails_on_reason_none(self):
+        error_msg = (
+            "ResultReason is mandatory for the non "
+            "SUCCESS ResultStatus")
+        args = [self.status_failed]
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args)
+
+    def test_add_attribute_validate_fails_on_message(self):
+        error_msg = (
+            "Invalid ResultMessage type; expected {0}; observed {1}".format(
+                ResultMessage, type(self.invalid)))
+        args = [self.status_failed]
+        kwargs = {
+            'result_reason': self.reason_not_found,
+            'result_message': self.invalid}
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args, **kwargs)
+
+    def test_add_attribute_validate_fails_on_uid(self):
+        error_msg = "UID is mandatory for result with SUCCESS status"
+        args = [self.status_success]
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args)
+
+    def test_add_attribute_validate_fails_on_attribute(self):
+        error_msg = "Attribute is mandatory for result with SUCCESS status"
+        args = [self.status_success]
+        kwargs = {'uid': self.uid}
+        self.assertRaisesRegexp(TypeError, error_msg,
+                                results.AddAttributeResult, *args, **kwargs)


### PR DESCRIPTION
Next PR from 'implementing Add Attribute' PR sequence - support of AddAttribute operation in KMIP service client

Depends on
#178 -- 'AddAttribute: payload messages';
#179 -- 'AddAttribute: payload factories';
#180 -- 'AddAttribute: service result'.

part of work to split closed #169
