### PR TITLE
Adding MAC operation(client/server) and related unit tests

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -263,6 +263,7 @@ class CryptographicParameters(Struct):
                 enums.BlockCipherMode, value, Tags.BLOCK_CIPHER_MODE)
 
     class PaddingMethod(Enumeration):
+
         def __init__(self, value=None):
             super(CryptographicParameters.PaddingMethod, self).__init__(
                 enums.PaddingMethod, value, Tags.PADDING_METHOD)
@@ -273,17 +274,28 @@ class CryptographicParameters(Struct):
             super(CryptographicParameters.KeyRoleType, self).__init__(
                 enums.KeyRoleType, value, Tags.KEY_ROLE_TYPE)
 
+    class DigitalSignatureAlgorithm(Enumeration):
+
+        def __init__(self, value=None):
+            super(CryptographicParameters.DigitalSignatureAlgorithm,
+                  self).__init__(enums.DigitalSignatureAlgorithm,
+                                 value, Tags.DIGITAL_SIGNATURE_ALGORITHM)
+
     def __init__(self,
                  block_cipher_mode=None,
                  padding_method=None,
                  hashing_algorithm=None,
-                 key_role_type=None):
+                 key_role_type=None,
+                 digital_signature_algorithm=None,
+                 cryptographic_algorithm=None):
         super(CryptographicParameters, self).__init__(
             tag=Tags.CRYPTOGRAPHIC_PARAMETERS)
         self.block_cipher_mode = block_cipher_mode
         self.padding_method = padding_method
         self.hashing_algorithm = hashing_algorithm
         self.key_role_type = key_role_type
+        self.digital_signature_algorithm = digital_signature_algorithm
+        self.cryptographic_algorithm = cryptographic_algorithm
 
     def read(self, istream):
         super(CryptographicParameters, self).read(istream)
@@ -305,6 +317,15 @@ class CryptographicParameters(Struct):
             self.key_role_type = CryptographicParameters.KeyRoleType()
             self.key_role_type.read(tstream)
 
+        if self.is_tag_next(Tags.DIGITAL_SIGNATURE_ALGORITHM, tstream):
+            self.digital_signature_algorithm = \
+                CryptographicParameters.DigitalSignatureAlgorithm()
+            self.digital_signature_algorithm.read(tstream)
+
+        if self.is_tag_next(Tags.CRYPTOGRAPHIC_ALGORITHM, tstream):
+            self.cryptographic_algorithm = CryptographicAlgorithm()
+            self.cryptographic_algorithm.read(tstream)
+
         self.is_oversized(tstream)
         self.validate()
 
@@ -320,6 +341,10 @@ class CryptographicParameters(Struct):
             self.hashing_algorithm.write(tstream)
         if self.key_role_type is not None:
             self.key_role_type.write(tstream)
+        if self.digital_signature_algorithm is not None:
+            self.digital_signature_algorithm.write(tstream)
+        if self.cryptographic_algorithm is not None:
+            self.cryptographic_algorithm.write(tstream)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
@@ -354,6 +379,21 @@ class CryptographicParameters(Struct):
                 msg += "; expected {0}, received {1}".format(
                     self.KeyRoleType, self.key_role_type)
                 raise TypeError(msg)
+        if self.digital_signature_algorithm is not None:
+            if not isinstance(self.digital_signature_algorithm,
+                              self.DigitalSignatureAlgorithm):
+                msg = "Invalid digital signature algorithm"
+                msg += "; expected {0}, received {1}".format(
+                    self.DigitalSignatureAlgorithm,
+                    self.digital_signature_algorithm)
+                raise TypeError(msg)
+        if self.cryptographic_algorithm is not None:
+            if not isinstance(self.cryptographic_algorithm,
+                              CryptographicAlgorithm):
+                msg = "Invalid cryptograhic algorithm"
+                msg += "; expected {0}, received {1}".format(
+                    CryptographicAlgorithm, self.cryptographic_algorithm)
+                raise TypeError(msg)
 
     def __eq__(self, other):
         if isinstance(other, CryptographicParameters):
@@ -362,6 +402,11 @@ class CryptographicParameters(Struct):
             elif self.key_role_type != other.key_role_type:
                 return False
             elif self.hashing_algorithm != other.hashing_algorithm:
