### PR TITLE
Remove support for Python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
     include:
-        - python: 2.6
-          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
         - python: 3.3

--- a/README.rst
+++ b/README.rst
@@ -343,9 +343,7 @@ PyKMIP has been tested and runs on the following platform(s):
 
 * Ubuntu: 12.04 LTS, 14.04 LTS, 16.04 LTS
 
-PyKMIP is supported by Python 2.6, 2.7, 3.3 - 3.6.
-
-**NOTE:** Support for Python 2.6 will be deprecated in a future release of PyKMIP.
+PyKMIP is supported by Python 2.7 and 3.3 - 3.6.
 
 References
 ==========

--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -15,8 +15,6 @@
 
 import os
 import re
-import sys
-import warnings
 
 # Dynamically set __version__
 version_path = os.path.join(os.path.dirname(
@@ -27,12 +25,3 @@ with open(version_path, 'r') as version_file:
 
 
 __all__ = ['core', 'demos', 'services']
-
-
-if sys.version_info[:2] == (2, 6):
-    warnings.simplefilter("always")
-    warnings.warn(
-        ("Please use a newer version of Python (2.7.9+ preferred). PyKMIP "
-         "support for Python 2.6 will be deprecated in the future."),
-        PendingDeprecationWarning)
-    warnings.simplefilter("default")

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setuptools.setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py26,py27,py33,py34,py35,py36,bandit
+envlist = pep8,py27,py33,py34,py35,py36,bandit
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This change removes PyKMIP support for Python2.6. The last release of Python2.6 occurred in October 2013, over 3 years ago. It also does not support security features needed to use PyKMIP according to best practices. This change drops tox and TravisCI settings for Python2.6 and updates setup to no longer categorize the library as Python2.6 compliant. The README has been updated accordingly.

Closes #116