### PR TITLE
Adding dynamic operation policy loading to the KMIP server

### DIFF
--- a/kmip/services/server/config.py
+++ b/kmip/services/server/config.py
@@ -41,7 +41,8 @@ class KmipServerConfig(object):
             'certificate_path',
             'key_path',
             'ca_path',
-            'auth_suite'
+            'auth_suite',
+            'policy_path'
         ]
 
     def set_setting(self, setting, value):
@@ -75,8 +76,10 @@ class KmipServerConfig(object):
             self._set_key_path(value)
         elif setting == 'ca_path':
             self._set_ca_path(value)
-        else:
+        elif setting == 'auth_suite':
             self._set_auth_suite(value)
+        else:
+            self._set_policy_path(value)
 
     def load_settings(self, path):
         """
@@ -141,6 +144,8 @@ class KmipServerConfig(object):
             self._set_ca_path(parser.get('server', 'ca_path'))
         if parser.has_option('server', 'auth_suite'):
             self._set_auth_suite(parser.get('server', 'auth_suite'))
+        if parser.has_option('server', 'policy_path'):
+            self._set_policy_path(parser.get('server', 'policy_path'))
 
     def _set_hostname(self, value):
         if isinstance(value, six.string_types):
@@ -224,3 +229,20 @@ class KmipServerConfig(object):
             )
         else:
             self.settings['auth_suite'] = value
+
+    def _set_policy_path(self, value):
+        if value is None:
+            self.settings['policy_path'] = None
+        elif isinstance(value, six.string_types):
+            if os.path.exists(value):
+                self.settings['policy_path'] = value
+            else:
+                raise exceptions.ConfigurationError(
+                    "The policy path value, if specified, must be a valid "
+                    "string path to a filesystem directory."
+                )
+        else:
+            raise exceptions.ConfigurationError(
+                "The policy path, if specified, must be a valid string path "
+                "to a filesystem directory."
+            )

--- a/kmip/tests/unit/core/test_policy.py
+++ b/kmip/tests/unit/core/test_policy.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2016 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import shutil
+import tempfile
+import testtools
+
+from kmip.core import enums
+from kmip.core import policy
+
+
+class TestPolicy(testtools.TestCase):
+
+    def setUp(self):
+        super(TestPolicy, self).setUp()
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.temp_dir)
+
+    def tearDown(self):
+        super(TestPolicy, self).tearDown()
+
+    def test_read_policy_from_file(self):
+        policy_file = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir,
+            delete=False
+        )
+        with open(policy_file.name, 'w') as f:
+            f.write(
+                '{"test": {"CERTIFICATE": {"LOCATE": "ALLOW_ALL"}}}'
+            )
+
+        policies = policy.read_policy_from_file(policy_file.name)
+
+        self.assertEqual(1, len(policies))
+        self.assertIn('test', policies.keys())
+
+        test_policy = {
+            enums.ObjectType.CERTIFICATE: {
+                enums.Operation.LOCATE: enums.Policy.ALLOW_ALL
+            }
+        }
+
+        self.assertEqual(test_policy, policies.get('test'))
+
+    def test_read_policy_from_file_empty(self):
+        policy_file = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir,
+            delete=False
+        )
+        with open(policy_file.name, 'w') as f:
+            f.write('')
+
+        args = (policy_file.name, )
+        regex = "An error occurred while attempting to parse the JSON file."
+        self.assertRaisesRegexp(
+            ValueError,
+            regex,
+            policy.read_policy_from_file,
+            *args
+        )
+
+    def test_read_policy_from_file_bad_object_type(self):
+        policy_file = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir,
+            delete=False
+        )
+        with open(policy_file.name, 'w') as f:
+            f.write(
+                '{"test": {"INVALID": {"LOCATE": "ALLOW_ALL"}}}'
+            )
+
+        args = (policy_file.name, )
+        regex = "'INVALID' is not a valid ObjectType value."
+        self.assertRaisesRegexp(
+            ValueError,
+            regex,
+            policy.read_policy_from_file,
+            *args
+        )
+
+    def test_read_policy_from_file_bad_operation(self):
+        policy_file = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir,
+            delete=False
+        )
+        with open(policy_file.name, 'w') as f:
+            f.write(
+                '{"test": {"CERTIFICATE": {"INVALID": "ALLOW_ALL"}}}'
+            )
+
+        args = (policy_file.name, )
+        regex = "'INVALID' is not a valid Operation value."
+        self.assertRaisesRegexp(
+            ValueError,
+            regex,
+            policy.read_policy_from_file,
+            *args
+        )
+
+    def test_read_policy_from_file_bad_permission(self):
+        policy_file = tempfile.NamedTemporaryFile(
+            dir=self.temp_dir,
+            delete=False
+        )
+        with open(policy_file.name, 'w') as f:
+            f.write(
+                '{"test": {"CERTIFICATE": {"LOCATE": "INVALID"}}}'
+            )
+
+        args = (policy_file.name, )
+        regex = "'INVALID' is not a valid Policy value."
+        self.assertRaisesRegexp(
+            ValueError,
+            regex,
+            policy.read_policy_from_file,
+            *args
+        )


### PR DESCRIPTION
This change adds support for dynamic operation policy loading. The server config file now supports a 'policy_path' option that points to a filesystem directory. Each file in the directory should contain a JSON policy object. The KMIP server will scan this directory and attempt to load all valid policies it finds. The results of this process will be logged.