### PR TITLE
Removing TextString check to encode characters when writing bytes

### DIFF
--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -810,11 +810,7 @@ class TextString(Base):
     def write_value(self, ostream):
         # Write string to stream
         for char in self.value:
-            if sys.version < '3':
-                c = char
-            else:
-                c = char.encode()
-            ostream.write(pack(self.BYTE_FORMAT, c))
+            ostream.write(pack(self.BYTE_FORMAT, char.encode()))
 
         # Write padding to stream
         for _ in range(self.padding_length):


### PR DESCRIPTION
This change removes extraneous code in the TextString primitive that would conditionally encode the individual string characters depending upon the version of Python being used. This code caused errors when using Unicode strings in Python 2.7 and below.