### PR TITLE
Updating the server to handle errors during attribute lookup

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -649,10 +649,13 @@ class KmipEngine(object):
                 attribute_name,
                 object_type
             ):
-                attribute_value = self._get_attribute_from_managed_object(
-                    managed_object,
-                    attribute_name
-                )
+                try:
+                    attribute_value = self._get_attribute_from_managed_object(
+                        managed_object,
+                        attribute_name
+                    )
+                except Exception:
+                    attribute_value = None
 
                 if attribute_value is not None:
                     if self._attribute_policy.is_attribute_multivalued(


### PR DESCRIPTION
This change updates the server to better handle exceptions thrown while looking up the value of different attributes on managed objects. Some managed objects in PyKMIP don't currently support attributes they are supposed to. This can cause lookup errors when using GetAttributes. This change suppresses any exceptions and simply returns None for the missing attribute value. The server unit tests have been updated to account for this change.