### PR TITLE
Updating the attribute value factory to support ObjectType values

### DIFF
--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -28,7 +28,7 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.NAME:
             return self._create_name(value)
         elif name is enums.AttributeType.OBJECT_TYPE:
-            return attributes.ObjectType()
+            return attributes.ObjectType(value)
         elif name is enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM:
             return attributes.CryptographicAlgorithm(value)
         elif name is enums.AttributeType.CRYPTOGRAPHIC_LENGTH:

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -49,9 +49,25 @@ class TestAttributeValueFactory(testtools.TestCase):
 
     def test_create_object_type(self):
         """
-        Test that an ObjectType attribute can be created.
+        Test that an empty ObjectType attribute can be created.
         """
-        self.skip('')
+        object_type = self.factory.create_attribute_value(
+            enums.AttributeType.OBJECT_TYPE,
+            None
+        )
+        self.assertIsInstance(object_type, attributes.ObjectType)
+        self.assertEqual(None, object_type.value)
+
+    def test_create_object_type_with_value(self):
+        """
+        Test that an ObjectType attribute can be created with a custom value.
+        """
+        object_type = self.factory.create_attribute_value(
+            enums.AttributeType.OBJECT_TYPE,
+            enums.ObjectType.SYMMETRIC_KEY
+        )
+        self.assertIsInstance(object_type, attributes.ObjectType)
+        self.assertEqual(enums.ObjectType.SYMMETRIC_KEY, object_type.value)
 
     def test_create_cryptographic_algorithm(self):
         """


### PR DESCRIPTION
This change updates the attribute value factory to allow for the creation of ObjectType attributes with values provided by the caller. Unit tests have been added to cover this change.