### PR TITLE
Adding server support for the GetAttributes operation

### DIFF
--- a/kmip/core/messages/payloads/get_attributes.py
+++ b/kmip/core/messages/payloads/get_attributes.py
@@ -31,19 +31,19 @@ class GetAttributesRequestPayload(primitives.Struct):
     duplicates in the attribute name list.
 
     Attributes:
-        uid: The unique ID of the managed object with which the retrieved
-            attributes should be associated.
+        unique_identifier: The unique ID of the managed object with which the
+            retrieved attributes should be associated.
         attribute_names: A list of strings identifying the names of the
             attributes associated with the managed object.
     """
-    def __init__(self, uid=None, attribute_names=None):
+    def __init__(self, unique_identifier=None, attribute_names=None):
         """
         Construct a GetAttributes request payload.
 
         Args:
-            uid (string): The ID of the managed object with which the
-                retrieved attributes should be associated. Optional, defaults
-                to None.
+            unique_identifier (string): The ID of the managed object with
+                which the retrieved attributes should be associated. Optional,
+                defaults to None.
             attribute_names: A list of strings identifying the names of the
                 attributes associated with the managed object. Optional,
                 defaults to None.
@@ -51,30 +51,30 @@ class GetAttributesRequestPayload(primitives.Struct):
         super(GetAttributesRequestPayload, self).__init__(
             enums.Tags.REQUEST_PAYLOAD)
 
-        self._uid = None
+        self._unique_identifier = None
         self._attribute_names = list()
 
-        self.uid = uid
+        self.unique_identifier = unique_identifier
         self.attribute_names = attribute_names
 
     @property
-    def uid(self):
-        if self._uid:
-            return self._uid.value
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
         else:
-            return self._uid
+            return self._unique_identifier
 
-    @uid.setter
-    def uid(self, value):
+    @unique_identifier.setter
+    def unique_identifier(self, value):
         if value is None:
-            self._uid = None
+            self._unique_identifier = None
         elif isinstance(value, six.string_types):