+                return False
+            elif self.digital_signature_algorithm \
+                    != other.digital_signature_algorithm:
+                return False
+            elif self.cryptographic_algorithm != other.cryptographic_algorithm:
                 return False
             elif self.padding_method != other.padding_method:
                 return False

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -140,6 +140,8 @@ class AttributeValueFactory(object):
         padding_method = None
         hashing_algorithm = None
         key_role_type = None
+        digital_signature_algorithm = None
+        cryptographic_algorithm = None
 
         if params is not None:
 
@@ -162,11 +164,23 @@ class AttributeValueFactory(object):
                 hashing_algorithm = attributes.HashingAlgorithm(
                     params.get("hashing_algorithm"))
 
+            if 'digital_signature_algorithm' in params:
+                digital_signature_algorithm = \
+                    attributes.CryptographicParameters. \
+                    DigitalSignatureAlgorithm(
+                        params.get("digital_signature_algorithm"))
+
+            if 'cryptographic_algorithm' in params:
+                cryptographic_algorithm = attributes.CryptographicAlgorithm(
+                    params.get("cryptographic_algorithm"))
+
         return attributes.CryptographicParameters(
             block_cipher_mode=bcm,
             padding_method=padding_method,
             hashing_algorithm=hashing_algorithm,
-            key_role_type=key_role_type)
+            key_role_type=key_role_type,
+            digital_signature_algorithm=digital_signature_algorithm,
+            cryptographic_algorithm=cryptographic_algorithm)
 
     def _create_cryptographic_usage_mask(self, flags):
         mask = None

--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -28,6 +28,7 @@ from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
 from kmip.core.messages.payloads import register
 from kmip.core.messages.payloads import revoke
+from kmip.core.messages.payloads import mac
 
 
 class RequestPayloadFactory(PayloadFactory):
@@ -70,3 +71,6 @@ class RequestPayloadFactory(PayloadFactory):
 
     def _create_revoke_payload(self):
         return revoke.RevokeRequestPayload()
+
+    def _create_mac_payload(self):
+        return mac.MACRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -28,6 +28,7 @@ from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
 from kmip.core.messages.payloads import register
 from kmip.core.messages.payloads import revoke
+from kmip.core.messages.payloads import mac
 
 
 class ResponsePayloadFactory(PayloadFactory):
@@ -70,3 +71,6 @@ class ResponsePayloadFactory(PayloadFactory):
 
     def _create_revoke_payload(self):
         return revoke.RevokeResponsePayload()
+
+    def _create_mac_payload(self):
+        return mac.MACResponsePayload()

