### PR TITLE
Fixing the KMIPProxy CreateKeyPair demo script

### DIFF
--- a/kmip/demos/units/create_key_pair.py
+++ b/kmip/demos/units/create_key_pair.py
@@ -98,10 +98,10 @@ if __name__ == '__main__':
     value = Name(name_value=name_value, name_type=name_type)
     name = Attribute(attribute_name=name, attribute_value=value)
 
-    name = Attribute.AttributeName('Cryptographic Usage Mask')
+    usage_mask = Attribute.AttributeName('Cryptographic Usage Mask')
     value = CryptographicUsageMask(
         UsageMaskEnum.ENCRYPT.value | UsageMaskEnum.DECRYPT.value)
-    usage_mask = Attribute(attribute_name=name, attribute_value=value)
+    usage_mask = Attribute(attribute_name=usage_mask, attribute_value=value)
 
     attribute_type = AttributeType.CRYPTOGRAPHIC_LENGTH
     length_obj = attribute_factory.create_attribute(attribute_type,


### PR DESCRIPTION
This change fixes a bug with the CreateKeyPair demo script for the KMIPProxy client. The key pair name was never included with the create request due to variable name overuse. This change fixes the variable names thereby fixing the demo script.

Fixes #249