-            self._uid = primitives.TextString(
+            self._unique_identifier = primitives.TextString(
                 value=value,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
         else:
-            raise TypeError("uid must be a string")
+            raise TypeError("unique identifier must be a string")
 
     @property
     def attribute_names(self):
@@ -125,10 +125,12 @@ class GetAttributesRequestPayload(primitives.Struct):
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
-            self._uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
-            self._uid.read(tstream)
+            self._unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            self._unique_identifier.read(tstream)
         else:
-            self._uid = None
+            self._unique_identifier = None
 
         names = list()
         while self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, tstream):
@@ -150,8 +152,8 @@ class GetAttributesRequestPayload(primitives.Struct):
         """
         tstream = utils.BytearrayStream()
 
-        if self._uid:
-            self._uid.write(tstream)
+        if self._unique_identifier:
+            self._unique_identifier.write(tstream)
 
         for attribute_name in self._attribute_names:
             attribute_name.write(tstream)
@@ -161,22 +163,24 @@ class GetAttributesRequestPayload(primitives.Struct):
         ostream.write(tstream.buffer)
 
     def __repr__(self):
-        uid = "uid={0}".format(self.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            self.unique_identifier
+        )
         attribute_names = "attribute_names={0}".format(self.attribute_names)
         return "GetAttributesRequestPayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             attribute_names
         )
 
     def __str__(self):
         return str({
-            'uid': self.uid,
+            'unique_identifier': self.unique_identifier,
             'attribute_names': self.attribute_names
         })
 
     def __eq__(self, other):
         if isinstance(other, GetAttributesRequestPayload):
-            if self.uid == other.uid:
+            if self.unique_identifier == other.unique_identifier:
                 if set(self.attribute_names) == set(other.attribute_names):
                     return True
                 else:
@@ -202,49 +206,49 @@ class GetAttributesResponsePayload(primitives.Struct):
     associated with the aforementioned managed object.
 
     Attributes:
-        uid: The unique ID of the managed object with which the retrieved
-            attributes should be associated.
+        unique_identifier: The unique ID of the managed object with which
+            the retrieved attributes should be associated.
         attributes: The list of attributes associated with managed object
-            identified by the uid above.
+            identified by the unique identifier above.
     """
-    def __init__(self, uid=None, attributes=None):
+    def __init__(self, unique_identifier=None, attributes=None):
         """
         Construct a GetAttributes response payload.
 
         Args:
-            uid (string): The ID of the managed object with which the
-                retrieved attributes should be associated. Optional, defaults
-                to None.
+            unique_identifier (string): The ID of the managed object with
+                which the retrieved attributes should be associated. Optional,
+                defaults to None.
             attributes (list): A list of attribute structures associated with
                 the managed object. Optional, defaults to None.
         """
         super(GetAttributesResponsePayload, self).__init__(
             enums.Tags.RESPONSE_PAYLOAD)
 
-        self._uid = None
+        self._unique_identifier = None
         self._attributes = list()
 
-        self.uid = uid
+        self.unique_identifier = unique_identifier
         self.attributes = attributes
 
     @property
-    def uid(self):
-        if self._uid:
-            return self._uid.value
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
         else:
-            return self._uid
+            return self._unique_identifier
 
-    @uid.setter
-    def uid(self, value):
+    @unique_identifier.setter
+    def unique_identifier(self, value):
         if value is None:
-            self._uid = None
+            self._unique_identifier = None
         elif isinstance(value, six.string_types):
-            self._uid = primitives.TextString(
+            self._unique_identifier = primitives.TextString(
                 value=value,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
         else:
-            raise TypeError("uid must be a string")
+            raise TypeError("unique identifier must be a string")
 
     @property
     def attributes(self):
@@ -279,12 +283,14 @@ class GetAttributesResponsePayload(primitives.Struct):
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
-            uid = primitives.TextString(tag=enums.Tags.UNIQUE_IDENTIFIER)
-            uid.read(tstream)
-            self.uid = uid.value
+            unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            unique_identifier.read(tstream)
+            self.unique_identifier = unique_identifier.value
         else:
             raise exceptions.InvalidKmipEncoding(
-                "expected GetAttributes response uid not found"
+                "expected GetAttributes response unique identifier not found"
             )
 
         self._attributes = list()
@@ -306,11 +312,11 @@ class GetAttributesResponsePayload(primitives.Struct):
         """
         tstream = utils.BytearrayStream()
 
-        if self._uid:
-            self._uid.write(tstream)
+        if self._unique_identifier:
+            self._unique_identifier.write(tstream)
         else:
             raise exceptions.InvalidField(
-                "The GetAttributes response uid is required."
+                "The GetAttributes response unique identifier is required."
             )
 
         for attribute in self._attributes:
@@ -321,16 +327,24 @@ class GetAttributesResponsePayload(primitives.Struct):
         ostream.write(tstream.buffer)
 
     def __repr__(self):
-        uid = "uid={0}".format(self.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            self.unique_identifier
+        )
         names = "attributes={0}".format(self.attributes)
-        return "GetAttributesResponsePayload({0}, {1})".format(uid, names)
+        return "GetAttributesResponsePayload({0}, {1})".format(
+            unique_identifier,
+            names
+        )
 
     def __str__(self):
-        return str({'uid': self.uid, 'attributes': self.attributes})
+        return str({
+            'unique_identifier': self.unique_identifier,
+            'attributes': self.attributes
+        })
 
     def __eq__(self, other):
         if isinstance(other, GetAttributesResponsePayload):
-            if self.uid != other.uid:
+            if self.unique_identifier != other.unique_identifier:
                 return False
             if len(self._attributes) != len(other._attributes):
                 return False

--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -825,11 +825,10 @@ class TextString(Base):
 
     def __validate(self):
         if self.value is not None:
-            data_type = type(self.value)
-            if data_type is not str:
+            if not isinstance(self.value, six.string_types):
                 msg = ErrorStrings.BAD_EXP_RECV
                 raise TypeError(msg.format('TextString', 'value', str,
-                                           data_type))
+                                           type(self.value)))
 
     def __repr__(self):
         return "{0}(value={1})".format(type(self).__name__, repr(self.value))

--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -1146,3 +1146,12 @@ class AttributePolicy(object):
         # TODO (peterhamilton) Handle multivalue swap between certificate types
         rule_set = self._attribute_rule_sets.get(attribute)
         return rule_set.multiple_instances_permitted
+
+    def get_all_attribute_names(self):
+        """
+        Get a list of all supported attribute names.
+
+        Returns:
+            list: A list of string attribute names.
+        """
+        return self._attribute_rule_sets.keys()

--- a/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
@@ -46,7 +46,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             b'\x69\x6F\x6E\x00\x00\x00\x00\x00\x42\x00\x0A\x07\x00\x00\x00\x09'
             b'\x78\x2D\x50\x75\x72\x70\x6F\x73\x65\x00\x00\x00\x00\x00\x00\x00'
         )
-        self.encoding_sans_uid = utils.BytearrayStream(
+        self.encoding_sans_unique_identifier = utils.BytearrayStream(
             b'\x42\x00\x79\x01\x00\x00\x00\x78\x42\x00\x0A\x07\x00\x00\x00\x0C'
             b'\x4F\x62\x6A\x65\x63\x74\x20\x47\x72\x6F\x75\x70\x00\x00\x00\x00'
             b'\x42\x00\x0A\x07\x00\x00\x00\x20\x41\x70\x70\x6C\x69\x63\x61\x74'
@@ -66,7 +66,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             b'\x42\x00\x79\x01\x00\x00\x00\x00'
         )
 
-        self.uid = '1703250b-4d40-4de2-93a0-c494a1d4ae40'
+        self.unique_identifier = '1703250b-4d40-4de2-93a0-c494a1d4ae40'
         self.attribute_names = [
             'Object Group',
             'Application Specific Information',
@@ -90,41 +90,41 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         valid value.
         """
         get_attributes.GetAttributesRequestPayload(
-            'test-uid',
+            'test-unique-identifier',
             ['test-attribute-name-1', 'test-attribute-name-2']
         )
 
-    def test_uid(self):
+    def test_unique_identifier(self):
         """
-        Test that the uid attribute of a GetAttributes request payload can
-        be properly set and retrieved.
+        Test that the unique_identifier attribute of a GetAttributes request
+        payload can be properly set and retrieved.
         """
         payload = get_attributes.GetAttributesRequestPayload()
 
-        self.assertIsNone(payload.uid)
-        self.assertIsNone(payload._uid)
+        self.assertIsNone(payload.unique_identifier)
+        self.assertIsNone(payload._unique_identifier)
 
-        payload.uid = 'test-uid'
+        payload.unique_identifier = 'test-unique-identifier'
 
-        self.assertEqual('test-uid', payload.uid)
+        self.assertEqual('test-unique-identifier', payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value='test-uid',
+                value='test-unique-identifier',
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
 
-    def test_uid_with_invalid_value(self):
+    def test_unique_identifier_with_invalid_value(self):
         """
         Test that a TypeError is raised when an invalid ID is used to set
-        the uid attribute of a GetAttributes request payload.
+        the unique_identifier attribute of a GetAttributes request payload.
         """
         payload = get_attributes.GetAttributesRequestPayload()
-        args = (payload, 'uid', 0)
+        args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
-            "uid must be a string",
+            "unique identifier must be a string",
             setattr,
             *args
         )
@@ -239,18 +239,18 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         payload = get_attributes.GetAttributesRequestPayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
 
         payload.read(self.full_encoding)
 
-        self.assertEqual(self.uid, payload.uid)
+        self.assertEqual(self.unique_identifier, payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value=self.uid,
+                value=self.unique_identifier,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
         self.assertEqual(
             set(self.attribute_names),
@@ -265,20 +265,20 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
                 payload._attribute_names
             )
 
-    def test_read_with_no_uid(self):
+    def test_read_with_no_unique_identifier(self):
         """
         Test that a GetAttributes request payload with no ID can be read
         from a data stream.
         """
         payload = get_attributes.GetAttributesRequestPayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
 
-        payload.read(self.encoding_sans_uid)
+        payload.read(self.encoding_sans_unique_identifier)
 
-        self.assertEqual(None, payload.uid)
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(
             set(self.attribute_names),
             set(payload.attribute_names)
@@ -299,18 +299,18 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         payload = get_attributes.GetAttributesRequestPayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
 
         payload.read(self.encoding_sans_attribute_names)
 
-        self.assertEqual(self.uid, payload.uid)
+        self.assertEqual(self.unique_identifier, payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value=self.uid,
+                value=self.unique_identifier,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
@@ -322,13 +322,13 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         payload = get_attributes.GetAttributesRequestPayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
 
         payload.read(self.empty_encoding)
 
-        self.assertEqual(None, payload.uid)
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
 
@@ -338,7 +338,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         stream.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         stream = utils.BytearrayStream()
@@ -347,7 +347,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         self.assertEqual(len(self.full_encoding), len(stream))
         self.assertEqual(str(self.full_encoding), str(stream))
 
-    def test_write_with_no_uid(self):
+    def test_write_with_no_unique_identifier(self):
         """
         Test that a GetAttributes request payload with no ID can be written
         to a data stream.
@@ -359,8 +359,14 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         stream = utils.BytearrayStream()
         payload.write(stream)
 
-        self.assertEqual(len(self.encoding_sans_uid), len(stream))
-        self.assertEqual(str(self.encoding_sans_uid), str(stream))
+        self.assertEqual(
+            len(self.encoding_sans_unique_identifier),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_sans_unique_identifier),
+            str(stream)
+        )
 
     def test_write_with_no_attribute_names(self):
         """
@@ -368,7 +374,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         can be written to a data stream.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
         stream = utils.BytearrayStream()
@@ -394,21 +400,23 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributes request payload.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
-        uid = "uid={0}".format(payload.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            payload.unique_identifier
+        )
         attribute_names = "attribute_names={0}".format(
             payload.attribute_names
         )
         expected = "GetAttributesRequestPayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             attribute_names
         )
         observed = repr(payload)
         self.assertEqual(expected, observed)
 
-    def test_repr_with_no_uid(self):
+    def test_repr_with_no_unique_identifier(self):
         """
         Test that repr can be applied to a GetAttributes request payload with
         no ID.
@@ -417,12 +425,14 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             None,
             self.attribute_names
         )
-        uid = "uid={0}".format(payload.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            payload.unique_identifier
+        )
         attribute_names = "attribute_names={0}".format(
             payload.attribute_names
         )
         expected = "GetAttributesRequestPayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             attribute_names
         )
         observed = repr(payload)
@@ -434,15 +444,17 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         no attribute names.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
-        uid = "uid={0}".format(payload.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            payload.unique_identifier
+        )
         attribute_names = "attribute_names={0}".format(
             payload.attribute_names
         )
         expected = "GetAttributesRequestPayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             attribute_names
         )
         observed = repr(payload)
@@ -457,12 +469,14 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             None,
             None
         )
-        uid = "uid={0}".format(payload.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            payload.unique_identifier
+        )
         attribute_names = "attribute_names={0}".format(
             payload.attribute_names
         )
         expected = "GetAttributesRequestPayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             attribute_names
         )
         observed = repr(payload)
@@ -473,11 +487,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that str can be applied to a GetAttributes request payload.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         expected = str({
-            'uid': self.uid,
+            'unique_identifier': self.unique_identifier,
             'attribute_names': self.attribute_names
         })
         observed = str(payload)
@@ -493,7 +507,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             self.attribute_names
         )
         expected = str({
-            'uid': None,
+            'unique_identifier': None,
             'attribute_names': self.attribute_names
         })
         observed = str(payload)
@@ -505,11 +519,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         no attribute names.
         """
         payload = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
         expected = str({
-            'uid': self.uid,
+            'unique_identifier': self.unique_identifier,
             'attribute_names': list()
         })
         observed = str(payload)
@@ -525,7 +539,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             None
         )
         expected = str({
-            'uid': None,
+            'unique_identifier': None,
             'attribute_names': list()
         })
         observed = str(payload)
@@ -537,11 +551,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payloads with the same data.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
 
@@ -555,25 +569,25 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         but with different attribute name orderings.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         self.attribute_names.reverse()
         b = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-    def test_equal_on_not_equal_uid(self):
+    def test_equal_on_not_equal_unique_identifier(self):
         """
         Test that the equality operator returns False when comparing two
         GetAttributes request payloads with different IDs.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
@@ -590,11 +604,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payloads with different attribute names.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
 
@@ -608,7 +622,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         payload.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = "invalid"
@@ -622,24 +636,24 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         two GetAttributes request payloads with the same internal data.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-    def test_not_equal_on_not_equal_uid(self):
+    def test_not_equal_on_not_equal_unique_identifier(self):
         """
         Test that the inequality operator returns True when comparing two
         GetAttributes request payloads with different IDs.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
@@ -656,11 +670,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payloads with different attribute names.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
 
@@ -674,7 +688,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         payload.
         """
         a = get_attributes.GetAttributesRequestPayload(
-            self.uid,
+            self.unique_identifier,
             self.attribute_names
         )
         b = "invalid"
@@ -715,7 +729,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
             b'\x42\x00\x0B\x07\x00\x00\x00\x0D\x64\x65\x6D\x6F\x6E\x73\x74\x72'
             b'\x61\x74\x69\x6F\x6E\x00\x00\x00'
         )
-        self.encoding_sans_uid = utils.BytearrayStream(
+        self.encoding_sans_unique_identifier = utils.BytearrayStream(
             b'\x42\x00\x7C\x01\x00\x00\x01\x00\x42\x00\x08\x01\x00\x00\x00\x28'
             b'\x42\x00\x0A\x07\x00\x00\x00\x0C\x4F\x62\x6A\x65\x63\x74\x20\x47'
             b'\x72\x6F\x75\x70\x00\x00\x00\x00\x42\x00\x0B\x07\x00\x00\x00\x06'
@@ -741,7 +755,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
             b'\x61\x65\x34\x30\x00\x00\x00\x00'
         )
 
-        self.uid = '1703250b-4d40-4de2-93a0-c494a1d4ae40'
+        self.unique_identifier = '1703250b-4d40-4de2-93a0-c494a1d4ae40'
         self.attributes = [
             objects.Attribute(
                 attribute_name=objects.Attribute.AttributeName(
@@ -785,41 +799,41 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         valid value.
         """
         get_attributes.GetAttributesResponsePayload(
-            'test-uid',
+            'test-unique-identifier',
             [objects.Attribute(), objects.Attribute()]
         )
 
-    def test_uid(self):
+    def test_unique_identifier(self):
         """
-        Test that the uid attribute of a GetAttributes response payload can
-        be properly set and retrieved.
+        Test that the unique_identifier attribute of a GetAttributes response
+        payload can be properly set and retrieved.
         """
         payload = get_attributes.GetAttributesResponsePayload()
 
-        self.assertIsNone(payload.uid)
-        self.assertIsNone(payload._uid)
+        self.assertIsNone(payload.unique_identifier)
+        self.assertIsNone(payload._unique_identifier)
 
-        payload.uid = 'test-uid'
+        payload.unique_identifier = 'test-unique-identifier'
 
-        self.assertEqual('test-uid', payload.uid)
+        self.assertEqual('test-unique-identifier', payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value='test-uid',
+                value='test-unique-identifier',
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
 
-    def test_uid_with_invalid_value(self):
+    def test_unique_identifier_with_invalid_value(self):
         """
         Test that a TypeError is raised when an invalid ID is used to set
-        the uid attribute of a GetAttributes response payload.
+        the unique_identifier attribute of a GetAttributes response payload.
         """
         payload = get_attributes.GetAttributesResponsePayload()
-        args = (payload, 'uid', 0)
+        args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
-            "uid must be a string",
+            "unique identifier must be a string",
             setattr,
             *args
         )
@@ -885,18 +899,18 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         payload = get_attributes.GetAttributesResponsePayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
 
         payload.read(self.full_encoding)
 
-        self.assertEqual(self.uid, payload.uid)
+        self.assertEqual(self.unique_identifier, payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value=self.uid,
+                value=self.unique_identifier,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
         self.assertEqual(
             len(self.attributes),
@@ -908,20 +922,20 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
                 payload._attributes
             )
 
-    def test_read_with_no_uid(self):
+    def test_read_with_no_unique_identifier(self):
         """
         Test that an InvalidKmipEncoding error gets raised when attempting to
         read a GetAttributes response encoding with no ID data.
         """
         payload = get_attributes.GetAttributesResponsePayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
 
-        args = (self.encoding_sans_uid, )
+        args = (self.encoding_sans_unique_identifier, )
         self.assertRaisesRegexp(
             exceptions.InvalidKmipEncoding,
-            "expected GetAttributes response uid not found",
+            "expected GetAttributes response unique identifier not found",
             payload.read,
             *args
         )
@@ -933,18 +947,18 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         payload = get_attributes.GetAttributesResponsePayload()
 
-        self.assertEqual(None, payload._uid)
+        self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
 
         payload.read(self.encoding_sans_attributes)
 
-        self.assertEqual(self.uid, payload.uid)
+        self.assertEqual(self.unique_identifier, payload.unique_identifier)
         self.assertEqual(
             primitives.TextString(
-                value=self.uid,
+                value=self.unique_identifier,
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             ),
-            payload._uid
+            payload._unique_identifier
         )
         self.assertEqual(list(), payload.attributes)
         self.assertEqual(list(), payload._attributes)
@@ -955,7 +969,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         stream.
         """
         payload = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         stream = utils.BytearrayStream()
@@ -964,7 +978,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         self.assertEqual(len(self.full_encoding), len(stream))
         self.assertEqual(str(self.full_encoding), str(stream))
 
-    def test_write_with_no_uid(self):
+    def test_write_with_no_unique_identifier(self):
         """
         Test that a GetAttributes request payload with no ID can be written
         to a data stream.
@@ -978,7 +992,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         args = (stream, )
         self.assertRaisesRegexp(
             exceptions.InvalidField,
-            "The GetAttributes response uid is required.",
+            "The GetAttributes response unique identifier is required.",
             payload.write,
             *args
         )
@@ -989,7 +1003,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         data can be written to a data stream.
         """
         payload = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
         stream = utils.BytearrayStream()
@@ -1003,15 +1017,17 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributes response payload.
         """
         payload = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
-        uid = "uid={0}".format(payload.uid)
+        unique_identifier = "unique_identifier={0}".format(
+            payload.unique_identifier
+        )
         payload_attributes = "attributes={0}".format(
             payload.attributes
         )
         expected = "GetAttributesResponsePayload({0}, {1})".format(
-            uid,
+            unique_identifier,
             payload_attributes
         )
         observed = repr(payload)
@@ -1022,11 +1038,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that str can be applied to a GetAttributes response payload.
         """
         payload = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         expected = str({
-            'uid': self.uid,
+            'unique_identifier': self.unique_identifier,
             'attributes': self.attributes
         })
         observed = str(payload)
@@ -1038,24 +1054,24 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with the same data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-    def test_equal_on_not_equal_uid(self):
+    def test_equal_on_not_equal_unique_identifier(self):
         """
         Test that the equality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
@@ -1072,13 +1088,13 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         reversed_attributes = copy.deepcopy(self.attributes)
         reversed_attributes.reverse()
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             reversed_attributes
         )
 
@@ -1091,11 +1107,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             list()
         )
 
@@ -1108,11 +1124,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
 
@@ -1126,7 +1142,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         payload.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = 'invalid'
@@ -1140,24 +1156,24 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         two GetAttributes response payloads with the same internal data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-    def test_not_equal_on_not_equal_uid(self):
+    def test_not_equal_on_not_equal_unique_identifier(self):
         """
         Test that the inequality operator returns True when comparing two
         GetAttributes request payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
@@ -1174,13 +1190,13 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         reversed_attributes = copy.deepcopy(self.attributes)
         reversed_attributes.reverse()
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             reversed_attributes
         )
 
@@ -1193,11 +1209,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             list()
         )
 
@@ -1210,11 +1226,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payloads with different data.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             None
         )
         b = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
 
@@ -1228,7 +1244,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         payload.
         """
         a = get_attributes.GetAttributesResponsePayload(
-            self.uid,
+            self.unique_identifier,
             self.attributes
         )
         b = "invalid"

--- a/kmip/tests/unit/services/server/test_policy.py
+++ b/kmip/tests/unit/services/server/test_policy.py
@@ -112,3 +112,57 @@ class TestAttributePolicy(testtools.TestCase):
 
         result = rules.is_attribute_multivalued(attribute_b)
         self.assertTrue(result)
+
+    def test_get_all_attribute_names(self):
+        """
+        Test that get_all_attribute_names returns a complete list of the
+        names of all spec-defined attributes.
+        """
+        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        attribute_names = [
+            'Unique Identifier',
+            'Name',
+            'Object Type',
+            'Cryptographic Algorithm',
+            'Cryptographic Length',
+            'Cryptographic Parameters',
+            'Cryptographic Domain Parameters',
+            'Certificate Type',
+            'Certificate Length',
+            'X.509 Certificate Identifier',
+            'X.509 Certificate Subject',
+            'X.509 Certificate Issuer',
+            'Certificate Identifier',
+            'Certificate Subject',
+            'Certificate Issuer',
+            'Digital Signature Algorithm',
+            'Digest',
+            'Operation Policy Name',
+            'Cryptographic Usage Mask',
+            'Lease Time',
+            'Usage Limits',
+            'State',
+            'Initial Date',
+            'Activation Date',
+            'Process Start Date',
+            'Protect Stop Date',
+            'Deactivation Date',
+            'Destroy Date',
+            'Compromise Occurrence Date',
+            'Compromise Date',
+            'Revocation Reason',
+            'Archive Date',
+            'Object Group',
+            'Fresh',
+            'Link',
+            'Application Specific Information',
+            'Contact Information',
+            'Last Change Date',
+            'Custom Attribute'
+        ]
+
+        result = rules.get_all_attribute_names()
+
+        self.assertEqual(len(attribute_names), len(result))
+        for attribute_name in attribute_names:
+            self.assertIn(attribute_name, result)


### PR DESCRIPTION
This change adds server support for the GetAttributes operation. The user can specify an object ID and an attribute list to get the values of the attributes listed from the specified object. The user can also omit either argument; the server will default to using the ID placeholder and all viable attributes respectively. Only a subset of the standard attributes are supported right now. New tests have been added to cover the new feature.