### PR TITLE
Adding support for the InitialDate attribute

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -57,6 +57,7 @@ class ManagedObject(sql.Base):
         String(50),
         default='default'
     )
+    initial_date = Column(Integer, default=0)
     _owner = Column('owner', String(50), default=None)
 
     __mapper_args__ = {
@@ -78,6 +79,7 @@ class ManagedObject(sql.Base):
         self.name_index = 0
         self.names = list()
         self.operation_policy_name = None
+        self.initial_date = 0
         self._object_type = None
         self._owner = None
 
@@ -90,7 +92,6 @@ class ManagedObject(sql.Base):
         # The following attributes are placeholders for attributes that are
         # unsupported by kmip.core
         self._archive_date = None
-        self._initial_date = None
         self._last_change_date = None
 
     @property

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -737,7 +737,7 @@ class KmipEngine(object):
         elif attr_name == 'State':
             return managed_object.state
         elif attr_name == 'Initial Date':
-            return None
+            return managed_object.initial_date
         elif attr_name == 'Activation Date':
             return None
         elif attr_name == 'Process Start Date':
@@ -997,6 +997,7 @@ class KmipEngine(object):
 
         # TODO (peterhamilton) Set additional server-only attributes.
         managed_object._owner = self._client_identity
+        managed_object.initial_date = int(time.time())
 
         self._data_session.add(managed_object)
 
@@ -1164,7 +1165,9 @@ class KmipEngine(object):
 
         # TODO (peterhamilton) Set additional server-only attributes.
         public_key._owner = self._client_identity
+        public_key.initial_date = int(time.time())
         private_key._owner = self._client_identity
+        private_key.initial_date = public_key.initial_date
 
         self._data_session.add(public_key)
         self._data_session.add(private_key)
@@ -1239,6 +1242,7 @@ class KmipEngine(object):
 
         # TODO (peterhamilton) Set additional server-only attributes.
         managed_object._owner = self._client_identity
+        managed_object.initial_date = int(time.time())
 
         self._data_session.add(managed_object)
 

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -1674,7 +1674,8 @@ class TestKmipEngine(testtools.TestCase):
             symmetric_key,
             'Initial Date'
         )
-        self.assertEqual(None, result)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, six.integer_types)
 
         result = e._get_attribute_from_managed_object(
             symmetric_key,
@@ -2395,6 +2396,8 @@ class TestKmipEngine(testtools.TestCase):
             symmetric_key.cryptographic_usage_masks
         )
         self.assertEqual('test', symmetric_key.operation_policy_name)
+        self.assertIsNotNone(symmetric_key.initial_date)
+        self.assertNotEqual(0, symmetric_key.initial_date)
 
         self.assertEqual(uid, e._id_placeholder)
 
@@ -2670,6 +2673,8 @@ class TestKmipEngine(testtools.TestCase):
             public_key.cryptographic_usage_masks
         )
         self.assertEqual('default', public_key.operation_policy_name)
+        self.assertIsNotNone(public_key.initial_date)
+        self.assertNotEqual(0, public_key.initial_date)
 
         # Retrieve the stored private key and verify all attributes were set
         # appropriately.
@@ -2695,6 +2700,8 @@ class TestKmipEngine(testtools.TestCase):
             private_key.cryptographic_usage_masks
         )
         self.assertEqual('default', private_key.operation_policy_name)
+        self.assertIsNotNone(private_key.initial_date)
+        self.assertNotEqual(0, private_key.initial_date)
 
         self.assertEqual(private_id, e._id_placeholder)
 
@@ -3369,6 +3376,8 @@ class TestKmipEngine(testtools.TestCase):
             symmetric_key.cryptographic_usage_masks
         )
         self.assertEqual('test', symmetric_key.operation_policy_name)
+        self.assertIsNotNone(symmetric_key.initial_date)
+        self.assertNotEqual(0, symmetric_key.initial_date)
 
         self.assertEqual(uid, e._id_placeholder)
 
@@ -3789,7 +3798,7 @@ class TestKmipEngine(testtools.TestCase):
             response_payload.unique_identifier
         )
         self.assertEqual(
-            8,
+            9,
             len(response_payload.attributes)
         )
 
@@ -3906,7 +3915,7 @@ class TestKmipEngine(testtools.TestCase):
             response_payload.unique_identifier
         )
         self.assertEqual(
-            8,
+            9,
             len(response_payload.attribute_names)
         )
         self.assertIn(
@@ -3939,6 +3948,10 @@ class TestKmipEngine(testtools.TestCase):
         )
         self.assertIn(
             "Unique Identifier",
+            response_payload.attribute_names
+        )
+        self.assertIn(
+            "Initial Date",
             response_payload.attribute_names
         )
 
@@ -3978,7 +3991,7 @@ class TestKmipEngine(testtools.TestCase):
             response_payload.unique_identifier
         )
         self.assertEqual(
-            8,
+            9,
             len(response_payload.attribute_names)
         )
         self.assertIn(
@@ -4011,6 +4024,10 @@ class TestKmipEngine(testtools.TestCase):
         )
         self.assertIn(
             "Unique Identifier",
+            response_payload.attribute_names
+        )
+        self.assertIn(
+            "Initial Date",
             response_payload.attribute_names
         )
 


### PR DESCRIPTION
This change updates the server and managed object set to support the InitialDate attribute. The InitialDate is set when the Create, CreateKeyPair, and Register operations are invoked and can be listed and retrieved with the GetAttributeList and GetAttributes operations respectively. The server unit tests have been updated to reflect these changes.