### PR TITLE
Updating payload factories to reflect new KMIP operations

### DIFF
--- a/kmip/core/factories/payloads/__init__.py
+++ b/kmip/core/factories/payloads/__init__.py
@@ -13,73 +13,95 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core.enums import Operation
+from kmip.core import enums
 
 
 class PayloadFactory():
 
     def create(self, operation):
-        # Switch on Operation enum
-        if operation is Operation.CREATE:
+        # Switch on operation enum
+        if operation is enums.Operation.CREATE:
             return self._create_create_payload()
-        elif operation is Operation.CREATE_KEY_PAIR:
+        elif operation is enums.Operation.CREATE_KEY_PAIR:
             return self._create_create_key_pair_payload()
-        elif operation is Operation.REGISTER:
+        elif operation is enums.Operation.REGISTER:
             return self._create_register_payload()
-        elif operation is Operation.REKEY:
+        elif operation is enums.Operation.REKEY:
             return self._create_rekey_payload()
-        elif operation is Operation.DERIVE_KEY:
+        elif operation is enums.Operation.DERIVE_KEY:
             return self._create_derive_key_payload()
-        elif operation is Operation.CERTIFY:
+        elif operation is enums.Operation.CERTIFY:
             return self._create_certify_payload()
-        elif operation is Operation.RECERTIFY:
+        elif operation is enums.Operation.RECERTIFY:
             return self._create_recertify_payload()
-        elif operation is Operation.LOCATE:
+        elif operation is enums.Operation.LOCATE:
             return self._create_locate_payload()
-        elif operation is Operation.CHECK:
+        elif operation is enums.Operation.CHECK:
             return self._create_check_payload()
-        elif operation is Operation.GET:
+        elif operation is enums.Operation.GET:
             return self._create_get_payload()
-        elif operation is Operation.GET_ATTRIBUTES:
+        elif operation is enums.Operation.GET_ATTRIBUTES:
             return self._create_get_attributes_payload()
-        elif operation is Operation.GET_ATTRIBUTE_LIST:
+        elif operation is enums.Operation.GET_ATTRIBUTE_LIST:
             return self._create_get_attribute_list_payload()
-        elif operation is Operation.ADD_ATTRIBUTE:
+        elif operation is enums.Operation.ADD_ATTRIBUTE:
             return self._create_add_attribute_payload()
-        elif operation is Operation.MODIFY_ATTRIBUTE:
+        elif operation is enums.Operation.MODIFY_ATTRIBUTE:
             return self._create_modify_attribute_payload()
-        elif operation is Operation.DELETE_ATTRIBUTE:
+        elif operation is enums.Operation.DELETE_ATTRIBUTE:
             return self._create_delete_attribute_payload()
-        elif operation is Operation.OBTAIN_LEASE:
+        elif operation is enums.Operation.OBTAIN_LEASE:
             return self._create_obtain_lease_payload()
-        elif operation is Operation.GET_USAGE_ALLOCATION:
+        elif operation is enums.Operation.GET_USAGE_ALLOCATION:
             return self._create_get_usage_allocation_payload()
-        elif operation is Operation.ACTIVATE:
+        elif operation is enums.Operation.ACTIVATE:
             return self._create_activate_payload()
-        elif operation is Operation.REVOKE:
+        elif operation is enums.Operation.REVOKE:
             return self._create_revoke_payload()
-        elif operation is Operation.DESTROY:
+        elif operation is enums.Operation.DESTROY:
             return self._create_destroy_payload()
-        elif operation is Operation.ARCHIVE:
+        elif operation is enums.Operation.ARCHIVE:
             return self._create_archive_payload()
-        elif operation is Operation.RECOVER:
+        elif operation is enums.Operation.RECOVER:
             return self._create_recover_payload()
-        elif operation is Operation.VALIDATE:
+        elif operation is enums.Operation.VALIDATE:
             return self._create_validate_payload()
-        elif operation is Operation.QUERY:
+        elif operation is enums.Operation.QUERY:
             return self._create_query_payload()