--- a/kmip/core/messages/payloads/mac.py
+++ b/kmip/core/messages/payloads/mac.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2017 Pure Storage, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from kmip.core import attributes
+from kmip.core import enums
+from kmip.core.enums import Tags
+
+from kmip.core.objects import Data, MACData
+
+from kmip.core.primitives import Struct
+
+from kmip.core.utils import BytearrayStream
+
+
+# 4.33
+class MACRequestPayload(Struct):
+
+    def __init__(self,
+                 unique_identifier=None,
+                 cryptographic_parameters=None,
+                 data=None):
+        super(MACRequestPayload, self).__init__(
+            tag=enums.Tags.REQUEST_PAYLOAD)
+        self.unique_identifier = unique_identifier
+        self.cryptographic_parameters = cryptographic_parameters
+        self.data = data
+        self.validate()
+
+    def read(self, istream):
+        super(MACRequestPayload, self).read(istream)
+        tstream = BytearrayStream(istream.read(self.length))
+
+        if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
+            self.unique_identifier = attributes.UniqueIdentifier()
+            self.unique_identifier.read(tstream)
+
+        if self.is_tag_next(Tags.CRYPTOGRAPHIC_PARAMETERS, tstream):
+            self.cryptographic_parameters = \
+                attributes.CryptographicParameters()
+            self.cryptographic_parameters.read(tstream)
+
+        if self.is_tag_next(Tags.DATA, tstream):
+            self.data = Data()
+            self.data.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        tstream = BytearrayStream()
+
+        # Write the object type and template attribute of the request payload
+        self.unique_identifier.write(tstream)
+        self.cryptographic_parameters.write(tstream)
+        self.data.write(tstream)
+
+        # Write the length and value of the request payload
+        self.length = tstream.length()
+        super(MACRequestPayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        # TODO.
+        pass
+
+
+class MACResponsePayload(Struct):
+
+    def __init__(self,
+                 unique_identifier=None,
+                 mac_data=None):
+        super(MACResponsePayload, self).__init__(
+            tag=enums.Tags.RESPONSE_PAYLOAD)
+        self.unique_identifier = unique_identifier
+        self.mac_data = mac_data
+        self.validate()
+
+    def read(self, istream):
+        super(MACResponsePayload, self).read(istream)
+        tstream = BytearrayStream(istream.read(self.length))
+
+        self.unique_identifier = attributes.UniqueIdentifier()
+        self.mac_data = MACData()
+        self.unique_identifier.read(tstream)
+        self.mac_data.read(tstream)
+
+        self.is_oversized(tstream)
+        self.validate()
+
+    def write(self, ostream):
+        tstream = BytearrayStream()
+
+        self.unique_identifier.write(tstream)
+        self.mac_data.write(tstream)
+
+        self.length = tstream.length()
+        super(MACResponsePayload, self).write(ostream)
+        ostream.write(tstream.buffer)
+
+    def validate(self):
+        # TODO.
+        pass

--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import binascii
 from six.moves import xrange
 
 from kmip.core import attributes
@@ -996,6 +997,26 @@ class ExtensionName(TextString):
                 Optional, defaults to the empty string.
         """
         super(ExtensionName, self).__init__(value, Tags.EXTENSION_NAME)
+
+
+# 2.1.10
+class Data(ByteString):
+
+    def __init__(self, value=None):
+        super(Data, self).__init__(value, Tags.DATA)
+
+    def __str__(self):
+        return str(binascii.hexlify(self.value))
+
+
+# 2.1.13
+class MACData(ByteString):
+
+    def __init__(self, value=None):
+        super(MACData, self).__init__(value, Tags.MAC_DATA)
+
+    def __str__(self):
+        return str(binascii.hexlify(self.value))
 
 
 class ExtensionTag(Integer):

--- a/kmip/demos/pie/mac.py
+++ b/kmip/demos/pie/mac.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2017 Pure Storage, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+
+import binascii
+
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    # Build and parse arguments
+    parser = utils.build_cli_parser(enums.Operation.MAC)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    uid = opts.uuid
+    algorithm = opts.algorithm
+
+    data = (
+        b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E'
+        b'\x0F')
+
+    # Exit early if the arguments are not specified
+    if uid is None:
+        logger.error('No UUID provided, exiting early from demo')
+        sys.exit()
+    if algorithm is None:
+        logger.error('No algorithm provided, exiting early from demo')
+        sys.exit()
+
+    algorithm = getattr(enums.CryptographicAlgorithm, algorithm, None)
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(config=config) as client:
+        try:
+            uid, mac_data = client.mac(uid, algorithm, data)
+            logger.info("Successfully done MAC using key with ID: "
+                        "{0}".format(uid))
+            logger.info("MACed data: {0}".format(
+                str(binascii.hexlify(mac_data))))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -214,15 +214,32 @@ def build_cli_parser(operation=None):
                   "SECRET_DATA"))
     elif operation is Operation.DISCOVER_VERSIONS:
         parser.add_option(
-                "-v",
-                "--protocol-versions",
-                action="store",
-                type="str",
-                default=None,
-                dest="protocol_versions",
-                help=("Protocol versions supported by client. "
-                      "ex. '1.1,1.2 1.3'"))
-
+            "-v",
+            "--protocol-versions",
+            action="store",
+            type="str",
+            default=None,
+            dest="protocol_versions",
+            help=("Protocol versions supported by client. "
+                  "ex. '1.1,1.2 1.3'"))
+    elif operation is Operation.MAC:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="The unique ID of the managed object that is the key"
+                 "to use for the MAC operation")
+        parser.add_option(
+            "-a",
+            "--algorithm",
+            action="store",
+            type="str",
+            default=None,
+            dest="algorithm",
+            help="Encryption algorithm for the secret (e.g., AES)")
     return parser
 
 

--- a/kmip/pie/api.py
+++ b/kmip/pie/api.py
@@ -90,3 +90,17 @@ class KmipClient:
             uid (string): The unique ID of the managed object to destroy.
         """
         pass
+
+    @abc.abstractmethod
+    def mac(self, uid, algorithm, data):
+        """
+        Get the message authentication code for data.
+
+        Args:
+            uid (string): The unique ID of the managed object that is the key
+                to use for the MAC operation.
+            algorithm (CryptographicAlgorithm): An enumeration defining the
+                algorithm to use to generate the MAC.
+            data (string): The data to be MACed.
+        """
+        pass

--- a/kmip/services/results.py
+++ b/kmip/services/results.py
@@ -295,3 +295,20 @@ class RevokeResult(OperationResult):
         super(RevokeResult, self).__init__(
             result_status, result_reason, result_message)
         self.unique_identifier = unique_identifier
+
+
+class MACResult(OperationResult):
+
+    def __init__(self,
+                 result_status,
+                 result_reason=None,
+                 result_message=None,
+                 uuid=None,
+                 mac_data=None):
+        super(MACResult, self).__init__(
+            result_status,
+            result_reason,
+            result_message
+        )
+        self.uuid = uuid
+        self.mac_data = mac_data

--- a/kmip/services/server/crypto/api.py
+++ b/kmip/services/server/crypto/api.py
@@ -66,3 +66,18 @@ class CryptographicEngine(object):
             dict: A dictionary containing the private key data, identical in
                 structure to the public key dictionary.
         """
+
+    @abstractmethod
+    def mac(self, algorithm, key, data):
+        """
+        Generate message authentication code.
+
+        Args:
+            algorithm(CryptographicAlgorithm): An enumeration specifying the
+                algorithm for which the MAC operation will use.
+            key(bytes): secret key used in the MAC operation
+            data(bytes): The data to be MACed.
+
+        Returns:
+            bytes: The MAC data
+        """

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -30,6 +30,8 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import exceptions
 
+from kmip.core.objects import MACData
+
 from kmip.core.factories import attributes as attribute_factory
 from kmip.core.factories import secrets
 
@@ -46,6 +48,7 @@ from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import get_attribute_list
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import register
+from kmip.core.messages.payloads import mac
 
 from kmip.core import misc
 
@@ -949,6 +952,8 @@ class KmipEngine(object):
             return self._process_query(payload)
         elif operation == enums.Operation.DISCOVER_VERSIONS:
             return self._process_discover_versions(payload)
+        elif operation == enums.Operation.MAC:
+            return self._process_mac(payload)
         else:
             raise exceptions.OperationNotSupported(
                 "{0} operation is not supported by the server.".format(
@@ -1553,6 +1558,64 @@ class KmipEngine(object):
 
         response_payload = discover_versions.DiscoverVersionsResponsePayload(
             protocol_versions=supported_versions
+        )
+
+        return response_payload
+
+    @_kmip_version_supported('1.2')
+    def _process_mac(self, payload):
+        self._logger.info("Processing operation: MAC")
+
+        unique_identifier = self._id_placeholder
+        if payload.unique_identifier:
+            unique_identifier = payload.unique_identifier.value
+
+        object_type = self._get_object_type(unique_identifier)
+
+        managed_object = self._data_session.query(object_type).filter(
+            object_type.unique_identifier == unique_identifier
+        ).one()
+
+        algorithm = None
+        if (payload.cryptographic_parameters and
+                payload.cryptographic_parameters.cryptographic_algorithm):
+            algorithm = \
+                payload.cryptographic_parameters.cryptographic_algorithm.value
+        elif (isinstance(managed_object, objects.Key) and
+              managed_object.cryptographic_algorithm):
+            algorithm = managed_object.cryptographic_algorithm
+        else:
+            raise exceptions.InvalidField(
+                "The cryptographic algorithm must be specified "
+                "for the MAC operation"
+            )
+
+        key = None
+        if managed_object.value:
+            key = managed_object.value
+        else:
+            raise exceptions.InvalidField(
+                "A secret key value must be specified "
+                "for the MAC operation"
+            )
+
+        data = None
+        if payload.data:
+            data = payload.data.value
+        else:
+            raise exceptions.InvalidField(
+                "No data to be MACed"
+            )
+
+        result = self._cryptography_engine.mac(
+            algorithm,
+            key,
+            data
+        )
+
+        response_payload = mac.MACResponsePayload(
+            unique_identifier=attributes.UniqueIdentifier(unique_identifier),
+            mac_data=MACData(result)
         )
 
         return response_payload

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -32,6 +32,8 @@ from kmip.core.enums import BlockCipherMode
 from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import HashingAlgorithm as HashingAlgorithmEnum
 from kmip.core.enums import KeyRoleType
+from kmip.core.enums import DigitalSignatureAlgorithm
+from kmip.core.enums import CryptographicAlgorithm
 from kmip.core.enums import PaddingMethod
 from kmip.core.enums import NameType
 
@@ -483,6 +485,7 @@ class TestApplicationData(TestCase):
 
 
 class TestCryptographicParameters(TestCase):
+
     """
     A test suite for the CryptographicParameters class
     """
@@ -498,25 +501,33 @@ class TestCryptographicParameters(TestCase):
             {'block_cipher_mode': BlockCipherMode.CBC,
              'padding_method': PaddingMethod.PKCS5,
              'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK})
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
 
         self.cp_none = self.factory.create_attribute_value(
             AttributeType.CRYPTOGRAPHIC_PARAMETERS, {})
 
         # Symmetric key object with Cryptographic Parameters
-        # Byte stream edited to add Key Role Type parameter
+        # Byte stream edited to add:
+        #      Key Role Type parameter
+        #      Digital Signature Algorithm parameter
+        #      Cryptographic Algorithm parameter
         # Based on the KMIP Spec 1.1 Test Cases document
         # 11.1 page 255 on the pdf version
         self.key_req_with_crypt_params = BytearrayStream((
-            b'\x42\x00\x2B\x01\x00\x00\x00\x40'
+            b'\x42\x00\x2B\x01\x00\x00\x00\x60'
             b'\x42\x00\x11\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
             b'\x42\x00\x5F\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
             b'\x42\x00\x38\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
             b'\x42\x00\x83\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\xAE\x05\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00'
+            b'\x42\x00\x28\x05\x00\x00\x00\x04\x00\x00\x00\x0B\x00\x00\x00\x00'
         ))
 
     def teardown(self):
-        super(TestDigestValue, self).tearDown()
+        super(TestCryptographicParameters, self).tearDown()
 
     def test_write_crypto_params(self):
         ostream = BytearrayStream()
@@ -546,6 +557,17 @@ class TestCryptographicParameters(TestCase):
         self.assertEqual(HashingAlgorithmEnum.SHA_1.value,
                          self.cp.hashing_algorithm.value.value)
 
+        self.assertEqual(Tags.DIGITAL_SIGNATURE_ALGORITHM.value,
+                         self.cp.digital_signature_algorithm.tag.value)
+        self.assertEqual(DigitalSignatureAlgorithm.
+                         SHA256_WITH_RSA_ENCRYPTION.value,
+                         self.cp.digital_signature_algorithm.value.value)
+
+        self.assertEqual(Tags.CRYPTOGRAPHIC_ALGORITHM.value,
+                         self.cp.cryptographic_algorithm.tag.value)
+        self.assertEqual(CryptographicAlgorithm.HMAC_SHA512.value,
+                         self.cp.cryptographic_algorithm.value.value)
+
     def test_bad_cipher_mode(self):
         self.cp.block_cipher_mode = self.bad_enum_code
         cp_valid = self.factory.create_attribute_value(
@@ -553,7 +575,10 @@ class TestCryptographicParameters(TestCase):
             {'block_cipher_mode': BlockCipherMode.CBC,
              'padding_method': PaddingMethod.PKCS5,
              'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK})
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
         self.assertFalse(self.cp == cp_valid)
         self.assertRaises(TypeError, self.cp.validate)
 
@@ -564,7 +589,10 @@ class TestCryptographicParameters(TestCase):
             {'block_cipher_mode': BlockCipherMode.CBC,
              'padding_method': PaddingMethod.PKCS5,
              'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK})
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
         self.assertFalse(self.cp == cp_valid)
         self.assertRaises(TypeError, self.cp.validate)
 
@@ -575,7 +603,10 @@ class TestCryptographicParameters(TestCase):
             {'block_cipher_mode': BlockCipherMode.CBC,
              'padding_method': PaddingMethod.PKCS5,
              'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK})
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
         self.assertFalse(self.cp == cp_valid)
         self.assertRaises(TypeError, self.cp.validate)
 
@@ -586,6 +617,37 @@ class TestCryptographicParameters(TestCase):
             {'block_cipher_mode': BlockCipherMode.CBC,
              'padding_method': PaddingMethod.PKCS5,
              'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK})
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
+        self.assertFalse(self.cp == cp_valid)
+        self.assertRaises(TypeError, self.cp.validate)
+
+    def test_bad_digital_signature_algorithm(self):
+        self.cp.digital_signature_algorithm = self.bad_enum_code
+        cp_valid = self.factory.create_attribute_value(
+            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
+            {'block_cipher_mode': BlockCipherMode.CBC,
+             'padding_method': PaddingMethod.PKCS5,
+             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
+        self.assertFalse(self.cp == cp_valid)
+        self.assertRaises(TypeError, self.cp.validate)
+
+    def test_bad_cryptographic_algorithm(self):
+        self.cp.cryptographic_algorithm = self.bad_enum_code
+        cp_valid = self.factory.create_attribute_value(
+            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
+            {'block_cipher_mode': BlockCipherMode.CBC,
+             'padding_method': PaddingMethod.PKCS5,
+             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
+             'key_role_type': KeyRoleType.BDK,
+             'digital_signature_algorithm':
+                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
         self.assertFalse(self.cp == cp_valid)
         self.assertRaises(TypeError, self.cp.validate)

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -31,6 +31,7 @@ from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
 from kmip.core.messages.payloads import register
 from kmip.core.messages.payloads import revoke
+from kmip.core.messages.payloads import mac
 
 
 class TestRequestPayloadFactory(testtools.TestCase):
@@ -228,7 +229,8 @@ class TestRequestPayloadFactory(testtools.TestCase):
         )
 
     def test_create_mac_payload(self):
-        self._test_not_implemented(self.factory.create, enums.Operation.MAC)
+        payload = self.factory.create(enums.Operation.MAC)
+        self._test_payload_type(payload, mac.MACRequestPayload)
 
     def test_create_mac_verify_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -31,6 +31,7 @@ from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import rekey_key_pair
 from kmip.core.messages.payloads import register
 from kmip.core.messages.payloads import revoke
+from kmip.core.messages.payloads import mac
 
 
 class TestResponsePayloadFactory(testtools.TestCase):
@@ -226,7 +227,11 @@ class TestResponsePayloadFactory(testtools.TestCase):
         )
 
     def test_create_mac_payload(self):
-        self._test_not_implemented(self.factory.create, enums.Operation.MAC)
+        payload = self.factory.create(enums.Operation.MAC)
+        self._test_payload_type(
+            payload,
+            mac.MACResponsePayload
+        )
 
     def test_create_mac_verify_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -89,7 +89,11 @@ class TestAttributeValueFactory(testtools.TestCase):
             'block_cipher_mode': enums.BlockCipherMode.NIST_KEY_WRAP,
             'padding_method': enums.PaddingMethod.ANSI_X9_23,
             'key_role_type': enums.KeyRoleType.KEK,
-            'hashing_algorithm': enums.HashingAlgorithm.SHA_512}
+            'hashing_algorithm': enums.HashingAlgorithm.SHA_512,
+            'digital_signature_algorithm':
+                enums.DigitalSignatureAlgorithm.ECDSA_WITH_SHA512,
+            'cryptographic_algorithm':
+                enums.CryptographicAlgorithm.HMAC_SHA512}
         params = self.factory.create_attribute_value(
             enums.AttributeType.CRYPTOGRAPHIC_PARAMETERS, value)
 
@@ -110,6 +114,14 @@ class TestAttributeValueFactory(testtools.TestCase):
         self.assertEqual(
             attributes.HashingAlgorithm(enums.HashingAlgorithm.SHA_512),
             params.hashing_algorithm)
+        self.assertEqual(
+            attributes.CryptographicParameters.DigitalSignatureAlgorithm(
+                enums.DigitalSignatureAlgorithm.ECDSA_WITH_SHA512),
+            params.digital_signature_algorithm)
+        self.assertEqual(
+            attributes.CryptographicAlgorithm(
+                enums.CryptographicAlgorithm.HMAC_SHA512),
+            params.cryptographic_algorithm)
 
     def test_create_cryptographic_domain_parameters(self):
         """

--- a/kmip/tests/unit/pie/test_api.py
+++ b/kmip/tests/unit/pie/test_api.py
@@ -44,6 +44,9 @@ class DummyKmipClient(api.KmipClient):
     def destroy(self, uid):
         super(DummyKmipClient, self).destroy(uid)
 
+    def mac(self, uid, algorithm, data):
+        super(DummyKmipClient, self).mac(uid, algorithm, data)
+
 
 class TestKmipClient(testtools.TestCase):
     """
@@ -106,3 +109,10 @@ class TestKmipClient(testtools.TestCase):
         """
         dummy = DummyKmipClient()
         dummy.destroy('uid')
+
+    def test_mac(self):
+        """
+        Test that the mac method can be called without error.
+        """
+        dummy = DummyKmipClient()
+        dummy.mac('uid', 'algorithm', 'data')

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -1056,3 +1056,25 @@ class TestProxyKmipClient(testtools.TestCase):
         self.assertIsInstance(opn.attribute_value, attr.OperationPolicyName)
         self.assertEqual(opn.attribute_name.value, 'Operation Policy Name')
         self.assertEqual(opn.attribute_value.value, 'test')
+
+    @mock.patch('kmip.pie.client.KMIPProxy',
+                mock.MagicMock(spec_set=KMIPProxy))
+    def test_mac(self):
+        """
+        Test the MAC client with proper input.
+        """
+        uuid = 'aaaaaaaa-1111-2222-3333-ffffffffffff'
+        algorithm = enums.CryptographicAlgorithm.HMAC_SHA256
+        data = (b'\x00\x01\x02\x03\x04')
+
+        result = results.MACResult(
+            contents.ResultStatus(enums.ResultStatus.SUCCESS),
+            uuid=attr.UniqueIdentifier(uuid),
+            mac_data=obj.MACData(data))
+
+        with ProxyKmipClient() as client:
+            client.proxy.mac.return_value = result
+
+            uid, mac_data = client.mac(uuid, algorithm, data)
+            self.assertEqual(uid, uuid)
+            self.assertEqual(mac_data, data)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -48,6 +48,7 @@ from kmip.core.messages.payloads import get_attribute_list
 from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import query
 from kmip.core.messages.payloads import register
+from kmip.core.messages.payloads import mac
 
 from kmip.pie import objects as pie_objects
 from kmip.pie import sqltypes
@@ -4536,6 +4537,149 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: DiscoverVersions"
         )
         self.assertEqual([], result.protocol_versions)
