### PR TITLE
Updating the CryptographicParameters struct

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -13,6 +13,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import six
+
 from kmip.core import enums
 
 from kmip.core.enums import CertificateTypeEnum
@@ -24,6 +26,7 @@ from kmip.core.errors import ErrorStrings
 
 from kmip.core.misc import KeyFormatType
 
+from kmip.core.primitives import Boolean
 from kmip.core.primitives import ByteString
 from kmip.core.primitives import Enumeration
 from kmip.core.primitives import Integer
@@ -255,163 +258,468 @@ class HashingAlgorithm(Enumeration):
 
 
 class CryptographicParameters(Struct):
+    """
+    A set of values for cryptographic operations.
 
-    class BlockCipherMode(Enumeration):
+    A structure containing optional fields describing certain cryptographic
+    parameters to be used when performing cryptographic operations with the
+    associated KMIP object.
+    """
 
-        def __init__(self, value=None):
-            super(CryptographicParameters.BlockCipherMode, self).__init__(
-                enums.BlockCipherMode, value, Tags.BLOCK_CIPHER_MODE)
-
-    class PaddingMethod(Enumeration):
-
-        def __init__(self, value=None):
-            super(CryptographicParameters.PaddingMethod, self).__init__(
-                enums.PaddingMethod, value, Tags.PADDING_METHOD)
-
-    class KeyRoleType(Enumeration):
-
-        def __init__(self, value=None):
-            super(CryptographicParameters.KeyRoleType, self).__init__(
-                enums.KeyRoleType, value, Tags.KEY_ROLE_TYPE)
-
-    class DigitalSignatureAlgorithm(Enumeration):
-
-        def __init__(self, value=None):
-            super(CryptographicParameters.DigitalSignatureAlgorithm,
-                  self).__init__(enums.DigitalSignatureAlgorithm,
-                                 value, Tags.DIGITAL_SIGNATURE_ALGORITHM)
-
-    # TODO: Need to implement other fields of CryptographicParameters (3.6)
     def __init__(self,
                  block_cipher_mode=None,
                  padding_method=None,
                  hashing_algorithm=None,
                  key_role_type=None,
                  digital_signature_algorithm=None,
-                 cryptographic_algorithm=None):
+                 cryptographic_algorithm=None,
+                 random_iv=None,
+                 iv_length=None,
+                 tag_length=None,
+                 fixed_field_length=None,
+                 invocation_field_length=None,
+                 counter_length=None,
+                 initial_counter_value=None):
         super(CryptographicParameters, self).__init__(
             tag=Tags.CRYPTOGRAPHIC_PARAMETERS)
+
+        self._block_cipher_mode = None
+        self._padding_method = None
+        self._hashing_algorithm = None
+        self._key_role_type = None
+        self._digital_signature_algorithm = None
+        self._cryptographic_algorithm = None
+        self._random_iv = None
+        self._iv_length = None
+        self._tag_length = None
+        self._fixed_field_length = None
+        self._invocation_field_length = None
+        self._counter_length = None
+        self._initial_counter_value = None
+
         self.block_cipher_mode = block_cipher_mode
         self.padding_method = padding_method
         self.hashing_algorithm = hashing_algorithm
         self.key_role_type = key_role_type
         self.digital_signature_algorithm = digital_signature_algorithm
         self.cryptographic_algorithm = cryptographic_algorithm
+        self.random_iv = random_iv
+        self.iv_length = iv_length
+        self.tag_length = tag_length
+        self.fixed_field_length = fixed_field_length
+        self.invocation_field_length = invocation_field_length
+        self.counter_length = counter_length
+        self.initial_counter_value = initial_counter_value
+
+    @property
+    def block_cipher_mode(self):
+        if self._block_cipher_mode:
+            return self._block_cipher_mode.value
+        else:
+            return None
+
+    @block_cipher_mode.setter
+    def block_cipher_mode(self, value):
+        if value is None:
+            self._block_cipher_mode = None
+        elif isinstance(value, enums.BlockCipherMode):
+            self._block_cipher_mode = Enumeration(
+                enums.BlockCipherMode,
+                value=value,
+                tag=Tags.BLOCK_CIPHER_MODE
+            )
+        else:
+            raise TypeError(
+                "block cipher mode must be a BlockCipherMode enumeration"
+            )
+
+    @property
+    def padding_method(self):
+        if self._padding_method:
+            return self._padding_method.value
+        else:
+            return None
+
+    @padding_method.setter
+    def padding_method(self, value):
+        if value is None:
+            self._padding_method = None
+        elif isinstance(value, enums.PaddingMethod):
+            self._padding_method = Enumeration(
+                enums.PaddingMethod,
+                value=value,
+                tag=Tags.PADDING_METHOD
+            )
+        else:
+            raise TypeError(
+                "padding method must be a PaddingMethod enumeration"
+            )
+
+    @property
+    def hashing_algorithm(self):
+        if self._hashing_algorithm:
+            return self._hashing_algorithm.value
+        else:
+            return None
+
+    @hashing_algorithm.setter
+    def hashing_algorithm(self, value):
+        if value is None:
+            self._hashing_algorithm = None
+        elif isinstance(value, enums.HashingAlgorithm):
+            self._hashing_algorithm = Enumeration(
+                enums.HashingAlgorithm,
+                value=value,
+                tag=Tags.HASHING_ALGORITHM
+            )
+        else:
+            raise TypeError(
+                "hashing algorithm must be a HashingAlgorithm enumeration"
+            )
+
+    @property
+    def key_role_type(self):
+        if self._key_role_type:
+            return self._key_role_type.value
+        else:
+            return None
+
+    @key_role_type.setter
+    def key_role_type(self, value):
+        if value is None:
+            self._key_role_type = None
+        elif isinstance(value, enums.KeyRoleType):
+            self._key_role_type = Enumeration(
+                enums.KeyRoleType,
+                value=value,
+                tag=Tags.KEY_ROLE_TYPE
+            )
+        else:
+            raise TypeError(
+                "key role type must be a KeyRoleType enumeration"
+            )
+
+    @property
+    def digital_signature_algorithm(self):
+        if self._digital_signature_algorithm:
+            return self._digital_signature_algorithm.value
+        else:
+            return None
+
+    @digital_signature_algorithm.setter
+    def digital_signature_algorithm(self, value):
+        if value is None:
+            self._digital_signature_algorithm = None
+        elif isinstance(value, enums.DigitalSignatureAlgorithm):
+            self._digital_signature_algorithm = Enumeration(
+                enums.DigitalSignatureAlgorithm,
+                value=value,
+                tag=Tags.DIGITAL_SIGNATURE_ALGORITHM
+            )
+        else:
+            raise TypeError(
+                "digital signature algorithm must be a "
+                "DigitalSignatureAlgorithm enumeration"
+            )
+
+    @property
+    def cryptographic_algorithm(self):
+        if self._cryptographic_algorithm:
+            return self._cryptographic_algorithm.value
+        else:
+            return None
+
+    @cryptographic_algorithm.setter
+    def cryptographic_algorithm(self, value):
+        if value is None:
+            self._cryptographic_algorithm = None
+        elif isinstance(value, enums.CryptographicAlgorithm):
+            self._cryptographic_algorithm = Enumeration(
+                enums.CryptographicAlgorithm,
+                value=value,
+                tag=Tags.CRYPTOGRAPHIC_ALGORITHM
+            )
+        else:
+            raise TypeError(
+                "cryptographic algorithm must be a CryptographicAlgorithm "
+                "enumeration"
+            )
+
+    @property
+    def random_iv(self):
+        if self._random_iv:
+            return self._random_iv.value
+        else:
+            return None
+
+    @random_iv.setter
+    def random_iv(self, value):
+        if value is None:
+            self._random_iv = None
+        elif isinstance(value, bool):
+            self._random_iv = Boolean(
+                value=value,
+                tag=Tags.RANDOM_IV
+            )
+        else:
+            raise TypeError("random iv must be a boolean")
+
+    @property
+    def iv_length(self):
+        if self._iv_length:
+            return self._iv_length.value
+        else:
+            return None
+
+    @iv_length.setter
+    def iv_length(self, value):
+        if value is None:
+            self._iv_length = None
+        elif isinstance(value, six.integer_types):
+            self._iv_length = Integer(
+                value=value,
+                tag=Tags.IV_LENGTH
+            )
+        else:
+            raise TypeError("iv length must be an integer")
+
+    @property
+    def tag_length(self):
+        if self._tag_length:
+            return self._tag_length.value
+        else:
+            return None
+
+    @tag_length.setter
+    def tag_length(self, value):
+        if value is None:
+            self._tag_length = None
+        elif isinstance(value, six.integer_types):
+            self._tag_length = Integer(
+                value=value,
+                tag=Tags.TAG_LENGTH
+            )
+        else:
+            raise TypeError("tag length must be an integer")
+
+    @property
+    def fixed_field_length(self):
+        if self._fixed_field_length:
+            return self._fixed_field_length.value
+        else:
+            return None
+
+    @fixed_field_length.setter
+    def fixed_field_length(self, value):
+        if value is None:
+            self._fixed_field_length = None
+        elif isinstance(value, six.integer_types):
+            self._fixed_field_length = Integer(
+                value=value,
+                tag=Tags.FIXED_FIELD_LENGTH
+            )
+        else:
+            raise TypeError("fixed field length must be an integer")
+
+    @property
+    def invocation_field_length(self):
+        if self._invocation_field_length:
+            return self._invocation_field_length.value
+        else:
+            return None
+
+    @invocation_field_length.setter
+    def invocation_field_length(self, value):
+        if value is None:
+            self._invocation_field_length = None
+        elif isinstance(value, six.integer_types):
+            self._invocation_field_length = Integer(
+                value=value,
+                tag=Tags.INVOCATION_FIELD_LENGTH
+            )
+        else:
+            raise TypeError("invocation field length must be an integer")
+
+    @property
+    def counter_length(self):
+        if self._counter_length:
+            return self._counter_length.value
+        else:
+            return None
+
+    @counter_length.setter
+    def counter_length(self, value):
+        if value is None:
+            self._counter_length = None
+        elif isinstance(value, six.integer_types):
+            self._counter_length = Integer(
+                value=value,
+                tag=Tags.COUNTER_LENGTH
+            )
+        else:
+            raise TypeError("counter length must be an integer")
+
+    @property
+    def initial_counter_value(self):
+        if self._initial_counter_value:
+            return self._initial_counter_value.value
+        else:
+            return None
+
+    @initial_counter_value.setter
+    def initial_counter_value(self, value):
+        if value is None:
+            self._initial_counter_value = None
+        elif isinstance(value, six.integer_types):
+            self._initial_counter_value = Integer(
+                value=value,
+                tag=Tags.INITIAL_COUNTER_VALUE
+            )
+        else:
+            raise TypeError("initial counter value must be an integer")
 
     def read(self, istream):
         super(CryptographicParameters, self).read(istream)
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.BLOCK_CIPHER_MODE, tstream):
-            self.block_cipher_mode = CryptographicParameters.BlockCipherMode()
-            self.block_cipher_mode.read(tstream)
+            self._block_cipher_mode = Enumeration(
+                enums.BlockCipherMode,
+                tag=Tags.BLOCK_CIPHER_MODE
+            )
+            self._block_cipher_mode.read(tstream)
 
         if self.is_tag_next(Tags.PADDING_METHOD, tstream):
