### PR TITLE
Fixing stringent uid value checks in the ProxyKmipClient

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -391,7 +391,7 @@ class ProxyKmipClient(api.KmipClient):
             message = result.result_message.value
             raise exceptions.KmipOperationFailure(status, reason, message)
 
-    def get(self, uid):
+    def get(self, uid=None):
         """
         Get a managed object from a KMIP appliance.
 
@@ -407,8 +407,9 @@ class ProxyKmipClient(api.KmipClient):
             TypeError: if the input argument is invalid
         """
         # Check input
-        if not isinstance(uid, six.string_types):
-            raise TypeError("uid must be a string")
+        if uid is not None:
+            if not isinstance(uid, six.string_types):
+                raise TypeError("uid must be a string")
 
         # Verify that operations can be given at this time
         if not self._is_open:
@@ -541,7 +542,7 @@ class ProxyKmipClient(api.KmipClient):
             message = result.result_message.value
             raise exceptions.KmipOperationFailure(status, reason, message)
 
-    def destroy(self, uid):
+    def destroy(self, uid=None):
         """
         Destroy a managed object stored by a KMIP appliance.
 
@@ -557,8 +558,9 @@ class ProxyKmipClient(api.KmipClient):
             TypeError: if the input argument is invalid
         """
         # Check input
-        if not isinstance(uid, six.string_types):
-            raise TypeError("uid must be a string")
+        if uid is not None:
+            if not isinstance(uid, six.string_types):
+                raise TypeError("uid must be a string")
 
         # Verify that operations can be given at this time
         if not self._is_open:

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -357,7 +357,7 @@ class KMIPProxy(KMIP):
                             revocation_message=message,
                             credential=credential)
 
-    def destroy(self, uuid, credential=None):
+    def destroy(self, uuid=None, credential=None):
         return self._destroy(unique_identifier=uuid,
                              credential=credential)
 


### PR DESCRIPTION
This change loosens the input requirements for ProxyKmipClient operations that accept a secret UID. Operations like Get and Destroy used to require a string value but are allowed in the KMIP specification to take no value at all. This change updates the ProxyKmipClient to properly reflect the specification. The underlying KMIPProxy client is mostly unchanged.

Closes #261