### PR TITLE
Unit test fixes

### DIFF
--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -583,7 +583,7 @@ class TestProxyKmipClient(testtools.TestCase):
             result = client.get_attribute_list(uid)
             client.proxy.get_attribute_list.assert_called_with(uid)
             self.assertIsInstance(result, list)
-            self.assertItemsEqual(attribute_names, result)
+            six.assertCountEqual(self, attribute_names, result)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
                 mock.MagicMock(spec_set=KMIPProxy))

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import six
 import mock
 import sqlalchemy
 
@@ -157,7 +158,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = "DiscoverVersions is not supported by KMIP {0}".format(
             e._protocol_version
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.OperationNotSupported,
             regex,
             e._process_discover_versions,
@@ -265,7 +267,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = "KMIP {0} is not supported by the server.".format(
             protocol
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             regex,
             e.process_request,
@@ -291,7 +294,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (request, )
         regex = "Stale request rejected by server."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             regex,
             e.process_request,
@@ -323,7 +327,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (request, )
         regex = "Future request rejected by server."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             regex,
             e.process_request,
@@ -355,7 +360,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (request, )
         regex = "Asynchronous operations are not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             regex,
             e.process_request,
@@ -384,7 +390,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (request, )
         regex = "Undo option for batch handling is not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             regex,
             e.process_request,
@@ -551,7 +558,8 @@ class TestKmipEngine(testtools.TestCase):
         ])
 
         args = (batch, None, None)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidMessage,
             "Batch item ID is undefined.",
             e._process_batch,
@@ -716,7 +724,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = "{0} operation is not supported by the server.".format(
             args[0].name.title()
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.OperationNotSupported,
             regex,
             e._process_operation,
@@ -760,7 +769,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = ('1', )
         regex = "Could not locate object: 1"
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._get_object_type,
@@ -826,7 +836,8 @@ class TestKmipEngine(testtools.TestCase):
             )
         )
 
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._get_object_type,
@@ -971,7 +982,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (None, )
         regex = "Cannot build an unsupported object type."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._build_core_object,
@@ -984,7 +996,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (DummyObject(), )
         regex = "The SplitKey object type is not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._build_core_object,
@@ -1077,7 +1090,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (template_attribute, )
         regex = "Attribute templates are not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_template_attribute,
@@ -1097,7 +1111,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (template_attribute, )
         regex = "The invalid attribute is unsupported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_template_attribute,
@@ -1126,7 +1141,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (template_attribute, )
         regex = "Attribute index missing from multivalued attribute."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_template_attribute,
@@ -1143,7 +1159,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (template_attribute, )
         regex = "Non-zero attribute index found for single-valued attribute."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_template_attribute,
@@ -1170,7 +1187,8 @@ class TestKmipEngine(testtools.TestCase):
             "Cannot set multiple instances of the Cryptographic Algorithm "
             "attribute."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.IndexOutOfBounds,
             regex,
             e._process_template_attribute,
@@ -1262,7 +1280,8 @@ class TestKmipEngine(testtools.TestCase):
             "Cannot set Cryptographic Usage Mask attribute on OpaqueData "
             "object."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._set_attributes_on_managed_object,
@@ -1396,7 +1415,8 @@ class TestKmipEngine(testtools.TestCase):
             ('Name', [name_a.attribute_value, name_b.attribute_value])
         )
         regex = "Cannot set duplicate name values."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._set_attribute_on_managed_object,
@@ -1425,7 +1445,8 @@ class TestKmipEngine(testtools.TestCase):
             ('Digest', [name_a.attribute_value, name_b.attribute_value])
         )
         regex = "The Digest attribute is unsupported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._set_attribute_on_managed_object,
@@ -1443,7 +1464,8 @@ class TestKmipEngine(testtools.TestCase):
             ('Cryptographic Length', length.attribute_value)
         )
         regex = "Cannot overwrite the Cryptographic Length attribute."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._set_attribute_on_managed_object,
@@ -1461,7 +1483,8 @@ class TestKmipEngine(testtools.TestCase):
             ('Object Group', object_group.attribute_value)
         )
         regex = "The Object Group attribute is unsupported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._set_attribute_on_managed_object,
@@ -1816,7 +1839,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Cannot create a PublicKey object with the Create operation."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create,
@@ -1873,7 +1897,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = (
             "The cryptographic algorithm must be specified as an attribute."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create,
@@ -1918,7 +1943,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = (
             "The cryptographic length must be specified as an attribute."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create,
@@ -1960,7 +1986,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = (
             "The cryptographic usage mask must be specified as an attribute."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create,
@@ -2162,7 +2189,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic algorithm must be specified as an attribute "
             "for the public key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2228,7 +2256,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic algorithm must be specified as an attribute "
             "for the private key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2294,7 +2323,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic length must be specified as an attribute for "
             "the public key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2360,7 +2390,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic length must be specified as an attribute for "
             "the private key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2424,7 +2455,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic usage mask must be specified as an attribute "
             "for the public key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2488,7 +2520,8 @@ class TestKmipEngine(testtools.TestCase):
             "The cryptographic usage mask must be specified as an attribute "
             "for the private key."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2570,7 +2603,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = (
             "The public and private key algorithms must be the same."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2639,7 +2673,8 @@ class TestKmipEngine(testtools.TestCase):
         regex = (
             "The public and private key lengths must be the same."
         )
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_create_key_pair,
@@ -2776,7 +2811,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "The SplitKey object type is not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_register,
@@ -2799,7 +2835,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Cannot register a secret in absentia."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.InvalidField,
             regex,
             e._process_register,
@@ -2906,7 +2943,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Key compression is not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.KeyCompressionTypeNotSupported,
             regex,
             e._process_get,
@@ -2926,7 +2964,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Key wrapping is not supported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.PermissionDenied,
             regex,
             e._process_get,
@@ -3005,7 +3044,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Key format conversion from RAW to OPAQUE is unsupported."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.KeyFormatTypeNotSupported,
             regex,
             e._process_get,
@@ -3037,7 +3077,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Key format is not applicable to the specified object."
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.KeyFormatTypeNotSupported,
             regex,
             e._process_get,
@@ -3072,7 +3113,8 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test by specifying the ID of the object to get.
         args = [payload]
-        self.assertRaisesRegex(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             "Could not locate object: {0}".format(id_a),
             e._process_get,
@@ -3116,7 +3158,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(id_a)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,
@@ -3142,7 +3185,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(id_b)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,
@@ -3176,7 +3220,8 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test by specifying the ID of the object to destroy.
         args = [payload]
-        self.assertRaisesRegex(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             "Could not locate object: {0}".format(id_a),
             e._process_destroy,
@@ -3443,7 +3488,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(uid)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,
@@ -3627,7 +3673,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(public_id)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,
@@ -3661,7 +3708,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(private_id)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,
@@ -3802,7 +3850,8 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload, )
         regex = "Could not locate object: {0}".format(uid)
-        self.assertRaisesRegexp(
+        six.assertRaisesRegex(
+            self,
             exceptions.ItemNotFound,
             regex,
             e._process_destroy,


### PR DESCRIPTION
Fix unittests for compatibility between Python 2 and 3.
Fixed a mock for open() in kmip.services.server.server