-        elif operation is Operation.CANCEL:
+        elif operation is enums.Operation.CANCEL:
             return self._create_cancel_payload()
-        elif operation is Operation.POLL:
+        elif operation is enums.Operation.POLL:
             return self._create_poll_payload()
-        elif operation is Operation.NOTIFY:
+        elif operation is enums.Operation.NOTIFY:
             return self._create_notify_payload()
-        elif operation is Operation.PUT:
+        elif operation is enums.Operation.PUT:
             return self._create_put_payload()
-        elif operation is Operation.REKEY_KEY_PAIR:
+        elif operation is enums.Operation.REKEY_KEY_PAIR:
             return self._create_rekey_key_pair_payload()
-        elif operation is Operation.DISCOVER_VERSIONS:
+        elif operation is enums.Operation.DISCOVER_VERSIONS:
             return self._create_discover_versions_payload()
+        elif operation is enums.Operation.ENCRYPT:
+            return self._create_encrypt_payload()
+        elif operation is enums.Operation.DECRYPT:
+            return self._create_decrypt_payload()
+        elif operation is enums.Operation.SIGN:
+            return self._create_sign_payload()
+        elif operation is enums.Operation.SIGNATURE_VERIFY:
+            return self._create_signature_verify_payload()
+        elif operation is enums.Operation.MAC:
+            return self._create_mac_payload()
+        elif operation is enums.Operation.MAC_VERIFY:
+            return self._create_mac_verify_payload()
+        elif operation is enums.Operation.RNG_RETRIEVE:
+            return self._create_rng_retrieve_payload()
+        elif operation is enums.Operation.RNG_SEED:
+            return self._create_rng_seed_payload()
+        elif operation is enums.Operation.HASH:
+            return self._create_hash_payload()
+        elif operation is enums.Operation.CREATE_SPLIT_KEY:
+            return self._create_create_split_key_payload()
+        elif operation is enums.Operation.JOIN_SPLIT_KEY:
+            return self._create_join_split_key_payload()
         else:
             raise ValueError('unsupported operation: {0}'.format(operation))
 
@@ -171,4 +193,37 @@ class PayloadFactory():
         raise NotImplementedError()
 
     def _create_discover_versions_payload(self):
+        raise NotImplementedError()
+
+    def _create_encrypt_payload(self):
+        raise NotImplementedError()
+
+    def _create_decrypt_payload(self):
+        raise NotImplementedError()
+
+    def _create_sign_payload(self):
+        raise NotImplementedError()
+
+    def _create_signature_verify_payload(self):
+        raise NotImplementedError()
+
+    def _create_mac_payload(self):
+        raise NotImplementedError()
+
+    def _create_mac_verify_payload(self):
+        raise NotImplementedError()
+
+    def _create_rng_retrieve_payload(self):
+        raise NotImplementedError()
+
+    def _create_rng_seed_payload(self):
+        raise NotImplementedError()
+
+    def _create_hash_payload(self):
+        raise NotImplementedError()
+
+    def _create_create_split_key_payload(self):
+        raise NotImplementedError()
+
+    def _create_join_split_key_payload(self):
         raise NotImplementedError()

--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -22,6 +22,7 @@ from kmip.core.messages.payloads import destroy
 from kmip.core.messages.payloads import discover_versions
 from kmip.core.messages.payloads import get
 from kmip.core.messages.payloads import get_attribute_list
+from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import locate
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
@@ -51,6 +52,9 @@ class RequestPayloadFactory(PayloadFactory):
 
     def _create_get_attribute_list_payload(self):
         return get_attribute_list.GetAttributeListRequestPayload()
+
+    def _create_get_attributes_payload(self):
+        return get_attributes.GetAttributesRequestPayload()
 
     def _create_destroy_payload(self):
         return destroy.DestroyRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -22,6 +22,7 @@ from kmip.core.messages.payloads import destroy
 from kmip.core.messages.payloads import discover_versions
 from kmip.core.messages.payloads import get
 from kmip.core.messages.payloads import get_attribute_list
+from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import locate
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
@@ -51,6 +52,9 @@ class ResponsePayloadFactory(PayloadFactory):
 
     def _create_get_attribute_list_payload(self):
         return get_attribute_list.GetAttributeListResponsePayload()
