### PR TITLE
Adding support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
         - python: 2.7
           env: TOXENV=pep8
         - python: 2.7

--- a/README.rst
+++ b/README.rst
@@ -343,7 +343,7 @@ PyKMIP has been tested and runs on the following platform(s):
 
 * Ubuntu: 12.04 LTS, 14.04 LTS, 16.04 LTS
 
-PyKMIP is supported by Python 2.6, 2.7, 3.3 - 3.5.
+PyKMIP is supported by Python 2.6, 2.7, 3.3 - 3.6.
 
 **NOTE:** Support for Python 2.6 will be deprecated in a future release of PyKMIP.
 

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py26,py27,py33,py34,py35,bandit
+envlist = pep8,py26,py27,py33,py34,py35,py36,bandit
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This change adds PyKMIP support for Python 3.6, including updates for the tox and TravisCI configurations in addition to setup.

Closes #243