### PR TITLE
Fixing a bug with multithreading support with the SQLite backend

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -98,7 +98,8 @@ class KmipEngine(object):
 
         self._data_store = sqlalchemy.create_engine(
             'sqlite:////tmp/pykmip.database',
-            echo=False
+            echo=False,
+            connect_args={'check_same_thread': False}
         )
         sqltypes.Base.metadata.create_all(self._data_store)
         self._data_store_session_factory = sqlalchemy.orm.sessionmaker(

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -140,6 +140,20 @@ class TestKmipEngine(testtools.TestCase):
         """
         engine.KmipEngine()
 
+    @mock.patch('sqlalchemy.create_engine')
+    def test_init_create_engine(self, create_engine_mock):
+        """
+        Test that the right arguments are used to create the engine's SQLite
+        backend.
+        """
+        engine.KmipEngine()
+        args = ("sqlite:////tmp/pykmip.database",)
+        fargs = {
+            'echo': False,
+            'connect_args': {'check_same_thread': False}
+        }
+        create_engine_mock.assert_called_once_with(*args, **fargs)
+
     def test_load_operation_policies(self):
         """
         Test that the KmipEngine can correctly load operation policies.


### PR DESCRIPTION
This change fixes a bug that could occur when accessing the server with multiple threads or processes. The SQLite backend by default does not support multithreading. This change updates how the SQLite backend is instantiated, preventing error generation when using multiple clients simultaenously. The server unit test suite has been updated to cover the change.