+
+    def _create_get_attributes_payload(self):
+        return get_attributes.GetAttributesResponsePayload()
 
     def _create_destroy_payload(self):
         return destroy.DestroyResponsePayload()

--- a/kmip/tests/unit/core/factories/payloads/test_payload.py
+++ b/kmip/tests/unit/core/factories/payloads/test_payload.py
@@ -15,7 +15,7 @@
 
 import testtools
 
-from kmip.core.enums import Operation
+from kmip.core import enums
 from kmip.core.factories.payloads import PayloadFactory
 
 
@@ -33,123 +33,222 @@ class TestPayloadFactory(testtools.TestCase):
 
     def test_create_create_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CREATE)
+            self.factory.create,
+            enums.Operation.CREATE
+        )
 
     def test_create_create_key_pair_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CREATE_KEY_PAIR)
+            self.factory.create,
+            enums.Operation.CREATE_KEY_PAIR
+        )
 
     def test_create_register_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.REGISTER)
+            self.factory.create,
+            enums.Operation.REGISTER
+        )
 
     def test_create_rekey_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.REKEY)
+        self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
 
     def test_create_derive_key_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DERIVE_KEY)
+            self.factory.create,
+            enums.Operation.DERIVE_KEY
+        )
 
     def test_create_certify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CERTIFY)
+            self.factory.create,
+            enums.Operation.CERTIFY
+        )
 
     def test_create_recertify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECERTIFY)
+            self.factory.create,
+            enums.Operation.RECERTIFY
+        )
 
     def test_create_locate_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.LOCATE)
+            self.factory.create,
+            enums.Operation.LOCATE
+        )
 
     def test_create_check_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.CHECK)
+        self._test_not_implemented(self.factory.create, enums.Operation.CHECK)
 
     def test_create_get_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.GET)
+        self._test_not_implemented(self.factory.create, enums.Operation.GET)
 
     def test_create_get_attributes_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.GET_ATTRIBUTES)
+            self.factory.create,
+            enums.Operation.GET_ATTRIBUTES
+        )
 
     def test_create_get_attributes_list_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.GET_ATTRIBUTE_LIST)
+            self.factory.create,
+            enums.Operation.GET_ATTRIBUTE_LIST
+        )
 
     def test_create_add_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.ADD_ATTRIBUTE
+        )
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.MODIFY_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.MODIFY_ATTRIBUTE
+        )
 
     def test_create_delete_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DELETE_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.DELETE_ATTRIBUTE
+        )
 
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.OBTAIN_LEASE)
+            self.factory.create,
+            enums.Operation.OBTAIN_LEASE
+        )
 
     def test_create_get_usage_allocation_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.GET_USAGE_ALLOCATION)
+            self.factory.create,
+            enums.Operation.GET_USAGE_ALLOCATION
+        )
 
     def test_create_activate_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ACTIVATE)
+            self.factory.create,
+            enums.Operation.ACTIVATE
+        )
 
     def test_create_revoke_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.REVOKE)
+            self.factory.create,
+            enums.Operation.REVOKE
+        )
 
     def test_create_destroy_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DESTROY)
+            self.factory.create,
+            enums.Operation.DESTROY
+        )
 
     def test_create_archive_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ARCHIVE)
+            self.factory.create,
+            enums.Operation.ARCHIVE
+        )
 
     def test_create_recover_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECOVER)
+            self.factory.create,
+            enums.Operation.RECOVER
+        )
 
     def test_create_validate_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.VALIDATE)
+            self.factory.create,
+            enums.Operation.VALIDATE
+        )
 
     def test_create_query_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.QUERY)
+        self._test_not_implemented(self.factory.create, enums.Operation.QUERY)
 
     def test_create_cancel_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CANCEL)
+            self.factory.create,
+            enums.Operation.CANCEL
+        )
 
     def test_create_poll_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.POLL)
+        self._test_not_implemented(self.factory.create, enums.Operation.POLL)
 
     def test_create_notify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.NOTIFY)