-            self.padding_method = CryptographicParameters.PaddingMethod()
-            self.padding_method.read(tstream)
+            self._padding_method = Enumeration(
+                enums.PaddingMethod,
+                tag=Tags.PADDING_METHOD
+            )
+            self._padding_method.read(tstream)
 
         if self.is_tag_next(Tags.HASHING_ALGORITHM, tstream):
-            self.hashing_algorithm = HashingAlgorithm()
-            self.hashing_algorithm.read(tstream)
+            self._hashing_algorithm = Enumeration(
+                enums.HashingAlgorithm,
+                tag=Tags.HASHING_ALGORITHM
+            )
+            self._hashing_algorithm.read(tstream)
 
         if self.is_tag_next(Tags.KEY_ROLE_TYPE, tstream):
-            self.key_role_type = CryptographicParameters.KeyRoleType()
-            self.key_role_type.read(tstream)
+            self._key_role_type = Enumeration(
+                enums.KeyRoleType,
+                tag=Tags.KEY_ROLE_TYPE
+            )
+            self._key_role_type.read(tstream)
 
         if self.is_tag_next(Tags.DIGITAL_SIGNATURE_ALGORITHM, tstream):
-            self.digital_signature_algorithm = \
-                CryptographicParameters.DigitalSignatureAlgorithm()
-            self.digital_signature_algorithm.read(tstream)
+            self._digital_signature_algorithm = Enumeration(
+                enums.DigitalSignatureAlgorithm,
+                tag=Tags.DIGITAL_SIGNATURE_ALGORITHM
+            )
+            self._digital_signature_algorithm.read(tstream)
 
         if self.is_tag_next(Tags.CRYPTOGRAPHIC_ALGORITHM, tstream):
-            self.cryptographic_algorithm = CryptographicAlgorithm()
-            self.cryptographic_algorithm.read(tstream)
+            self._cryptographic_algorithm = Enumeration(
+                enums.CryptographicAlgorithm,
+                tag=Tags.CRYPTOGRAPHIC_ALGORITHM
+            )
+            self._cryptographic_algorithm.read(tstream)
+
+        if self.is_tag_next(Tags.RANDOM_IV, tstream):
+            self._random_iv = Boolean(tag=Tags.RANDOM_IV)
+            self._random_iv.read(tstream)
+
+        if self.is_tag_next(Tags.IV_LENGTH, tstream):
+            self._iv_length = Integer(tag=Tags.IV_LENGTH)
+            self._iv_length.read(tstream)
+
+        if self.is_tag_next(Tags.TAG_LENGTH, tstream):
+            self._tag_length = Integer(tag=Tags.TAG_LENGTH)
+            self._tag_length.read(tstream)
+
+        if self.is_tag_next(Tags.FIXED_FIELD_LENGTH, tstream):
+            self._fixed_field_length = Integer(tag=Tags.FIXED_FIELD_LENGTH)
+            self._fixed_field_length.read(tstream)
+
+        if self.is_tag_next(Tags.INVOCATION_FIELD_LENGTH, tstream):
+            self._invocation_field_length = Integer(
+                tag=Tags.INVOCATION_FIELD_LENGTH
+            )
+            self._invocation_field_length.read(tstream)
+
+        if self.is_tag_next(Tags.COUNTER_LENGTH, tstream):
+            self._counter_length = Integer(tag=Tags.COUNTER_LENGTH)
+            self._counter_length.read(tstream)
+
+        if self.is_tag_next(Tags.INITIAL_COUNTER_VALUE, tstream):
+            self._initial_counter_value = Integer(
+                tag=Tags.INITIAL_COUNTER_VALUE
+            )
+            self._initial_counter_value.read(tstream)
 
         self.is_oversized(tstream)
-        self.validate()
 
     def write(self, ostream):
         tstream = BytearrayStream()
 
