### PR TITLE
Fixes premature server shutdown on receiving invalid certificate

### DIFF
--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -298,12 +298,12 @@ class KmipServer(object):
             except socket.error as e:
                 if e.errno == errno.EINTR:
                     self._logger.warning("Interrupting connection service.")
+                    break
                 else:
                     self._logger.warning(
                         "Error detected while establishing new connection."
                     )
                     self._logger.exception(e)
-                break
             except Exception as e:
                 self._logger.warning(
                     "Error detected while establishing new connection."

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -381,7 +381,7 @@ class TestKmipServer(testtools.TestCase):
         s._is_serving = True
         s._logger.reset_mock()
         s._socket.accept = mock.MagicMock(
-            side_effect=[unexpected_error]
+            side_effect=[unexpected_error, expected_error]
         )
 
         s.serve()


### PR DESCRIPTION
This change fixes a bug with the server where the server would prematurely shutdown upon receiving a client connection using an invalid certificate. The server will now withstand bad client connections. The impacted server unit tests have been updated to reflect the bug fix.