### PR TITLE
Adding server support for the GetAttributeList operation

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -591,7 +591,7 @@ class KMIPProxy(KMIP):
         names = None
 
         if payload:
-            uid = payload.uid
+            uid = payload.unique_identifier
             names = payload.attribute_names
 
         return GetAttributeListResult(

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -421,7 +421,7 @@ class TestKMIPClient(TestCase):
         self.assertIsInstance(
             batch_item.request_payload,
             get_attribute_list.GetAttributeListRequestPayload)
-        self.assertEqual(uid, batch_item.request_payload.uid)
+        self.assertEqual(uid, batch_item.request_payload.unique_identifier)
 
     def test_process_batch_items(self):
         batch_item = ResponseBatchItem(
@@ -631,7 +631,7 @@ class TestKMIPClient(TestCase):
         uid = '00000000-1111-2222-3333-444444444444'
         names = ['Cryptographic Algorithm', 'Cryptographic Length']
         payload = get_attribute_list.GetAttributeListResponsePayload(
-            uid=uid, attribute_names=names)
+            unique_identifier=uid, attribute_names=names)
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.GET_ATTRIBUTE_LIST),
             response_payload=payload)


### PR DESCRIPTION
This change adds support for the GetAttributeList operation. The user can specify the ID of a managed object and get back a list containing the names of all attributes currently set on the object. The user can also omit the ID and the server will default to using the ID placeholder for the object ID. New server tests have been added to cover this feature. The GetAttributeList payloads have also been updated for consistency with other payloads, requiring minor updates in other clients and unit tests.