-        # Write the contents of the request payload
-        if self.block_cipher_mode is not None:
-            self.block_cipher_mode.write(tstream)
-        if self.padding_method is not None:
-            self.padding_method.write(tstream)
-        if self.hashing_algorithm is not None:
-            self.hashing_algorithm.write(tstream)
-        if self.key_role_type is not None:
-            self.key_role_type.write(tstream)
-        if self.digital_signature_algorithm is not None:
-            self.digital_signature_algorithm.write(tstream)
-        if self.cryptographic_algorithm is not None:
-            self.cryptographic_algorithm.write(tstream)
+        if self._block_cipher_mode:
+            self._block_cipher_mode.write(tstream)
+        if self._padding_method:
+            self._padding_method.write(tstream)
+        if self._hashing_algorithm:
+            self._hashing_algorithm.write(tstream)
+        if self._key_role_type:
+            self._key_role_type.write(tstream)
+        if self._digital_signature_algorithm:
+            self._digital_signature_algorithm.write(tstream)
+        if self._cryptographic_algorithm:
+            self._cryptographic_algorithm.write(tstream)
+        if self._random_iv:
+            self._random_iv.write(tstream)
+        if self._iv_length:
+            self._iv_length.write(tstream)
+        if self._tag_length:
+            self._tag_length.write(tstream)
+        if self._fixed_field_length:
+            self._fixed_field_length.write(tstream)
+        if self._invocation_field_length:
+            self._invocation_field_length.write(tstream)
+        if self._counter_length:
+            self._counter_length.write(tstream)
+        if self._initial_counter_value:
+            self._initial_counter_value.write(tstream)
 
-        # Write the length and value of the request payload
         self.length = tstream.length()
         super(CryptographicParameters, self).write(ostream)
         ostream.write(tstream.buffer)
-
-    def validate(self):
-        self.__validate()
-
-    def __validate(self):
-        if self.block_cipher_mode is not None:
-            if not isinstance(self.block_cipher_mode, self.BlockCipherMode):
-                msg = "Invalid block cipher mode"
-                msg += "; expected {0}, received {1}".format(
-                    self.BlockCipherMode, self.block_cipher_mode)
-                raise TypeError(msg)
-        if self.padding_method is not None:
-            if not isinstance(self.padding_method, self.PaddingMethod):
-                msg = "Invalid padding method"
-                msg += "; expected {0}, received {1}".format(
-                    self.PaddingMethod, self.padding_method)
-                raise TypeError(msg)
-        if self.hashing_algorithm is not None:
-            if not isinstance(self.hashing_algorithm, HashingAlgorithm):
-                msg = "Invalid hashing algorithm"
-                msg += "; expected {0}, received {1}".format(
-                    HashingAlgorithm, self.hashing_algorithm)
-                raise TypeError(msg)
-        if self.key_role_type is not None:
-            if not isinstance(self.key_role_type, self.KeyRoleType):
-                msg = "Invalid key role type"
-                msg += "; expected {0}, received {1}".format(
-                    self.KeyRoleType, self.key_role_type)
-                raise TypeError(msg)
-        if self.digital_signature_algorithm is not None:
-            if not isinstance(
-                self.digital_signature_algorithm,
-                CryptographicParameters.DigitalSignatureAlgorithm
-            ):
-                msg = "Invalid digital signature algorithm"
-                msg += "; expected {0}, received {1}".format(
-                    CryptographicParameters.DigitalSignatureAlgorithm,
-                    self.digital_signature_algorithm)
-                raise TypeError(msg)
-        if self.cryptographic_algorithm is not None:
-            if not isinstance(self.cryptographic_algorithm,
-                              CryptographicAlgorithm):
-                msg = "Invalid cryptograhic algorithm"
-                msg += "; expected {0}, received {1}".format(
-                    CryptographicAlgorithm, self.cryptographic_algorithm)
-                raise TypeError(msg)
 
     def __eq__(self, other):
         if isinstance(other, CryptographicParameters):
             if self.block_cipher_mode != other.block_cipher_mode:
                 return False
-            elif self.key_role_type != other.key_role_type:
+            elif self.padding_method != other.padding_method:
                 return False
             elif self.hashing_algorithm != other.hashing_algorithm:
+                return False
+            elif self.key_role_type != other.key_role_type:
                 return False
             elif self.digital_signature_algorithm \
                     != other.digital_signature_algorithm:
                 return False
             elif self.cryptographic_algorithm != other.cryptographic_algorithm:
                 return False
-            elif self.padding_method != other.padding_method:
+            elif self.random_iv != other.random_iv:
+                return False
+            elif self.iv_length != other.iv_length:
+                return False
+            elif self.tag_length != other.tag_length:
+                return False
+            elif self.fixed_field_length != other.fixed_field_length:
+                return False
+            elif self.invocation_field_length != other.invocation_field_length:
+                return False
+            elif self.counter_length != other.counter_length:
+                return False
+            elif self.initial_counter_value != other.initial_counter_value:
                 return False
             else:
                 return True
@@ -421,6 +729,47 @@ class CryptographicParameters(Struct):
             return not self == other
         else:
             return NotImplemented
+
+    def __repr__(self):
+        args = ", ".join([
+            "block_cipher_mode={0}".format(self.block_cipher_mode),
+            "padding_method={0}".format(self.padding_method),
+            "hashing_algorithm={0}".format(self.hashing_algorithm),
+            "key_role_type={0}".format(self.key_role_type),
+            "digital_signature_algorithm={0}".format(
+                self.digital_signature_algorithm
+            ),
+            "cryptographic_algorithm={0}".format(
+                self.cryptographic_algorithm
+            ),
+            "random_iv={0}".format(self.random_iv),
+            "iv_length={0}".format(self.iv_length),
+            "tag_length={0}".format(self.tag_length),
+            "fixed_field_length={0}".format(self.fixed_field_length),
+            "invocation_field_length={0}".format(
+                self.invocation_field_length
+            ),
+            "counter_length={0}".format(self.counter_length),
+            "initial_counter_value={0}".format(self.initial_counter_value)
+        ])
+        return "CryptographicParameters({0})".format(args)
+
+    def __str__(self):
+        return str({
+            'block_cipher_mode': self.block_cipher_mode,
+            'padding_method': self.padding_method,
+            'hashing_algorithm': self.hashing_algorithm,
+            'key_role_type': self.key_role_type,
+            'digital_signature_algorithm': self.digital_signature_algorithm,
+            'cryptographic_algorithm': self.cryptographic_algorithm,
+            'random_iv': self.random_iv,
+            'iv_length': self.iv_length,
+            'tag_length': self.tag_length,
+            'fixed_field_length': self.fixed_field_length,
+            'invocation_field_length': self.invocation_field_length,
+            'counter_length': self.counter_length,
+            'initial_counter_value': self.initial_counter_value
+        })
 
 
 class CertificateType(Enumeration):

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -136,52 +136,39 @@ class AttributeValueFactory(object):
         return attributes.CryptographicLength(length)
 
     def _create_cryptographic_parameters(self, params):
-        bcm = None
-        padding_method = None
-        hashing_algorithm = None
-        key_role_type = None
-        digital_signature_algorithm = None
-        cryptographic_algorithm = None
-        # TODO: Need to implement other fields of CryptographicParameters (3.6)
+        if params is None:
+            params = {}
 