+            self.factory.create,
+            enums.Operation.NOTIFY
+        )
 
     def test_create_put_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.PUT)
+        self._test_not_implemented(self.factory.create, enums.Operation.PUT)
 
     def test_create_rekey_key_pair_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.REKEY_KEY_PAIR)
+            self.factory.create,
+            enums.Operation.REKEY_KEY_PAIR
+        )
 
     def test_create_discover_versions_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DISCOVER_VERSIONS)
+            self.factory.create,
+            enums.Operation.DISCOVER_VERSIONS
+        )
+
+    def test_create_encrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.ENCRYPT
+        )
+
+    def test_create_decrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.DECRYPT
+        )
+
+    def test_create_sign_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.SIGN)
+
+    def test_create_signature_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.SIGNATURE_VERIFY
+        )
+
+    def test_create_mac_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.MAC)
+
+    def test_create_mac_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.MAC_VERIFY
+        )
+
+    def test_create_rng_retrieve_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_RETRIEVE
+        )
+
+    def test_create_rng_seed_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_SEED
+        )
+
+    def test_create_hash_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.HASH)
+
+    def test_create_create_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.CREATE_SPLIT_KEY
+        )
+
+    def test_create_join_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.JOIN_SPLIT_KEY
+        )
 
     def test_invalid_operation(self):
         self.assertRaises(ValueError, self.factory.create, None)

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -15,7 +15,7 @@
 
 import testtools
 
-from kmip.core.enums import Operation
+from kmip.core import enums
 from kmip.core.factories.payloads.request import RequestPayloadFactory
 
 from kmip.core.messages.payloads import activate
@@ -25,6 +25,7 @@ from kmip.core.messages.payloads import destroy
 from kmip.core.messages.payloads import discover_versions
 from kmip.core.messages.payloads import get
 from kmip.core.messages.payloads import get_attribute_list
+from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import locate
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
@@ -49,125 +50,215 @@ class TestRequestPayloadFactory(testtools.TestCase):
         self.assertIsInstance(payload, payload_type, msg)
 
     def test_create_create_payload(self):
-        payload = self.factory.create(Operation.CREATE)
+        payload = self.factory.create(enums.Operation.CREATE)
         self._test_payload_type(payload, create.CreateRequestPayload)
 
     def test_create_create_key_pair_payload(self):
-        payload = self.factory.create(Operation.CREATE_KEY_PAIR)
+        payload = self.factory.create(enums.Operation.CREATE_KEY_PAIR)
         self._test_payload_type(
-            payload, create_key_pair.CreateKeyPairRequestPayload)
+            payload,
+            create_key_pair.CreateKeyPairRequestPayload
+        )
 
     def test_create_register_payload(self):
-        payload = self.factory.create(Operation.REGISTER)
+        payload = self.factory.create(enums.Operation.REGISTER)
         self._test_payload_type(payload, register.RegisterRequestPayload)
 
     def test_create_rekey_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.REKEY)
+        self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
 
     def test_create_derive_key_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DERIVE_KEY)
+            self.factory.create,
+            enums.Operation.DERIVE_KEY
+        )
 
     def test_create_certify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CERTIFY)
+            self.factory.create,
+            enums.Operation.CERTIFY
+        )
 
     def test_create_recertify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECERTIFY)
+            self.factory.create,
+            enums.Operation.RECERTIFY
+        )
 
     def test_create_locate_payload(self):
-        payload = self.factory.create(Operation.LOCATE)
+        payload = self.factory.create(enums.Operation.LOCATE)
         self._test_payload_type(payload, locate.LocateRequestPayload)
 
     def test_create_check_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.CHECK)
+        self._test_not_implemented(self.factory.create, enums.Operation.CHECK)
 
     def test_create_get_payload(self):
-        payload = self.factory.create(Operation.GET)
+        payload = self.factory.create(enums.Operation.GET)
         self._test_payload_type(payload, get.GetRequestPayload)
 
     def test_create_get_attributes_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.GET_ATTRIBUTES)