+
+    def test_mac(self):
+        """
+        Test that a MAC request can be processed correctly.
+        """
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._logger = mock.MagicMock()
+        e._cryptography_engine.logger = mock.MagicMock()
+
+        key = (b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+               b'\x00\x00\x00\x00\x00')
+        data = (b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A'
+                b'\x0B\x0C\x0D\x0E\x0F')
+        algorithm_a = enums.CryptographicAlgorithm.AES
+        algorithm_b = enums.CryptographicAlgorithm.HMAC_SHA512
+        obj = pie_objects.SymmetricKey(algorithm_a, 128, key)
+
+        e._data_session.add(obj)
+        e._data_session.commit()
+        e._data_session = e._data_store_session_factory()
+
+        uuid = str(obj.unique_identifier)
+
+        cryptographic_parameters = attributes.CryptographicParameters(
+            cryptographic_algorithm=attributes.
+            CryptographicAlgorithm(algorithm_b)
+        )
+
+        # Verify when cryptographic_parameters is specified in request
+        payload = mac.MACRequestPayload(
+            unique_identifier=attributes.UniqueIdentifier(uuid),
+            cryptographic_parameters=cryptographic_parameters,
+            data=objects.Data(data)
+        )
+
+        response_payload = e._process_mac(payload)
+
+        e._logger.info.assert_any_call(
+            "Processing operation: MAC"
+        )
+        e._cryptography_engine.logger.info.assert_any_call(
+            "Generating hash-based Message authentication codes using {0}".
+            format(algorithm_b.name)
+        )
+        e._cryptography_engine.logger.reset_mock()
+        self.assertEqual(str(uuid), response_payload.unique_identifier.value)
+        self.assertIsInstance(response_payload.mac_data, objects.MACData)
+
+        # Verify when cryptographic_parameters is not specified in request
+        payload = mac.MACRequestPayload(
+            unique_identifier=attributes.UniqueIdentifier(uuid),
+            cryptographic_parameters=None,
+            data=objects.Data(data)
+        )
+
+        response_payload = e._process_mac(payload)
+
+        e._cryptography_engine.logger.info.assert_any_call(
+            "Generating cipher-based Message authentication codes using {0}".
+            format(algorithm_a.name)
+        )
+        self.assertEqual(str(uuid), response_payload.unique_identifier.value)
+        self.assertIsInstance(response_payload.mac_data, objects.MACData)
+
+    def test_mac_with_missing_fields(self):
+        """
+        Test that the right errors are generated when required fields
+        are missing.
+        """
+        e = engine.KmipEngine()
+        e._data_store = self.engine
+        e._data_store_session_factory = self.session_factory
+        e._data_session = e._data_store_session_factory()
+        e._logger = mock.MagicMock()
+
+        key = (b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+               b'\x00\x00\x00\x00')
+        data = (b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B'
+                b'\x0C\x0D\x0E\x0F')
+        algorithm = enums.CryptographicAlgorithm.AES
+        obj_no_key = pie_objects.OpaqueObject(b'', enums.OpaqueDataType.NONE)
+        obj_no_algorithm = pie_objects.OpaqueObject(
+            key, enums.OpaqueDataType.NONE)
+
+        e._data_session.add(obj_no_key)
+        e._data_session.add(obj_no_algorithm)
+        e._data_session.commit()
+        e._data_session = e._data_store_session_factory()
+
+        uuid_no_key = str(obj_no_key.unique_identifier)
+        uuid_no_algorithm = str(obj_no_algorithm.unique_identifier)
+
+        cryptographic_parameters = attributes.CryptographicParameters(
+            cryptographic_algorithm=attributes.
+            CryptographicAlgorithm(algorithm))
+
+        payload_no_key = mac.MACRequestPayload(
+            unique_identifier=attributes.UniqueIdentifier(uuid_no_key),
+            cryptographic_parameters=cryptographic_parameters,
+            data=objects.Data(data)
+        )
+
+        args = (payload_no_key, )
+        regex = "A secret key value must be specified"
+        self.assertRaisesRegexp(
+            exceptions.InvalidField,
+            regex,
+            e._process_mac,
+            *args
+        )
+
+        payload_no_algorithm = mac.MACRequestPayload(
+            unique_identifier=attributes.UniqueIdentifier(uuid_no_algorithm),
+            cryptographic_parameters=None,
+            data=objects.Data(data)
+        )
+
+        args = (payload_no_algorithm, )
+        regex = "The cryptographic algorithm must be specified"
+        self.assertRaisesRegexp(
+            exceptions.InvalidField,
+            regex,
+            e._process_mac,
+            *args
+        )
+
+        payload_no_data = mac.MACRequestPayload(
+            unique_identifier=attributes.UniqueIdentifier(uuid_no_algorithm),
+            cryptographic_parameters=cryptographic_parameters,
+            data=None
+        )
+
+        args = (payload_no_data, )
+        regex = "No data to be MACed"
+        self.assertRaisesRegexp(
+            exceptions.InvalidField,
+            regex,
+            e._process_mac,
+            *args
+        )
 
     def test_create_get_destroy(self):
         """


### PR DESCRIPTION
I didn’t add any integration test because currently I can not make integration test work due to some sqlalchemy  failure. But all the unit tests and manual integration test(manually spinning up the server and sending MAC request from client) work fine.