### PR TITLE
Add Encrypt operation support to the server

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -44,6 +44,7 @@ from kmip.core.messages.payloads import create
 from kmip.core.messages.payloads import create_key_pair
 from kmip.core.messages.payloads import destroy
 from kmip.core.messages.payloads import discover_versions
+from kmip.core.messages.payloads import encrypt
 from kmip.core.messages.payloads import get
 from kmip.core.messages.payloads import get_attributes
 from kmip.core.messages.payloads import get_attribute_list
@@ -980,6 +981,8 @@ class KmipEngine(object):
             return self._process_query(payload)
         elif operation == enums.Operation.DISCOVER_VERSIONS:
             return self._process_discover_versions(payload)
+        elif operation == enums.Operation.ENCRYPT:
+            return self._process_encrypt(payload)
         elif operation == enums.Operation.MAC:
             return self._process_mac(payload)
         else:
@@ -1633,6 +1636,7 @@ class KmipEngine(object):
                 ])
             if self._protocol_version >= contents.ProtocolVersion.create(1, 2):
                 operations.extend([
+                    contents.Operation(enums.Operation.ENCRYPT),
                     contents.Operation(enums.Operation.MAC)
                 ])
 
@@ -1677,6 +1681,69 @@ class KmipEngine(object):
             protocol_versions=supported_versions
         )
 
+        return response_payload
+
+    @_kmip_version_supported('1.2')
+    def _process_encrypt(self, payload):
+        self._logger.info("Processing operation: Encrypt")
+
+        unique_identifier = self._id_placeholder
+        if payload.unique_identifier:
+            unique_identifier = payload.unique_identifier
+
+        # The KMIP spec does not indicate that the Encrypt operation should
+        # have it's own operation policy entry. Rather, the cryptographic
+        # usage mask should be used to determine if the object can be used
+        # to encrypt data (see below).
+        managed_object = self._get_object_with_access_controls(
+            unique_identifier,
+            enums.Operation.GET
+        )
+
+        cryptographic_parameters = payload.cryptographic_parameters
+        if cryptographic_parameters is None:
+            # TODO (peter-hamilton): Pull the cryptographic parameters from
+            # the attributes associated with the encryption key.
+            raise exceptions.InvalidField(
+                "The cryptographic parameters must be specified."
+            )
+
+        # TODO (peter-hamilton): Check the usage limitations for the key to
+        # confirm that it can be used for this operation.
+
+        if managed_object._object_type != enums.ObjectType.SYMMETRIC_KEY:
+            raise exceptions.PermissionDenied(
+                "The requested encryption key is not a symmetric key. "
+                "Only symmetric encryption is currently supported."
+            )
+
+        if managed_object.state != enums.State.ACTIVE:
+            raise exceptions.PermissionDenied(
+                "The encryption key must be in the Active state to be used "
+                "for encryption."
+            )
+
+        if enums.CryptographicUsageMask.ENCRYPT not in \
+           managed_object.cryptographic_usage_masks:
+                raise exceptions.PermissionDenied(
+                    "The Encrypt bit must be set in the encryption key's "
+                    "cryptographic usage mask."
+                )
+
+        result = self._cryptography_engine.encrypt(
+            cryptographic_parameters.cryptographic_algorithm,
+            managed_object.value,
+            payload.data,
+            cipher_mode=cryptographic_parameters.block_cipher_mode,
+            padding_method=cryptographic_parameters.padding_method,
+            iv_nonce=payload.iv_counter_nonce
+        )
+
+        response_payload = encrypt.EncryptResponsePayload(
+            unique_identifier,
+            result.get('cipher_text'),
+            result.get('iv_nonce')
+        )
         return response_payload
 
     @_kmip_version_supported('1.2')


### PR DESCRIPTION
This change adds the Encrypt operation to the server. Support is currently limited to symmetric encryption only. The encryption key used with the operation must be in the Active state and it must have the Encrypt bit set in its cryptographic usage mask.