+        payload = self.factory.create(enums.Operation.GET_ATTRIBUTES)
+        self._test_payload_type(
+            payload,
+            get_attributes.GetAttributesRequestPayload
+        )
 
     def test_create_get_attributes_list_payload(self):
-        payload = self.factory.create(Operation.GET_ATTRIBUTE_LIST)
+        payload = self.factory.create(enums.Operation.GET_ATTRIBUTE_LIST)
         self._test_payload_type(
-            payload, get_attribute_list.GetAttributeListRequestPayload)
+            payload,
+            get_attribute_list.GetAttributeListRequestPayload
+        )
 
     def test_create_add_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.ADD_ATTRIBUTE
+        )
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.MODIFY_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.MODIFY_ATTRIBUTE
+        )
 
     def test_create_delete_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DELETE_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.DELETE_ATTRIBUTE
+        )
 
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.OBTAIN_LEASE)
+            self.factory.create,
+            enums.Operation.OBTAIN_LEASE
+        )
 
     def test_create_get_usage_allocation_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.GET_USAGE_ALLOCATION)
+            self.factory.create,
+            enums.Operation.GET_USAGE_ALLOCATION
+        )
 
     def test_create_activate_payload(self):
-        payload = self.factory.create(Operation.ACTIVATE)
+        payload = self.factory.create(enums.Operation.ACTIVATE)
         self._test_payload_type(payload, activate.ActivateRequestPayload)
 
     def test_create_revoke_payload(self):
-        payload = self.factory.create(Operation.REVOKE)
+        payload = self.factory.create(enums.Operation.REVOKE)
         self._test_payload_type(payload, revoke.RevokeRequestPayload)
 
     def test_create_destroy_payload(self):
-        payload = self.factory.create(Operation.DESTROY)
+        payload = self.factory.create(enums.Operation.DESTROY)
         self._test_payload_type(payload, destroy.DestroyRequestPayload)
 
     def test_create_archive_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ARCHIVE)
+            self.factory.create,
+            enums.Operation.ARCHIVE
+        )
 
     def test_create_recover_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECOVER)
+            self.factory.create,
+            enums.Operation.RECOVER
+        )
 
     def test_create_validate_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.VALIDATE)
+            self.factory.create,
+            enums.Operation.VALIDATE
+        )
 
     def test_create_query_payload(self):
-        payload = self.factory.create(Operation.QUERY)
+        payload = self.factory.create(enums.Operation.QUERY)
         self._test_payload_type(payload, query.QueryRequestPayload)
 
     def test_create_cancel_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CANCEL)
+            self.factory.create,
+            enums.Operation.CANCEL
+        )
 
     def test_create_poll_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.POLL)
+        self._test_not_implemented(self.factory.create, enums.Operation.POLL)
 
     def test_create_notify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.NOTIFY)
+            self.factory.create,
+            enums.Operation.NOTIFY
+        )
 
     def test_create_put_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.PUT)
+        self._test_not_implemented(self.factory.create, enums.Operation.PUT)
 
     def test_create_rekey_key_pair_payload(self):
-        payload = self.factory.create(Operation.REKEY_KEY_PAIR)
+        payload = self.factory.create(enums.Operation.REKEY_KEY_PAIR)
         self._test_payload_type(
-            payload, rekey_key_pair.RekeyKeyPairRequestPayload)
+            payload,
+            rekey_key_pair.RekeyKeyPairRequestPayload
+        )
 
     def test_create_discover_versions_payload(self):
-        payload = self.factory.create(Operation.DISCOVER_VERSIONS)
+        payload = self.factory.create(enums.Operation.DISCOVER_VERSIONS)
         self._test_payload_type(
-            payload, discover_versions.DiscoverVersionsRequestPayload)
+            payload,
+            discover_versions.DiscoverVersionsRequestPayload
+        )
+
+    def test_create_encrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.ENCRYPT
+        )
+
+    def test_create_decrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.DECRYPT
+        )
+
+    def test_create_sign_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.SIGN)
+
+    def test_create_signature_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.SIGNATURE_VERIFY
+        )
+
+    def test_create_mac_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.MAC)
+
+    def test_create_mac_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.MAC_VERIFY
+        )
+
+    def test_create_rng_retrieve_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_RETRIEVE
+        )
+
+    def test_create_rng_seed_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_SEED
+        )
+
+    def test_create_hash_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.HASH)
+
+    def test_create_create_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.CREATE_SPLIT_KEY
+        )
+
+    def test_create_join_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.JOIN_SPLIT_KEY
+        )

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -15,7 +15,7 @@
 
 import testtools
 