-        if params is not None:
-
-            if 'block_cipher_mode' in params:
-                bcm = attributes.CryptographicParameters.BlockCipherMode(
-                    params.get('block_cipher_mode'))
-
-            padding_method = None
-            if 'padding_method' in params:
-                padding_method = attributes.CryptographicParameters. \
-                    PaddingMethod(params.get('padding_method'))
-
-            key_role_type = None
-            if 'key_role_type' in params:
-                key_role_type = attributes.CryptographicParameters.KeyRoleType(
-                    params.get('key_role_type'))
-
-            hashing_algorithm = None
-            if 'hashing_algorithm' in params:
-                hashing_algorithm = attributes.HashingAlgorithm(
-                    params.get("hashing_algorithm"))
-
-            if 'digital_signature_algorithm' in params:
-                digital_signature_algorithm = \
-                    attributes.CryptographicParameters. \
-                    DigitalSignatureAlgorithm(
-                        params.get("digital_signature_algorithm"))
-
-            if 'cryptographic_algorithm' in params:
-                cryptographic_algorithm = attributes.CryptographicAlgorithm(
-                    params.get("cryptographic_algorithm"))
-
-        return attributes.CryptographicParameters(
-            block_cipher_mode=bcm,
-            padding_method=padding_method,
-            hashing_algorithm=hashing_algorithm,
-            key_role_type=key_role_type,
-            digital_signature_algorithm=digital_signature_algorithm,
-            cryptographic_algorithm=cryptographic_algorithm)
+        if isinstance(params, dict):
+            return attributes.CryptographicParameters(
+                block_cipher_mode=params.get('block_cipher_mode', None),
+                padding_method=params.get('padding_method', None),
+                hashing_algorithm=params.get('hashing_algorithm', None),
+                key_role_type=params.get('key_role_type', None),
+                digital_signature_algorithm=params.get(
+                    'digital_signature_algorithm',
+                    None
+                ),
+                cryptographic_algorithm=params.get(
+                    'cryptographic_algorithm',
+                    None
+                ),
+                random_iv=params.get('random_iv', None),
+                iv_length=params.get('iv_length', None),
+                tag_length=params.get('tag_length', None),
+                fixed_field_length=params.get('fixed_field_length', None),
+                invocation_field_length=params.get(
+                    'invocation_field_length',
+                    None
+                ),
+                counter_length=params.get('counter_length', None),
+                initial_counter_value=params.get(
+                    'initial_counter_value',
+                    None
+                )
+            )
+        else:
+            raise TypeError("cryptographic parameters must be a dict")
 
     def _create_cryptographic_usage_mask(self, flags):
         mask = None

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -22,8 +22,7 @@ from kmip.core import objects as cobjects
 
 from kmip.core.factories import attributes
 
-from kmip.core.attributes import CryptographicParameters, \
-    CryptographicAlgorithm
+from kmip.core.attributes import CryptographicParameters
 
 from kmip.pie import api
 from kmip.pie import exceptions
@@ -687,7 +686,8 @@ class ProxyKmipClient(api.KmipClient):
             raise exceptions.ClientConnectionNotOpen()
 
         parameters_attribute = CryptographicParameters(
-            cryptographic_algorithm=CryptographicAlgorithm(algorithm))
+            cryptographic_algorithm=algorithm
+        )
 
         # Get the message authentication code and handle the results
         result = self.proxy.mac(data, uid, parameters_attribute)

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1700,7 +1700,7 @@ class KmipEngine(object):
         if (payload.cryptographic_parameters and
                 payload.cryptographic_parameters.cryptographic_algorithm):
             algorithm = \
-                payload.cryptographic_parameters.cryptographic_algorithm.value
+                payload.cryptographic_parameters.cryptographic_algorithm
         elif (isinstance(managed_object, objects.Key) and
               managed_object.cryptographic_algorithm):
             algorithm = managed_object.cryptographic_algorithm

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -23,18 +23,10 @@ from kmip.core.attributes import DigestValue
 from kmip.core.attributes import HashingAlgorithm
 from kmip.core.attributes import Name
 from kmip.core.attributes import OperationPolicyName
-from kmip.core.attributes import Tags
 
-from kmip.core.factories.attribute_values import AttributeValueFactory
-
-from kmip.core.enums import AttributeType
-from kmip.core.enums import BlockCipherMode
+from kmip.core import enums
 from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import HashingAlgorithm as HashingAlgorithmEnum
-from kmip.core.enums import KeyRoleType
-from kmip.core.enums import DigitalSignatureAlgorithm
-from kmip.core.enums import CryptographicAlgorithm
-from kmip.core.enums import PaddingMethod
 from kmip.core.enums import NameType
 
 from kmip.core.utils import BytearrayStream
@@ -485,169 +477,1122 @@ class TestApplicationData(TestCase):
 
 
 class TestCryptographicParameters(TestCase):
-
     """
-    A test suite for the CryptographicParameters class
+    Test suite for the CryptographicParameters struct.
     """
 
     def setUp(self):
         super(TestCryptographicParameters, self).setUp()
 
-        self.bad_enum_code = 8535937
-        self.factory = AttributeValueFactory()
+        # Encoding obtained in part from the KMIP 1.1 testing document,
+        # Section 11.1. The rest of the encoding for KMIP 1.2+ features was
+        # built by hand; later KMIP testing documents do not include the
+        # encoding, so a manual construction is necessary.
+        #
+        # This encoding matches the following set of values:
+        # Block Cipher Mode - CBC
+        # Padding Method - PKCS5
+        # Hashing Algorithm - SHA-1
+        # Key Role Type - KEK
+        # Digital Signature Algorithm - SHA-256 with RSA
+        # Cryptographic Algorithm - AES
+        # Random IV - True
+        # IV Length - 96
+        # Tag Length - 128
+        # Fixed Field Length - 32
+        # Invocation Field Length - 64
+        # Counter Length - 0
+        # Initial Counter Value - 1
 
