### PR TITLE
Fixes a bug with socket interrupt handling under Python3.5

### DIFF
--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -13,7 +13,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import errno
 import logging
 
 try:
@@ -363,8 +362,7 @@ class TestKmipServer(testtools.TestCase):
         s._socket = mock.MagicMock()
         s._setup_connection_handler = mock.MagicMock()
 
-        expected_error = socket.error()
-        expected_error.errno = errno.EINTR
+        expected_error = KeyboardInterrupt
 
         # Test the expected behavior for a normal server/interrupt sequence
         s._socket.accept = mock.MagicMock(
@@ -418,7 +416,13 @@ class TestKmipServer(testtools.TestCase):
         # Test the signal handler for each expected signal
         s._is_serving = True
         handler = signal.getsignal(signal.SIGINT)
-        handler(None, None)
+        args = (signal.SIGINT, None)
+        self.assertRaisesRegex(
+            KeyboardInterrupt,
+            "SIGINT received",
+            handler,
+            *args
+        )
         self.assertFalse(s._is_serving)
 
         s._is_serving = True


### PR DESCRIPTION
This change fixes a bug introduced with the addition of Python3.5 support. In Python3.5, SIGINT is silently ignored for system calls (e.g., socket.accept) if the SIGINT signal handler does not raise an exception. This causes the server to delay shutdown when receiving SIGINT until after a new connection has been made. This change updates the server's SIGINT signal handler to raise the correct exception and updates the error handling code while serving connections to account for this change in SIGINT processing. This allows the server to shutdown immediately upon receiving SIGINT. The server unit tests are updated to account for this change.