-from kmip.core.enums import Operation
+from kmip.core import enums
 from kmip.core.factories.payloads.response import ResponsePayloadFactory
 
 from kmip.core.messages.payloads import activate
@@ -25,6 +25,7 @@ from kmip.core.messages.payloads import destroy
 from kmip.core.messages.payloads import discover_versions
 from kmip.core.messages.payloads import get
 from kmip.core.messages.payloads import get_attribute_list
+from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import locate
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
@@ -49,125 +50,213 @@ class TestResponsePayloadFactory(testtools.TestCase):
         self.assertIsInstance(payload, payload_type, msg)
 
     def test_create_create_payload(self):
-        payload = self.factory.create(Operation.CREATE)
+        payload = self.factory.create(enums.Operation.CREATE)
         self._test_payload_type(payload, create.CreateResponsePayload)
 
     def test_create_create_key_pair_payload(self):
-        payload = self.factory.create(Operation.CREATE_KEY_PAIR)
+        payload = self.factory.create(enums.Operation.CREATE_KEY_PAIR)
         self._test_payload_type(
-            payload, create_key_pair.CreateKeyPairResponsePayload)
+            payload,
+            create_key_pair.CreateKeyPairResponsePayload
+        )
 
     def test_create_register_payload(self):
-        payload = self.factory.create(Operation.REGISTER)
+        payload = self.factory.create(enums.Operation.REGISTER)
         self._test_payload_type(payload, register.RegisterResponsePayload)
 
     def test_create_rekey_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.REKEY)
+        self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
 
     def test_create_derive_key_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DERIVE_KEY)
+            self.factory.create,
+            enums.Operation.DERIVE_KEY
+        )
 
     def test_create_certify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CERTIFY)
+            self.factory.create,
+            enums.Operation.CERTIFY
+        )
 
     def test_create_recertify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECERTIFY)
+            self.factory.create,
+            enums.Operation.RECERTIFY
+        )
 
     def test_create_locate_payload(self):
-        payload = self.factory.create(Operation.LOCATE)
+        payload = self.factory.create(enums.Operation.LOCATE)
         self._test_payload_type(payload, locate.LocateResponsePayload)
 
     def test_create_check_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.CHECK)
+        self._test_not_implemented(self.factory.create, enums.Operation.CHECK)
 
     def test_create_get_payload(self):
-        payload = self.factory.create(Operation.GET)
+        payload = self.factory.create(enums.Operation.GET)
         self._test_payload_type(payload, get.GetResponsePayload)
 
     def test_create_get_attributes_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.GET_ATTRIBUTES)
+        payload = self.factory.create(enums.Operation.GET_ATTRIBUTES)
+        self._test_payload_type(
+            payload,
+            get_attributes.GetAttributesResponsePayload
+        )
 
     def test_create_get_attributes_list_payload(self):
-        payload = self.factory.create(Operation.GET_ATTRIBUTE_LIST)
+        payload = self.factory.create(enums.Operation.GET_ATTRIBUTE_LIST)
         self._test_payload_type(
-            payload, get_attribute_list.GetAttributeListResponsePayload)
+            payload,
+            get_attribute_list.GetAttributeListResponsePayload
+        )
 
     def test_create_add_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ADD_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.ADD_ATTRIBUTE
+        )
 
     def test_create_modify_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.MODIFY_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.MODIFY_ATTRIBUTE
+        )
 
     def test_create_delete_attribute_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.DELETE_ATTRIBUTE)
+            self.factory.create,
+            enums.Operation.DELETE_ATTRIBUTE
+        )
 
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.OBTAIN_LEASE)
+            self.factory.create,
+            enums.Operation.OBTAIN_LEASE
+        )
 
     def test_create_get_usage_allocation_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.GET_USAGE_ALLOCATION)
