### PR TITLE
Adding operation policy enforcement to the KMIP server engine

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -57,6 +57,7 @@ class ManagedObject(sql.Base):
         String(50),
         default='default'
     )
+    _owner = Column('owner', String(50), default=None)
 
     __mapper_args__ = {
         'polymorphic_identity': 'ManagedObject',
@@ -78,6 +79,7 @@ class ManagedObject(sql.Base):
         self.names = list()
         self.operation_policy_name = None
         self._object_type = None
+        self._owner = None
 
         # All remaining attributes are not considered part of the public API
         # and are subject to change.


### PR DESCRIPTION
This change adds enforcement of KMIP operation policies to the server engine, specifically to the Get and Destroy operations. Explicit object ownership is enforced as a result, with ownership now a tracked internal server property of managed objects. Tests for this new functionality are included.