-        self.cp = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-
-        self.cp_none = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS, {})
-
-        # Symmetric key object with Cryptographic Parameters
-        # Byte stream edited to add:
-        #      Key Role Type parameter
-        #      Digital Signature Algorithm parameter
-        #      Cryptographic Algorithm parameter
-        # Based on the KMIP Spec 1.1 Test Cases document
-        # 11.1 page 255 on the pdf version
-        self.key_req_with_crypt_params = BytearrayStream((
-            b'\x42\x00\x2B\x01\x00\x00\x00\x60'
+        self.full_encoding = BytearrayStream(
+            b'\x42\x00\x2B\x01\x00\x00\x00\xD0'
             b'\x42\x00\x11\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
             b'\x42\x00\x5F\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
             b'\x42\x00\x38\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
-            b'\x42\x00\x83\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x83\x05\x00\x00\x00\x04\x00\x00\x00\x0B\x00\x00\x00\x00'
             b'\x42\x00\xAE\x05\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00'
-            b'\x42\x00\x28\x05\x00\x00\x00\x04\x00\x00\x00\x0B\x00\x00\x00\x00'
-        ))
+            b'\x42\x00\x28\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\xC5\x06\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x01'
+            b'\x42\x00\xCD\x02\x00\x00\x00\x04\x00\x00\x00\x60\x00\x00\x00\x00'
+            b'\x42\x00\xCE\x02\x00\x00\x00\x04\x00\x00\x00\x80\x00\x00\x00\x00'
+            b'\x42\x00\xCF\x02\x00\x00\x00\x04\x00\x00\x00\x20\x00\x00\x00\x00'
+            b'\x42\x00\xD2\x02\x00\x00\x00\x04\x00\x00\x00\x40\x00\x00\x00\x00'
+            b'\x42\x00\xD0\x02\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xD1\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
 
-    def teardown(self):
+        # Adapted from the full encoding above. This encoding matches the
+        # following set of values:
+        # Block Cipher Mode - CBC
+        # Padding Method - PKCS5
+        # Hashing Algorithm - SHA-1
+        # Key Role Type - KEK
+        # Digital Signature Algorithm - SHA-256 with RSA
+        # Cryptographic Algorithm - AES
+        # Tag Length - 128
+        # Initial Counter Value - 1
+
+        self.partial_encoding = BytearrayStream(
+            b'\x42\x00\x2B\x01\x00\x00\x00\x80'
+            b'\x42\x00\x11\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x5F\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\x38\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
+            b'\x42\x00\x83\x05\x00\x00\x00\x04\x00\x00\x00\x0B\x00\x00\x00\x00'
+            b'\x42\x00\xAE\x05\x00\x00\x00\x04\x00\x00\x00\x05\x00\x00\x00\x00'
+            b'\x42\x00\x28\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\xCE\x02\x00\x00\x00\x04\x00\x00\x00\x80\x00\x00\x00\x00'
+            b'\x42\x00\xD1\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        self.empty_encoding = BytearrayStream(
+            b'\x42\x00\x2B\x01\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
         super(TestCryptographicParameters, self).tearDown()
 
-    def test_write_crypto_params(self):
-        ostream = BytearrayStream()
-        self.cp.write(ostream)
-        self.assertEqual(self.key_req_with_crypt_params, ostream)
+    def test_init(self):
+        """
+        Test that a CryptographicParameters struct can be constructed with
+        no arguments.
+        """
+        cryptographic_parameters = CryptographicParameters()
 
-    def test_read_crypto_params(self):
-        CryptographicParameters.read(self.cp, self.key_req_with_crypt_params)
+        self.assertEqual(None, cryptographic_parameters.block_cipher_mode)
+        self.assertEqual(None, cryptographic_parameters.padding_method)
+        self.assertEqual(None, cryptographic_parameters.hashing_algorithm)
+        self.assertEqual(None, cryptographic_parameters.key_role_type)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            None,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(None, cryptographic_parameters.initial_counter_value)
 
-        self.assertEqual(Tags.BLOCK_CIPHER_MODE.value,
-                         self.cp.block_cipher_mode.tag.value)
-        self.assertEqual(BlockCipherMode.CBC.value,
-                         self.cp.block_cipher_mode.value.value)
+    def test_init_with_args(self):
+        """
+        Test that a CryptographicParameters struct can be constructed with
+        valid values.
+        """
+        cryptographic_parameters = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CTR,
+            padding_method=enums.PaddingMethod.NONE,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_256,
+            key_role_type=enums.KeyRoleType.BDK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA1_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.TRIPLE_DES,
+            random_iv=False,
+            iv_length=128,
+            tag_length=256,
+            fixed_field_length=48,
+            invocation_field_length=60,
+            counter_length=20,
+            initial_counter_value=2
+        )
 
-        self.assertEqual(Tags.PADDING_METHOD.value,
-                         self.cp.padding_method.tag.value)
-        self.assertEqual(PaddingMethod.PKCS5.value,
-                         self.cp.padding_method.value.value)
+        self.assertEqual(
+            enums.BlockCipherMode.CTR,
+            cryptographic_parameters.block_cipher_mode
+        )
+        self.assertEqual(
+            enums.PaddingMethod.NONE,
+            cryptographic_parameters.padding_method
+        )
+        self.assertEqual(
+            enums.HashingAlgorithm.SHA_256,
+            cryptographic_parameters.hashing_algorithm
+        )
+        self.assertEqual(
+            enums.KeyRoleType.BDK,
+            cryptographic_parameters.key_role_type
+        )
+        self.assertEqual(
+            enums.DigitalSignatureAlgorithm.SHA1_WITH_RSA_ENCRYPTION,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            enums.CryptographicAlgorithm.TRIPLE_DES,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(False, cryptographic_parameters.random_iv)
+        self.assertEqual(128, cryptographic_parameters.iv_length)
+        self.assertEqual(256, cryptographic_parameters.tag_length)
+        self.assertEqual(48, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(60, cryptographic_parameters.invocation_field_length)
+        self.assertEqual(20, cryptographic_parameters.counter_length)
+        self.assertEqual(2, cryptographic_parameters.initial_counter_value)
 
-        self.assertEqual(Tags.KEY_ROLE_TYPE.value,
-                         self.cp.key_role_type.tag.value)
-        self.assertEqual(KeyRoleType.BDK.value,
-                         self.cp.key_role_type.value.value)
+    def test_invalid_block_cipher_mode(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the block cipher mode of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'block_cipher_mode', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "block cipher mode must be a BlockCipherMode enumeration",
+            setattr,
+            *args
+        )
 
-        self.assertEqual(Tags.HASHING_ALGORITHM.value,
-                         self.cp.hashing_algorithm.tag.value)
-        self.assertEqual(HashingAlgorithmEnum.SHA_1.value,
-                         self.cp.hashing_algorithm.value.value)
+    def test_invalid_padding_method(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the padding method of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'padding_method', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "padding method must be a PaddingMethod enumeration",
+            setattr,
+            *args
+        )
 
-        self.assertEqual(Tags.DIGITAL_SIGNATURE_ALGORITHM.value,
-                         self.cp.digital_signature_algorithm.tag.value)
-        self.assertEqual(DigitalSignatureAlgorithm.
-                         SHA256_WITH_RSA_ENCRYPTION.value,
-                         self.cp.digital_signature_algorithm.value.value)
+    def test_invalid_hashing_algorithm(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the hashing algorithm of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'hashing_algorithm', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "hashing algorithm must be a HashingAlgorithm enumeration",
+            setattr,
+            *args
+        )
 
-        self.assertEqual(Tags.CRYPTOGRAPHIC_ALGORITHM.value,
-                         self.cp.cryptographic_algorithm.tag.value)
-        self.assertEqual(CryptographicAlgorithm.HMAC_SHA512.value,
-                         self.cp.cryptographic_algorithm.value.value)
+    def test_invalid_key_role_type(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the key role type of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'key_role_type', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "key role type must be a KeyRoleType enumeration",
+            setattr,
+            *args
+        )
 
-    def test_bad_cipher_mode(self):
-        self.cp.block_cipher_mode = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_digital_signature_algorithm(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the digital signature algorithm of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (
+            cryptographic_parameters,
+            'digital_signature_algorithm',
+            'invalid'
+        )
+        self.assertRaisesRegexp(
+            TypeError,
+            "digital signature algorithm must be a "
+            "DigitalSignatureAlgorithm enumeration",
+            setattr,
+            *args
+        )
 
-    def test_bad_padding_method(self):
-        self.cp.padding_method = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_cryptographic_algorithm(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the cryptographic algorithm of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'cryptographic_algorithm', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "cryptographic algorithm must be a CryptographicAlgorithm "
+            "enumeration",
+            setattr,
+            *args
+        )
 
-    def test_bad_hash_algorithm(self):
-        self.cp.hashing_algorithm = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_random_iv(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the random IV of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'random_iv', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "random iv must be a boolean",
+            setattr,
+            *args
+        )
 
-    def test_bad_key_role_type(self):
-        self.cp.key_role_type = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_iv_length(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the IV length of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'iv_length', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "iv length must be an integer",
+            setattr,
+            *args
+        )
 
-    def test_bad_digital_signature_algorithm(self):
-        self.cp.digital_signature_algorithm = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_tag_length(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the tag length of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'tag_length', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "tag length must be an integer",
+            setattr,
+            *args
+        )
 
-    def test_bad_cryptographic_algorithm(self):
-        self.cp.cryptographic_algorithm = self.bad_enum_code
-        cp_valid = self.factory.create_attribute_value(
-            AttributeType.CRYPTOGRAPHIC_PARAMETERS,
-            {'block_cipher_mode': BlockCipherMode.CBC,
-             'padding_method': PaddingMethod.PKCS5,
-             'hashing_algorithm': HashingAlgorithmEnum.SHA_1,
-             'key_role_type': KeyRoleType.BDK,
-             'digital_signature_algorithm':
-                DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
-             'cryptographic_algorithm': CryptographicAlgorithm.HMAC_SHA512})
-        self.assertFalse(self.cp == cp_valid)
-        self.assertRaises(TypeError, self.cp.validate)
+    def test_invalid_fixed_field_length(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the fixed field length of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'fixed_field_length', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "fixed field length must be an integer",
+            setattr,
+            *args
+        )
+
+    def test_invalid_invocation_field_length(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the invocation field length of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'invocation_field_length', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "invocation field length must be an integer",
+            setattr,
+            *args
+        )
+
+    def test_invalid_counter_length(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the counter length of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'counter_length', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "counter length must be an integer",
+            setattr,
+            *args
+        )
+
+    def test_invalid_initial_counter_value(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the counter value of a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        args = (cryptographic_parameters, 'initial_counter_value', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "initial counter value must be an integer",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a CryptographicParameters struct can be read from a data
+        stream.
+        """
+        cryptographic_parameters = CryptographicParameters()
+
+        self.assertEqual(None, cryptographic_parameters.block_cipher_mode)
+        self.assertEqual(None, cryptographic_parameters.padding_method)
+        self.assertEqual(None, cryptographic_parameters.hashing_algorithm)
+        self.assertEqual(None, cryptographic_parameters.key_role_type)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            None,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(None, cryptographic_parameters.initial_counter_value)
+
+        cryptographic_parameters.read(self.full_encoding)
+
+        self.assertEqual(
+            enums.BlockCipherMode.CBC,
+            cryptographic_parameters.block_cipher_mode
+        )
+        self.assertEqual(
+            enums.PaddingMethod.PKCS5,
+            cryptographic_parameters.padding_method
+        )
+        self.assertEqual(
+            enums.HashingAlgorithm.SHA_1,
+            cryptographic_parameters.hashing_algorithm
+        )
+        self.assertEqual(
+            enums.KeyRoleType.KEK,
+            cryptographic_parameters.key_role_type
+        )
+        self.assertEqual(
+            enums.DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            enums.CryptographicAlgorithm.AES,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(True, cryptographic_parameters.random_iv)
+        self.assertEqual(96, cryptographic_parameters.iv_length)
+        self.assertEqual(128, cryptographic_parameters.tag_length)
+        self.assertEqual(32, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(64, cryptographic_parameters.invocation_field_length)
+        self.assertEqual(0, cryptographic_parameters.counter_length)
+        self.assertEqual(1, cryptographic_parameters.initial_counter_value)
+
+    def test_read_partial(self):
+        """
+        Test that a CryptographicParameters struct can be read from a partial
+        data stream.
+        """
+        cryptographic_parameters = CryptographicParameters()
+
+        self.assertEqual(None, cryptographic_parameters.block_cipher_mode)
+        self.assertEqual(None, cryptographic_parameters.padding_method)
+        self.assertEqual(None, cryptographic_parameters.hashing_algorithm)
+        self.assertEqual(None, cryptographic_parameters.key_role_type)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            None,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(None, cryptographic_parameters.initial_counter_value)
+
+        cryptographic_parameters.read(self.partial_encoding)
+
+        self.assertEqual(
+            enums.BlockCipherMode.CBC,
+            cryptographic_parameters.block_cipher_mode
+        )
+        self.assertEqual(
+            enums.PaddingMethod.PKCS5,
+            cryptographic_parameters.padding_method
+        )
+        self.assertEqual(
+            enums.HashingAlgorithm.SHA_1,
+            cryptographic_parameters.hashing_algorithm
+        )
+        self.assertEqual(
+            enums.KeyRoleType.KEK,
+            cryptographic_parameters.key_role_type
+        )
+        self.assertEqual(
+            enums.DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            enums.CryptographicAlgorithm.AES,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(128, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(1, cryptographic_parameters.initial_counter_value)
+
+    def test_read_empty(self):
+        """
+        Test that a CryptographicParameters struct can be read from an empty
+        data stream.
+        """
+        cryptographic_parameters = CryptographicParameters()
+
+        self.assertEqual(None, cryptographic_parameters.block_cipher_mode)
+        self.assertEqual(None, cryptographic_parameters.padding_method)
+        self.assertEqual(None, cryptographic_parameters.hashing_algorithm)
+        self.assertEqual(None, cryptographic_parameters.key_role_type)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            None,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(None, cryptographic_parameters.initial_counter_value)
+
+        cryptographic_parameters.read(self.empty_encoding)
+
+        self.assertEqual(None, cryptographic_parameters.block_cipher_mode)
+        self.assertEqual(None, cryptographic_parameters.padding_method)
+        self.assertEqual(None, cryptographic_parameters.hashing_algorithm)
+        self.assertEqual(None, cryptographic_parameters.key_role_type)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.digital_signature_algorithm
+        )
+        self.assertEqual(
+            None,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(None, cryptographic_parameters.random_iv)
+        self.assertEqual(None, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(None, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(
+            None,
+            cryptographic_parameters.invocation_field_length
+        )
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(None, cryptographic_parameters.initial_counter_value)
+
+    def test_write(self):
+        """
+        Test that a CryptographicParameters struct can be written to a data
+        stream.
+        """
+        cryptographic_parameters = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+        stream = BytearrayStream()
+        cryptographic_parameters.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_partial(self):
+        """
+        Test that a partially defined CryptographicParameters struct can be
+        written to a data stream.
+        """
+        cryptographic_parameters = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            tag_length=128,
+            initial_counter_value=1
+        )
+        stream = BytearrayStream()
+        cryptographic_parameters.write(stream)
+
+        self.assertEqual(len(self.partial_encoding), len(stream))
+        self.assertEqual(str(self.partial_encoding), str(stream))
+
+    def test_write_empty(self):
+        """
+        Test that an empty CryptographicParameters struct can be written to a
+        data stream.
+        """
+        cryptographic_parameters = CryptographicParameters()
+        stream = BytearrayStream()
+        cryptographic_parameters.write(stream)
+
+        self.assertEqual(len(self.empty_encoding), len(stream))
+        self.assertEqual(str(self.empty_encoding), str(stream))
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        CryptographicParameters structs with the same data.
+        """
+        a = CryptographicParameters()
+        b = CryptographicParameters()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+        b = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_block_cipher_mode(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different block cipher modes.
+        """
+        a = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC
+        )
+        b = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.GCM
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_padding_method(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different padding methods.
+        """
+        a = CryptographicParameters(padding_method=enums.PaddingMethod.NONE)
+        b = CryptographicParameters(padding_method=enums.PaddingMethod.PKCS5)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_hashing_algorithm(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different hashing algorithms.
+        """
+        a = CryptographicParameters(
+            hashing_algorithm=enums.HashingAlgorithm.MD5
+        )
+        b = CryptographicParameters(
+            hashing_algorithm=enums.HashingAlgorithm.SHA_256
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_key_role_type(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different key role types.
+        """
+        a = CryptographicParameters(key_role_type=enums.KeyRoleType.BDK)
+        b = CryptographicParameters(key_role_type=enums.KeyRoleType.KEK)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_digital_signature_algorithm(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different digital signature
+        algorithms.
+        """
+        a = CryptographicParameters(
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            DSA_WITH_SHA1
+        )
+        b = CryptographicParameters(
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            ECDSA_WITH_SHA1
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_cryptographic_algorithm(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different cryptographic
+        algorithms.
+        """
+        a = CryptographicParameters(
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES
+        )
+        b = CryptographicParameters(
+            cryptographic_algorithm=enums.CryptographicAlgorithm.DES
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_random_iv(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different random IVs.
+        """
+        a = CryptographicParameters(random_iv=True)
+        b = CryptographicParameters(random_iv=False)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_iv_length(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different IV lengths.
+        """
+        a = CryptographicParameters(iv_length=96)
+        b = CryptographicParameters(iv_length=128)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_tag_length(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different tag lengths.
+        """
+        a = CryptographicParameters(tag_length=128)
+        b = CryptographicParameters(tag_length=256)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_fixed_field_length(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different fixed field lengths.
+        """
+        a = CryptographicParameters(fixed_field_length=32)
+        b = CryptographicParameters(fixed_field_length=40)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_invocation_field_length(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different invocation field
+        lengths.
+        """
+        a = CryptographicParameters(invocation_field_length=64)
+        b = CryptographicParameters(invocation_field_length=80)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_counter_length(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different counter lengths.
+        """
+        a = CryptographicParameters(counter_length=0)
+        b = CryptographicParameters(counter_length=32)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_initial_counter_value(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different counter values.
+        """
+        a = CryptographicParameters(initial_counter_value=0)
+        b = CryptographicParameters(initial_counter_value=1)
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CryptographicParameters structs with different types.
+        """
+        a = CryptographicParameters()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        CryptographicParameters structs with the same data.
+        """
+        a = CryptographicParameters()
+        b = CryptographicParameters()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+        b = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_block_cipher_mode(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different block cipher modes.
+        """
+        a = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC
+        )
+        b = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.GCM
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_padding_method(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different padding methods.
+        """
+        a = CryptographicParameters(padding_method=enums.PaddingMethod.NONE)
+        b = CryptographicParameters(padding_method=enums.PaddingMethod.PKCS5)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_hashing_algorithm(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different hashing algorithms.
+        """
+        a = CryptographicParameters(
+            hashing_algorithm=enums.HashingAlgorithm.MD5
+        )
+        b = CryptographicParameters(
+            hashing_algorithm=enums.HashingAlgorithm.SHA_256
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_key_role_type(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different key role types.
+        """
+        a = CryptographicParameters(key_role_type=enums.KeyRoleType.BDK)
+        b = CryptographicParameters(key_role_type=enums.KeyRoleType.KEK)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_digital_signature_algorithm(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different digital signature
+        algorithms.
+        """
+        a = CryptographicParameters(
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            DSA_WITH_SHA1
+        )
+        b = CryptographicParameters(
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            ECDSA_WITH_SHA1
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_cryptographic_algorithm(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different cryptographic
+        algorithms.
+        """
+        a = CryptographicParameters(
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES
+        )
+        b = CryptographicParameters(
+            cryptographic_algorithm=enums.CryptographicAlgorithm.DES
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_random_iv(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different random IVs.
+        """
+        a = CryptographicParameters(random_iv=True)
+        b = CryptographicParameters(random_iv=False)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_iv_length(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different IV lengths.
+        """
+        a = CryptographicParameters(iv_length=96)
+        b = CryptographicParameters(iv_length=128)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_tag_length(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different tag lengths.
+        """
+        a = CryptographicParameters(tag_length=128)
+        b = CryptographicParameters(tag_length=256)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_fixed_field_length(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different fixed field lengths.
+        """
+        a = CryptographicParameters(fixed_field_length=32)
+        b = CryptographicParameters(fixed_field_length=40)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_invocation_field_length(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different invocation field
+        lengths.
+        """
+        a = CryptographicParameters(invocation_field_length=64)
+        b = CryptographicParameters(invocation_field_length=80)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_counter_length(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different counter lengths.
+        """
+        a = CryptographicParameters(counter_length=0)
+        b = CryptographicParameters(counter_length=32)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_initial_counter_value(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different counter values.
+        """
+        a = CryptographicParameters(initial_counter_value=0)
+        b = CryptographicParameters(initial_counter_value=1)
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CryptographicParameters structs with different types.
+        """
+        a = CryptographicParameters()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a CryptographicParameters struct.
+        """
+        cryptographic_parameters = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+
+        expected = (
+            "CryptographicParameters("
+            "block_cipher_mode=BlockCipherMode.CBC, "
+            "padding_method=PaddingMethod.PKCS5, "
+            "hashing_algorithm=HashingAlgorithm.SHA_1, "
+            "key_role_type=KeyRoleType.KEK, "
+            "digital_signature_algorithm="
+            "DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION, "
+            "cryptographic_algorithm=CryptographicAlgorithm.AES, "
+            "random_iv=True, "
+            "iv_length=96, "
+            "tag_length=128, "
+            "fixed_field_length=32, "
+            "invocation_field_length=64, "
+            "counter_length=0, "
+            "initial_counter_value=1)"
+        )
+        observed = repr(cryptographic_parameters)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a GetAttributeList response payload.
+        """
+        cryptographic_parameters = CryptographicParameters(
+            block_cipher_mode=enums.BlockCipherMode.CBC,
+            padding_method=enums.PaddingMethod.PKCS5,
+            hashing_algorithm=enums.HashingAlgorithm.SHA_1,
+            key_role_type=enums.KeyRoleType.KEK,
+            digital_signature_algorithm=enums.DigitalSignatureAlgorithm.
+            SHA256_WITH_RSA_ENCRYPTION,
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            random_iv=True,
+            iv_length=96,
+            tag_length=128,
+            fixed_field_length=32,
+            invocation_field_length=64,
+            counter_length=0,
+            initial_counter_value=1
+        )
+
+        expected = str({
+            'block_cipher_mode': enums.BlockCipherMode.CBC,
+            'padding_method': enums.PaddingMethod.PKCS5,
+            'hashing_algorithm': enums.HashingAlgorithm.SHA_1,
+            'key_role_type': enums.KeyRoleType.KEK,
+            'digital_signature_algorithm':
+                enums.DigitalSignatureAlgorithm.SHA256_WITH_RSA_ENCRYPTION,
+            'cryptographic_algorithm': enums.CryptographicAlgorithm.AES,
+            'random_iv': True,
+            'iv_length': 96,
+            'tag_length': 128,
+            'fixed_field_length': 32,
+            'invocation_field_length': 64,
+            'counter_length': 0,
+            'initial_counter_value': 1
+        })
+        observed = str(cryptographic_parameters)
+
+        self.assertEqual(expected, observed)

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -93,35 +93,55 @@ class TestAttributeValueFactory(testtools.TestCase):
             'digital_signature_algorithm':
                 enums.DigitalSignatureAlgorithm.ECDSA_WITH_SHA512,
             'cryptographic_algorithm':
-                enums.CryptographicAlgorithm.HMAC_SHA512}
-        params = self.factory.create_attribute_value(
-            enums.AttributeType.CRYPTOGRAPHIC_PARAMETERS, value)
+                enums.CryptographicAlgorithm.HMAC_SHA512,
+            'random_iv': True,
+            'iv_length': 96,
+            'tag_length': None,
+            'fixed_field_length': 32,
+            'invocation_field_length': 64,
+            'counter_length': None,
+            'initial_counter_value': 1
+        }
+        cryptographic_parameters = self.factory.create_attribute_value(
+            enums.AttributeType.CRYPTOGRAPHIC_PARAMETERS,
+            value
+        )
 
-        # TODO (peter-hamilton): Update assertEquals after structure changes
-        self.assertIsInstance(params, attributes.CryptographicParameters)
+        self.assertIsInstance(
+            cryptographic_parameters,
+            attributes.CryptographicParameters
+        )
         self.assertEqual(
-            attributes.CryptographicParameters.BlockCipherMode(
-                enums.BlockCipherMode.NIST_KEY_WRAP),
-            params.block_cipher_mode)
+            enums.BlockCipherMode.NIST_KEY_WRAP,
+            cryptographic_parameters.block_cipher_mode
+        )
         self.assertEqual(
-            attributes.CryptographicParameters.PaddingMethod(
-                enums.PaddingMethod.ANSI_X9_23),
-            params.padding_method)
+            enums.PaddingMethod.ANSI_X9_23,
+            cryptographic_parameters.padding_method
+        )
         self.assertEqual(
-            attributes.CryptographicParameters.KeyRoleType(
-                enums.KeyRoleType.KEK),
-            params.key_role_type)
+            enums.KeyRoleType.KEK,
+            cryptographic_parameters.key_role_type
+        )
         self.assertEqual(
-            attributes.HashingAlgorithm(enums.HashingAlgorithm.SHA_512),
-            params.hashing_algorithm)
+            enums.HashingAlgorithm.SHA_512,
+            cryptographic_parameters.hashing_algorithm
+        )
         self.assertEqual(
-            attributes.CryptographicParameters.DigitalSignatureAlgorithm(
-                enums.DigitalSignatureAlgorithm.ECDSA_WITH_SHA512),
-            params.digital_signature_algorithm)
+            enums.DigitalSignatureAlgorithm.ECDSA_WITH_SHA512,
+            cryptographic_parameters.digital_signature_algorithm
+        )
         self.assertEqual(
-            attributes.CryptographicAlgorithm(
-                enums.CryptographicAlgorithm.HMAC_SHA512),
-            params.cryptographic_algorithm)
+            enums.CryptographicAlgorithm.HMAC_SHA512,
+            cryptographic_parameters.cryptographic_algorithm
+        )
+        self.assertEqual(True, cryptographic_parameters.random_iv)
+        self.assertEqual(96, cryptographic_parameters.iv_length)
+        self.assertEqual(None, cryptographic_parameters.tag_length)
+        self.assertEqual(32, cryptographic_parameters.fixed_field_length)
+        self.assertEqual(64, cryptographic_parameters.invocation_field_length)
+        self.assertEqual(None, cryptographic_parameters.counter_length)
+        self.assertEqual(1, cryptographic_parameters.initial_counter_value)
 
     def test_create_cryptographic_domain_parameters(self):
         """

--- a/kmip/tests/unit/core/messages/payloads/test_mac.py
+++ b/kmip/tests/unit/core/messages/payloads/test_mac.py
@@ -31,8 +31,8 @@ class TestMACRequestPayload(TestCase):
         self.unique_identifier = attributes.UniqueIdentifier(value='1')
         self.cryptographic_parameters = \
             attributes.CryptographicParameters(
-                cryptographic_algorithm=attributes.CryptographicAlgorithm(
-                    enums.CryptographicAlgorithm.HMAC_SHA512)
+                cryptographic_algorithm=enums.CryptographicAlgorithm.
+                HMAC_SHA512
             )
         self.data = objects.Data(
             value=(b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B'

--- a/kmip/tests/unit/core/messages/test_messages.py
+++ b/kmip/tests/unit/core/messages/test_messages.py
@@ -1077,13 +1077,13 @@ class TestRequestMessage(TestCase):
         cryptographic_algorithm = parameters_attribute.cryptographic_algorithm
         msg = "Bad cryptographic algorithm type: expected {0}, received {1}"
         self.assertIsInstance(cryptographic_algorithm,
-                              attr.CryptographicAlgorithm,
-                              msg.format(attr.CryptographicAlgorithm,
+                              enums.CryptographicAlgorithm,
+                              msg.format(enums.CryptographicAlgorithm,
                                          type(cryptographic_algorithm)))
         msg = "Bad cryptographic algorithm value: expected {0}, received {1}"
-        self.assertEquals(cryptographic_algorithm.value,
+        self.assertEquals(cryptographic_algorithm,
                           enums.CryptographicAlgorithm.HMAC_SHA512,
-                          msg.format(cryptographic_algorithm.value,
+                          msg.format(cryptographic_algorithm,
                                      enums.CryptographicAlgorithm.HMAC_SHA512))
 
         data = request_payload.data
@@ -1114,8 +1114,7 @@ class TestRequestMessage(TestCase):
                    b'\x0C\x0D\x0E\x0F')
         )
         parameters_attribute = attr.CryptographicParameters(
-            cryptographic_algorithm=attr.
-            CryptographicAlgorithm(enums.CryptographicAlgorithm.HMAC_SHA512)
+            cryptographic_algorithm=enums.CryptographicAlgorithm.HMAC_SHA512
         )
         request_payload = mac.MACRequestPayload(
             unique_identifier=uuid,

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -5157,8 +5157,7 @@ class TestKmipEngine(testtools.TestCase):
         uuid = str(obj.unique_identifier)
 
         cryptographic_parameters = attributes.CryptographicParameters(
-            cryptographic_algorithm=attributes.
-            CryptographicAlgorithm(algorithm_b)
+            cryptographic_algorithm=algorithm_b
         )
 
         # Verify when cryptographic_parameters is specified in request
@@ -5226,8 +5225,8 @@ class TestKmipEngine(testtools.TestCase):
         uuid_no_algorithm = str(obj_no_algorithm.unique_identifier)
 
         cryptographic_parameters = attributes.CryptographicParameters(
-            cryptographic_algorithm=attributes.
-            CryptographicAlgorithm(algorithm))
+            cryptographic_algorithm=algorithm
+        )
 
         payload_no_key = mac.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid_no_key),
@@ -5303,8 +5302,7 @@ class TestKmipEngine(testtools.TestCase):
         uuid = str(obj.unique_identifier)
 
         cryptographic_parameters = attributes.CryptographicParameters(
-            cryptographic_algorithm=attributes.
-            CryptographicAlgorithm(algorithm_b)
+            cryptographic_algorithm=algorithm_b
         )
 
         # Verify when cryptographic_parameters is specified in request
@@ -5352,8 +5350,7 @@ class TestKmipEngine(testtools.TestCase):
         uuid = str(obj.unique_identifier)
 
         cryptographic_parameters = attributes.CryptographicParameters(
-            cryptographic_algorithm=attributes.
-            CryptographicAlgorithm(algorithm_b)
+            cryptographic_algorithm=algorithm_b
         )
 
         # Verify when cryptographic_parameters is specified in request

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -16,8 +16,7 @@
 from testtools import TestCase
 
 from kmip.core.attributes import PrivateKeyUniqueIdentifier
-from kmip.core.attributes import CryptographicParameters, \
-                                 CryptographicAlgorithm
+from kmip.core.attributes import CryptographicParameters
 
 
 from kmip.core.enums import AuthenticationSuite
@@ -786,8 +785,7 @@ class TestKMIPClient(TestCase):
         uuid = '1'
 
         cryptographic_parameters = CryptographicParameters(
-            cryptographic_algorithm=CryptographicAlgorithm(
-                CryptographicAlgorithmEnum.HMAC_SHA512)
+            cryptographic_algorithm=CryptographicAlgorithmEnum.HMAC_SHA512
         )
 
         self.client._send_message.side_effect = verify_request


### PR DESCRIPTION
This change updates the CryptographicParameters struct, removing the primitive class wrappers that it used to use for attribute values and replacing them with struct properties that internally manage the primitive objects directly. This gutting and regutting necessitates cascading changes to every part of the library that used these internal primitive class wrappers, including unit tests, client and client tests, and attribute factory handlers. All of these have been updated to reflect the correct usage of the CryptographicParameters struct.

This change also adds in additional attribute members for the CryptographicParameters struct to bring it up to spec with KMIP 1.2.