### PR TITLE
Removing coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,7 @@ install:
   - pip install tox
   - pip install bandit
   - pip install codecov
-  - pip install coveralls
 script:
   - tox
 after_success:
   - codecov
-  - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
-       coveralls
 
 commands =
     coverage run --source=kmip/ --omit=kmip/demos/*,kmip/tests/* -m pytest --strict kmip/tests/unit


### PR DESCRIPTION
This change removes coveralls integration from PyKMIP, specifically the tox and TravisCI configuration files. codecov will be the primary coverage tool used going forward.