### PR TITLE
Adding string utilites to the Attribute object

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -129,6 +129,27 @@ class Attribute(Struct):
         super(Attribute, self).write(ostream)
         ostream.write(tstream.buffer)
 
+    def __repr__(self):
+        attribute_name = "attribute_name={0}".format(repr(self.attribute_name))
+        attribute_index = "attribute_index={0}".format(
+            repr(self.attribute_index)
+        )
+        attribute_value = "attribute_value={0}".format(
+            repr(self.attribute_value)
+        )
+        return "Attribute({0}, {1}, {2})".format(
+            attribute_name,
+            attribute_index,
+            attribute_value
+        )
+
+    def __str__(self):
+        return str({
+            'attribute_name': str(self.attribute_name),
+            'attribute_index': str(self.attribute_index),
+            'attribute_value': str(self.attribute_value)
+        })
+
     def __eq__(self, other):
         if isinstance(other, Attribute):
             if self.attribute_name != other.attribute_name:
@@ -143,7 +164,10 @@ class Attribute(Struct):
             return NotImplemented
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        if isinstance(other, Attribute):
+            return not self.__eq__(other)
+        else:
+            return NotImplemented
 
 
 # 2.1.2

--- a/kmip/tests/unit/core/objects/test_attribute.py
+++ b/kmip/tests/unit/core/objects/test_attribute.py
@@ -1,0 +1,110 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from kmip.core import attributes
+from kmip.core import objects
+
+
+class TestAttribute(testtools.TestCase):
+    """
+    Test suite for the Attribute object.
+    """
+
+    def setUp(self):
+        super(TestAttribute, self).setUp()
+
+    def tearDown(self):
+        super(TestAttribute, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that an Attribute object can be created.
+        """
+        objects.Attribute()
+
+    def test_init_with_args(self):
+        self.skip('')
+
+    def test_read(self):
+        self.skip('')
+
+    def test_write(self):
+        self.skip('')
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to an Attribute object.
+        """
+        attribute = objects.Attribute(
+            attribute_name=objects.Attribute.AttributeName('test-name'),
+            attribute_index=objects.Attribute.AttributeIndex(0),
+            attribute_value=attributes.CustomAttribute('test-value')
+        )
+
+        self.assertEqual(
+            "Attribute("
+            "attribute_name=AttributeName(value='test-name'), "
+            "attribute_index=AttributeIndex(value=0), "
+            "attribute_value=CustomAttribute(value='test-value'))",
+            repr(attribute)
+        )
+
+    def test_str(self):
+        """
+        Test that str can be applied to an Attribute object.
+        """
+        attribute = objects.Attribute(
+            attribute_name=objects.Attribute.AttributeName('test-name'),
+            attribute_index=objects.Attribute.AttributeIndex(0),
+            attribute_value=attributes.CustomAttribute('test-value')
+        )
+
+        self.assertEqual(
+            str({
+                'attribute_name': 'test-name',
+                'attribute_index': '0',
+                'attribute_value': 'test-value'
+            }),
+            str(attribute)
+        )
+
+    def test_equal_on_equal(self):
+        self.skip('')
+
+    def test_equal_on_not_equal_name(self):
+        self.skip('')
+
+    def test_equal_on_not_equal_index(self):
+        self.skip('')
+
+    def test_equal_on_not_equal_value(self):
+        self.skip('')
+
+    def test_equal_on_type_mismatch(self):
+        self.skip('')
+
+    def test_not_equal_on_equal(self):
+        self.skip('')
+
+    def test_not_equal_on_not_equal_name(self):
+        self.skip('')
+
+    def test_not_equal_on_not_equal_index(self):
+        self.skip('')
+
+    def test_not_equal_on_not_equal_value(self):
+        self.skip('')
+
+    def test_not_equal_on_type_mismatch(self):
+        self.skip('')


### PR DESCRIPTION
This change adds str and repr utilities to the Attribute object. A new test suite for Attribute object tests is included, however only the tests for the string utilities are included with this patch. The remaining Attribute tests will be implemented in a later patch.