### PR TITLE
Adding server support for the Activate operation

### DIFF
--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -57,6 +57,26 @@ class CryptographicFailure(KmipError):
         )
 
 
+class IllegalOperation(KmipError):
+    """
+    An error generated when an improper operation is attempted. The operation
+    can be 'illegal' for various reasons, including invalid permissions or
+    literal object/operation mismatch (e.g., a Template item cannot be
+    activated with the Activate operation since it has no state).
+    """
+    def __init__(self, message):
+        """
+        Create an IllegalOperation exception.
+
+        Args:
+            message (string): A string containing information about the error.
+        """
+        super(IllegalOperation, self).__init__(
+            reason=enums.ResultReason.ILLEGAL_OPERATION,
+            message=message
+        )
+
+
 class IndexOutOfBounds(KmipError):
     """
     An error generated when exceeding the attribute instance limit.

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -159,6 +159,7 @@ class CryptographicObject(ManagedObject):
                                primary_key=True)
     cryptographic_usage_masks = Column('cryptographic_usage_mask',
                                        sql.UsageMaskType)
+    state = Column('state', sql.EnumType(enums.State))
     __mapper_args__ = {
         'polymorphic_identity': 'CryptographicObject'
     }
@@ -175,6 +176,7 @@ class CryptographicObject(ManagedObject):
         super(CryptographicObject, self).__init__()
 
         self.cryptographic_usage_masks = list()
+        self.state = enums.State.PRE_ACTIVE
 
         # All remaining attributes are not considered part of the public API
         # and are subject to change.
@@ -191,7 +193,6 @@ class CryptographicObject(ManagedObject):
         self._lease_time = None
         self._links = list()
         self._revocation_reason = None
-        self._state = None
 
 
 class Key(CryptographicObject):

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -34,6 +34,7 @@ from kmip.core.factories import secrets
 from kmip.core.messages import contents
 from kmip.core.messages import messages
 
+from kmip.core.messages.payloads import activate
 from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
@@ -1182,6 +1183,59 @@ class KmipEngine(object):
             object_type=attributes.ObjectType(managed_object._object_type),
             unique_identifier=attributes.UniqueIdentifier(unique_identifier),
             secret=core_secret
+        )
+
+        return response_payload
+
+    @_kmip_version_supported('1.0')
+    def _process_activate(self, payload):
+        self._logger.info("Processing operation: Activate")
+
+        if payload.unique_identifier:
+            unique_identifier = payload.unique_identifier.value
+        else:
+            unique_identifier = self._id_placeholder
+
+        object_type = self._get_object_type(unique_identifier)
+
+        managed_object = self._data_session.query(object_type).filter(
+            object_type.unique_identifier == unique_identifier
+        ).one()
+
+        # Determine if the request should be carried out under the object's
+        # operation policy. If not, feign ignorance of the object.
+        is_allowed = self._is_allowed_by_operation_policy(
+            managed_object.operation_policy_name,
+            self._client_identity,
+            managed_object._owner,
+            managed_object._object_type,
+            enums.Operation.ACTIVATE
+        )
+        if not is_allowed:
+            raise exceptions.ItemNotFound(
+                "Could not locate object: {0}".format(unique_identifier)
+            )
+
+        object_type = managed_object._object_type
+        if not hasattr(managed_object, 'state'):
+            raise exceptions.IllegalOperation(
+                "An {0} object has no state and cannot be activated.".format(
+                    ''.join(
+                        [x.capitalize() for x in object_type.name.split('_')]
+                    )
+                )
+            )
+
+        if managed_object.state != enums.State.PRE_ACTIVE:
+            raise exceptions.PermissionDenied(
+                "The object state is not pre-active and cannot be activated."
+            )
+
+        managed_object.state = enums.State.ACTIVE
+        self._data_session.commit()
+
+        response_payload = activate.ActivateResponsePayload(
+            unique_identifier=attributes.UniqueIdentifier(unique_identifier)
         )
 
         return response_payload


### PR DESCRIPTION
This change adds support for the Activate operation to the server, including additional server unit tests, a new IllegalOperation exception, and updated state attribute support in Pie objects.

Fixes #186