+            self.factory.create, enums.Operation.GET_USAGE_ALLOCATION)
 
     def test_create_activate_payload(self):
-        payload = self.factory.create(Operation.ACTIVATE)
+        payload = self.factory.create(enums.Operation.ACTIVATE)
         self._test_payload_type(payload, activate.ActivateResponsePayload)
 
     def test_create_revoke_payload(self):
-        payload = self.factory.create(Operation.REVOKE)
+        payload = self.factory.create(enums.Operation.REVOKE)
         self._test_payload_type(payload, revoke.RevokeResponsePayload)
 
     def test_create_destroy_payload(self):
-        payload = self.factory.create(Operation.DESTROY)
+        payload = self.factory.create(enums.Operation.DESTROY)
         self._test_payload_type(payload, destroy.DestroyResponsePayload)
 
     def test_create_archive_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.ARCHIVE)
+            self.factory.create,
+            enums.Operation.ARCHIVE
+        )
 
     def test_create_recover_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.RECOVER)
+            self.factory.create,
+            enums.Operation.RECOVER
+        )
 
     def test_create_validate_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.VALIDATE)
+            self.factory.create,
+            enums.Operation.VALIDATE
+        )
 
     def test_create_query_payload(self):
-        payload = self.factory.create(Operation.QUERY)
+        payload = self.factory.create(enums.Operation.QUERY)
         self._test_payload_type(payload, query.QueryResponsePayload)
 
     def test_create_cancel_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.CANCEL)
+            self.factory.create,
+            enums.Operation.CANCEL
+        )
 
     def test_create_poll_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.POLL)
+        self._test_not_implemented(self.factory.create, enums.Operation.POLL)
 
     def test_create_notify_payload(self):
         self._test_not_implemented(
-            self.factory.create, Operation.NOTIFY)
+            self.factory.create,
+            enums.Operation.NOTIFY
+        )
 
     def test_create_put_payload(self):
-        self._test_not_implemented(
-            self.factory.create, Operation.PUT)
+        self._test_not_implemented(self.factory.create, enums.Operation.PUT)
 
     def test_create_rekey_key_pair_payload(self):
-        payload = self.factory.create(Operation.REKEY_KEY_PAIR)
+        payload = self.factory.create(enums.Operation.REKEY_KEY_PAIR)
         self._test_payload_type(
-            payload, rekey_key_pair.RekeyKeyPairResponsePayload)
+            payload,
+            rekey_key_pair.RekeyKeyPairResponsePayload
+        )
 
     def test_create_discover_versions_payload(self):
-        payload = self.factory.create(Operation.DISCOVER_VERSIONS)
+        payload = self.factory.create(enums.Operation.DISCOVER_VERSIONS)
         self._test_payload_type(
-            payload, discover_versions.DiscoverVersionsResponsePayload)
+            payload,
+            discover_versions.DiscoverVersionsResponsePayload
+        )
+
+    def test_create_encrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.ENCRYPT
+        )
+
+    def test_create_decrypt_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.DECRYPT
+        )
+
+    def test_create_sign_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.SIGN)
+
+    def test_create_signature_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.SIGNATURE_VERIFY
+        )
+
+    def test_create_mac_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.MAC)
+
+    def test_create_mac_verify_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.MAC_VERIFY
+        )
+
+    def test_create_rng_retrieve_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_RETRIEVE
+        )
+
+    def test_create_rng_seed_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.RNG_SEED
+        )
+
+    def test_create_hash_payload(self):
+        self._test_not_implemented(self.factory.create, enums.Operation.HASH)
+
+    def test_create_create_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.CREATE_SPLIT_KEY
+        )
+
+    def test_create_join_split_key_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.JOIN_SPLIT_KEY
+        )


### PR DESCRIPTION
This change updates the payload factories, adding placeholder support for operations added in KMIP 1.3. It also updates old placeholders with now supported payloads. The corresponding unit test suites have been updated to match the additions.