### PR TITLE
Add optional 'name' argument to create and create_key_pair functions

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -154,6 +154,9 @@ class Name(Struct):
 
     @classmethod
     def create(cls, name_value, name_type):
+        '''
+            Returns a Name object, populated with the given value and type
+        '''
         if isinstance(name_value, Name.NameValue):
             value = name_value
         elif isinstance(name_value, str):
@@ -199,6 +202,9 @@ class Name(Struct):
                 return False
         else:
             return NotImplemented
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 # 3.3

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -112,10 +112,17 @@ class AttributeValueFactory(object):
 
     def _create_name(self, name):
         if name is not None:
-            name_value = name.name_value
-            name_type = name.name_type
+            if isinstance(name, attributes.Name):
+                return attributes.Name.create(name.name_value, name.name_type)
 
-            return attributes.Name.create(name_value, name_type)
+            elif isinstance(name, str):
+                return attributes.Name.create(
+                            name,
+                            enums.NameType.UNINTERPRETED_TEXT_STRING
+                        )
+            else:
+                raise ValueError('Unrecognized attribute type: '
+                                 '{0}'.format(name))
         else:
             return attributes.Name()
 

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -70,6 +70,13 @@ class TestNameValue(TestCase):
         self.assertFalse(name_val == other_name_val)
         self.assertFalse(name_val == 'invalid')
 
+    def test__ne(self):
+        name_val = Name.NameValue(self.stringName1)
+        other_name_val = Name.NameValue(self.stringName2)
+
+        self.assertTrue(name_val != other_name_val)
+        self.assertTrue(name_val != 'invalid')
+
     def test__str(self):
         name_val = Name.NameValue(self.stringName1)
         repr_name = "NameValue(value='{0}')".format(self.stringName1)
@@ -109,6 +116,15 @@ class TestNameType(TestCase):
         self.assertTrue(type_uri == same_type)
         self.assertFalse(type_uri == type_txt)
         self.assertFalse(type_uri == 'invalid')
+
+    def test__ne(self):
+        type_uri = Name.NameType(self.enum_uri)
+        same_type = Name.NameType(self.enum_uri)
+        type_txt = Name.NameType(self.enum_txt)
+
+        self.assertFalse(type_uri != same_type)
+        self.assertTrue(type_uri != type_txt)
+        self.assertTrue(type_uri != 'invalid')
 
     def test__str(self):
         type_uri = Name.NameType(self.enum_uri)
@@ -190,6 +206,16 @@ class TestName(TestCase):
         self.assertFalse(name_obj == other_name)
         self.assertFalse(name_obj == other_type)
         self.assertFalse(name_obj == 'invalid')
+
+    def test__ne(self):
+        name_obj = Name.create(self.stringName1, self.enumNameType)
+        same_name = Name.create(self.stringName1, self.enumNameType)
+        other_name = Name.create(self.stringName2, self.enumNameType)
+        other_type = Name.create(self.stringName1, self.enumNameTypeUri)
+
+        self.assertFalse(name_obj != same_name)
+        self.assertNotEqual(name_obj, other_name)
+        self.assertNotEqual(name_obj, other_type)
 
     def test__str(self):
         name_obj = Name.create(self.stringName1, self.enumNameType)
@@ -563,10 +589,3 @@ class TestCryptographicParameters(TestCase):
              'key_role_type': KeyRoleType.BDK})
         self.assertFalse(self.cp == cp_valid)
         self.assertRaises(TypeError, self.cp.validate)
-
-    def test_bad_object(self):
-        name_value = 'puppies'
-        name_type = NameType.UNINTERPRETED_TEXT_STRING
-        bad_obj = Name.create(name_value, name_type)
-
-        self.assertNotEqual(NotImplemented, bad_obj)

--- a/kmip/tests/unit/core/factories/test_attribute.py
+++ b/kmip/tests/unit/core/factories/test_attribute.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2016 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+import testtools
+
+from kmip.core import enums
+
+from kmip.core.factories import attributes
+
+class TestAttributeFactory(testtools.TestCase):
+    """
+    Test suite for Attribute Factory
+    """
+
+    def setUp(self):
+        super(TestAttributeFactory, self).setUp()
+        self.attribute_factory = attributes.AttributeFactory()
+
+    def tearDown(self):
+        super(TestAttributeFactory, self).tearDown()
+
+    def test_name_eq(self):
+        """
+        Test that two identical name attributes match
+        """
+        attr_type = enums.AttributeType.NAME
+        attr_name = "foo"
+        attr_a = self.attribute_factory.create_attribute(attr_type, attr_name)
+        attr_b = self.attribute_factory.create_attribute(attr_type, attr_name)
+        self.assertTrue(attr_a == attr_b)
+        self.assertFalse(attr_a != attr_b)
+

--- a/kmip/tests/unit/core/factories/test_attribute.py
+++ b/kmip/tests/unit/core/factories/test_attribute.py
@@ -13,12 +13,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import mock
 import testtools
 
 from kmip.core import enums
 
 from kmip.core.factories import attributes
+
 
 class TestAttributeFactory(testtools.TestCase):
     """
@@ -42,4 +42,3 @@ class TestAttributeFactory(testtools.TestCase):
         attr_b = self.attribute_factory.create_attribute(attr_type, attr_name)
         self.assertTrue(attr_a == attr_b)
         self.assertFalse(attr_a != attr_b)
-

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -41,7 +41,11 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a Name attribute can be created.
         """
-        self.skip('')
+        attr_type = enums.AttributeType.NAME
+        name = self.factory.create_attribute_value(attr_type, "foo")
+        self.assertIsInstance(name, attributes.Name)
+        self.assertEqual("foo", name.name_value.value)
+        self.assertEqual(enums.Tags.NAME, name.tag)
 
     def test_create_object_type(self):
         """

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -310,18 +310,6 @@ class TestProxyKmipClient(testtools.TestCase):
             client.proxy.create.assert_called_with(
                 enums.ObjectType.SYMMETRIC_KEY, template)
 
-    def test_name_eq(self):
-        """
-        Test that two identical name attributes match
-        """
-
-        attr_type = enums.AttributeType.NAME
-        attr_name = "foo"
-        attr_a = self.attribute_factory.create_attribute(attr_type, attr_name)
-        attr_b = self.attribute_factory.create_attribute(attr_type, attr_name)
-        self.assertTrue(attr_a == attr_b)
-        self.assertFalse(attr_a != attr_b)
-
     @mock.patch('kmip.pie.client.KMIPProxy',
                 mock.MagicMock(spec_set=KMIPProxy))
     def test_create_on_invalid_algorithm(self):


### PR DESCRIPTION
The ProxyKmipClient now allows you to optionally provide a name
when performing a `Create` or a `Create Key Pair`. If not specified,
the name is excluded from the request.

 * For `create`, users specify `name`
 * For `create_key_pair`, users specify `private_name` and `public_name`