### PR TITLE
Fixing server failure on missing request credential

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -249,7 +249,10 @@ class KmipEngine(object):
             )
 
         # Process the authentication credentials
-        auth_credentials = header.authentication.credential
+        if header.authentication:
+            auth_credentials = header.authentication.credential
+        else:
+            auth_credentials = None
         self._verify_credential(auth_credentials, credential)
 
         # Process the batch error continuation option

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -391,6 +391,41 @@ class TestKmipEngine(testtools.TestCase):
             *args
         )
 
+    def test_process_request_missing_credential(self):
+        """
+        Test that the engine does not immediately error out when retrieving
+        a non-existent credential from the request.
+        """
+        e = engine.KmipEngine()
+        e._logger = mock.MagicMock()
+
+        protocol = contents.ProtocolVersion.create(1, 1)
+        header = messages.RequestHeader(
+            protocol_version=protocol,
+            authentication=None,
+            batch_error_cont_option=contents.BatchErrorContinuationOption(
+                enums.BatchErrorContinuationOption.STOP
+            ),
+            batch_order_option=contents.BatchOrderOption(True),
+            time_stamp=contents.TimeStamp(int(time.time())),
+            batch_count=contents.BatchCount(1)
+        )
+        payload = discover_versions.DiscoverVersionsRequestPayload()
+        batch = list([
+            messages.RequestBatchItem(
+                operation=contents.Operation(
+                    enums.Operation.DISCOVER_VERSIONS
+                ),
+                request_payload=payload
+            )
+        ])
+        request = messages.RequestMessage(
+            request_header=header,
+            batch_items=batch
+        )
+
+        e.process_request(request)
+
     def test_build_error_response(self):
         """
         Test that a bare bones response containing a single error result can


### PR DESCRIPTION
This change fixes a bug in the KMIP server engine where a missing request credential would cause the session to prematurely terminate. Credential handling may require session termination for missing credentials, but that decision should be made by credential processing not request processing.

Fixes #193