### PR TITLE
Fixes how open is mocked in the server test suite

### DIFF
--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -15,7 +15,12 @@
 
 import errno
 import logging
-import mock
+
+try:
+    import unittest.mock as mock
+except:
+    import mock
+
 import signal
 import socket
 import testtools
@@ -75,9 +80,11 @@ class TestKmipServer(testtools.TestCase):
         # Dynamically mock out the built-in open function. Approach changes
         # across Python versions.
         try:
-            import io  # NOQA
-            module = 'kmip.services.server.server'
-        except:
+            # For Python3+
+            import builtins  # NOQA
+            module = 'builtins'
+        except ImportError:
+            # For Python2+
             module = '__builtin__'
 
         with mock.patch('{0}.open'.format(module), open_mock):


### PR DESCRIPTION
This change updates how the built-in open function is mocked in the PyKMIP server test suite. On some platforms the old approach was insufficient. This change explicitly references the builtins module for Python3+, removing the old module-based mock.