### PR TITLE
Fixing a bug with attribute handling in ProxyKmipClient.register

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -297,17 +297,19 @@ class ProxyKmipClient(api.KmipClient):
         object_attributes = list()
 
         if hasattr(managed_object, 'cryptographic_usage_masks'):
-            mask_attribute = self.attribute_factory.create_attribute(
-                enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
-                managed_object.cryptographic_usage_masks
-            )
-            object_attributes.append(mask_attribute)
+            if managed_object.cryptographic_usage_masks is not None:
+                mask_attribute = self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    managed_object.cryptographic_usage_masks
+                )
+                object_attributes.append(mask_attribute)
         if hasattr(managed_object, 'operation_policy_name'):
-            opn_attribute = self.attribute_factory.create_attribute(
-                enums.AttributeType.OPERATION_POLICY_NAME,
-                managed_object.operation_policy_name
-            )
-            object_attributes.append(opn_attribute)
+            if managed_object.operation_policy_name is not None:
+                opn_attribute = self.attribute_factory.create_attribute(
+                    enums.AttributeType.OPERATION_POLICY_NAME,
+                    managed_object.operation_policy_name
+                )
+                object_attributes.append(opn_attribute)
 
         template = cobjects.TemplateAttribute(attributes=object_attributes)
         object_type = managed_object.object_type

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -959,7 +959,9 @@ class TestProxyKmipClient(testtools.TestCase):
             enums.CryptographicAlgorithm.AES,
             128,
             (b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E'
-             b'\x0F'))
+             b'\x0F')
+        )
+        key.operation_policy_name = 'default'
 
         result = results.RegisterResult(
             contents.ResultStatus(enums.ResultStatus.SUCCESS),


### PR DESCRIPTION
This change fixes a bug in the ProxyKmipClient, specifically in the register method. The client would create attributes for the object to register, regardless if those attributes were set on the object. This could cause attribute value overwrites, deleting valid default values with empty values. This change adds checks to ensure these attributes are not created with the request if they are not set on the object. The client unit tests have been updated to reflect this change.