### PR TITLE
rename compromise_date to compromise_occurrence_date in revoke reques…

### DIFF
--- a/kmip/core/messages/payloads/revoke.py
+++ b/kmip/core/messages/payloads/revoke.py
@@ -40,7 +40,7 @@ class RevokeRequestPayload(Struct):
     def __init__(self,
                  unique_identifier=None,
                  revocation_reason=None,
-                 compromise_date=None):
+                 compromise_occurrence_date=None):
         """
         Construct a RevokeRequestPayload object.
         Args:
@@ -48,13 +48,13 @@ class RevokeRequestPayload(Struct):
                 cryptographic object.
             revocation_reason (RevocationReason): The reason why the object was
                 revoked.
-            compromise_date (DateTime): the date of compromise if the object
-                was compromised.
+            compromise_occurrence_date (DateTime): the datetime when the object
+                was first believed to be compromised.
         """
         super(RevokeRequestPayload, self).__init__(
             tag=enums.Tags.REQUEST_PAYLOAD)
         self.unique_identifier = unique_identifier
-        self.compromise_date = compromise_date
+        self.compromise_occurrence_date = compromise_occurrence_date
         self.revocation_reason = revocation_reason
         if self.revocation_reason is None:
             self.revocation_reason = objects.RevocationReason()
@@ -78,9 +78,9 @@ class RevokeRequestPayload(Struct):
         self.revocation_reason.read(tstream)
 
         if self.is_tag_next(enums.Tags.COMPROMISE_OCCURRENCE_DATE, tstream):
-            self.compromise_date = primitives.DateTime(
+            self.compromise_occurrence_date = primitives.DateTime(
                 tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE)
-            self.compromise_date.read(tstream)
+            self.compromise_occurrence_date.read(tstream)
 
         self.is_oversized(tstream)
         self.validate()
@@ -100,8 +100,8 @@ class RevokeRequestPayload(Struct):
 
         self.revocation_reason.write(tstream)
 
-        if self.compromise_date is not None:
-            self.compromise_date.write(tstream)
+        if self.compromise_occurrence_date is not None:
+            self.compromise_occurrence_date.write(tstream)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
@@ -117,8 +117,9 @@ class RevokeRequestPayload(Struct):
                               attributes.UniqueIdentifier):
                 msg = "invalid unique identifier"
                 raise TypeError(msg)
-        if self.compromise_date is not None:
-            if not isinstance(self.compromise_date, primitives.DateTime):
+        if self.compromise_occurrence_date is not None:
+            if not isinstance(self.compromise_occurrence_date,
+                              primitives.DateTime):
                 msg = "invalid compromise time"
                 raise TypeError(msg)
         if not isinstance(self.revocation_reason, objects.RevocationReason):

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -570,7 +570,7 @@ class ProxyKmipClient(api.KmipClient):
                 Optional, defaults to None.
             compromise_occurrence_date (int): An integer, the number of seconds
                 since the epoch, which will be converted to the Datetime when
-                the managed object was firstly believed to be compromised.
+                the managed object was first believed to be compromised.
                 Optional, defaults to None.
 
         Returns:

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -822,7 +822,7 @@ class KMIPProxy(KMIP):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=uuid,
             revocation_reason=reason,
-            compromise_date=compromise_occurrence_date)
+            compromise_occurrence_date=compromise_occurrence_date)
 
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=payload)

--- a/kmip/tests/unit/core/messages/payloads/test_revoke.py
+++ b/kmip/tests/unit/core/messages/payloads/test_revoke.py
@@ -121,7 +121,7 @@ class TestRevokeRequestPayload(TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=self.uuid,
             revocation_reason=reason,
-            compromise_date=date)
+            compromise_occurrence_date=date)
         payload.write(stream)
 
         length_expected = len(self.encoding_a)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -4397,7 +4397,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         response_payload = e._process_revoke(payload)
         e._data_session.commit()
@@ -4424,7 +4424,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_compromise,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         response_payload = e._process_revoke(payload)
         e._data_session.commit()
@@ -4454,7 +4454,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_compromise,
-            compromise_date=date)
+            compromise_occurrence_date=date)
         response_payload = e._process_revoke(payload)
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
@@ -4482,7 +4482,7 @@ class TestKmipEngine(testtools.TestCase):
         e._id_placeholder = str(object_id)
         payload = revoke.RevokeRequestPayload(
             revocation_reason=reason_unspecified,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         response_payload = e._process_revoke(payload)
         e._data_session.commit()
@@ -4537,7 +4537,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         args = (payload, )
         regex = "The object is not active and cannot be revoked with " \
@@ -4578,7 +4578,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         args = (payload,)
         name = enums.ObjectType.OPAQUE_DATA.name
@@ -4622,7 +4622,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = revoke.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_a),
             revocation_reason=reason_unspecified,
-            compromise_date=date)
+            compromise_occurrence_date=date)
 
         args = [payload]
         self.assertRaisesRegex(


### PR DESCRIPTION
rename compromise_date to compromise_occurrence_date in revoke request payload

Both of them are valid attribute names and we should use the compromise_occurrence_date in revoke()