### PR TITLE
Add Revoke operation support for pie client

### DIFF
--- a/kmip/pie/api.py
+++ b/kmip/pie/api.py
@@ -111,6 +111,25 @@ class KmipClient:
         pass
 
     @abc.abstractmethod
+    def revoke(self, revocation_reason, uid, revocation_message,
+               compromise_occurrence_date):
+        """
+        Revoke a managed object stored by a KMIP appliance.
+
+        Args:
+            revocation_reason (RevocationReasonCode): An enumeration indicating
+                the revocation reason.
+            uid (string): The unique ID of the managed object to revoke.
+                Optional, defaults to None.
+            revocation_message (string): A message regarding the revocation.
+                Optional, defaults to None.
+            compromise_occurrence_date (int): A integer which will be converted
+                to the Datetime when the managed object was firstly believed to
+                be compromised. Optional, defaults to None.
+        """
+        pass
+
+    @abc.abstractmethod
     def destroy(self, uid):
         """
         Destroy a managed object stored by a KMIP appliance.

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -351,11 +351,14 @@ class KMIPProxy(KMIP):
         results = self._process_batch_items(response)
         return results[0]
 
-    def revoke(self, uuid, reason, message=None, credential=None):
-        return self._revoke(unique_identifier=uuid,
-                            revocation_code=reason,
-                            revocation_message=message,
-                            credential=credential)
+    def revoke(self, revocation_reason, uuid=None, revocation_message=None,
+               compromise_occurrence_date=None, credential=None):
+        return self._revoke(
+            unique_identifier=uuid,
+            revocation_reason=revocation_reason,
+            revocation_message=revocation_message,
+            compromise_occurrence_date=compromise_occurrence_date,
+            credential=credential)
 
     def destroy(self, uuid=None, credential=None):
         return self._destroy(unique_identifier=uuid,
@@ -805,11 +808,12 @@ class KMIPProxy(KMIP):
                                payload_unique_identifier)
         return result
 
-    def _revoke(self, unique_identifier=None, revocation_code=None,
-                revocation_message=None, credential=None):
+    def _revoke(self, unique_identifier=None, revocation_reason=None,
+                revocation_message=None, compromise_occurrence_date=None,
+                credential=None):
         operation = Operation(OperationEnum.REVOKE)
 
-        reason = objects.RevocationReason(code=revocation_code,
+        reason = objects.RevocationReason(code=revocation_reason,
                                           message=revocation_message)
         uuid = None
         if unique_identifier is not None:
@@ -818,7 +822,7 @@ class KMIPProxy(KMIP):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=uuid,
             revocation_reason=reason,
-            compromise_date=None)  # TODO(tim-kelsey): sort out date handling
+            compromise_date=compromise_occurrence_date)
 
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=payload)

--- a/kmip/tests/unit/pie/test_api.py
+++ b/kmip/tests/unit/pie/test_api.py
@@ -50,6 +50,12 @@ class DummyKmipClient(api.KmipClient):
     def activate(self, uid):
         super(DummyKmipClient, self).activate(uid)
 
+    def revoke(self, revocation_reason, uid, revocation_message,
+               compromise_occurrence_date):
+        super(DummyKmipClient, self).revoke(
+                revocation_reason, uid, revocation_message,
+                compromise_occurrence_date)
+
     def destroy(self, uid):
         super(DummyKmipClient, self).destroy(uid)
 
@@ -126,6 +132,13 @@ class TestKmipClient(testtools.TestCase):
         """
         dummy = DummyKmipClient()
         dummy.activate('uid')
+
+    def test_revoke(self):
+        """
+        Test that the revoke method can be called without error.
+        """
+        dummy = DummyKmipClient()
+        dummy.revoke('reason', 'uid', 'message', 'date')
 
     def test_destroy(self):
         """


### PR DESCRIPTION
Also  I think for revoke payload, we should rename compromise_date to be compromise_occurrence_date, since both of them exits and should be differentiated. I will try to modify it (and all relevant places) in another commit.