### PR TITLE
Update requirements to match required features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=1.1
+cryptography>=1.3
 enum34
 six>=1.9.0
 sqlalchemy>=1.0


### PR DESCRIPTION
This change bumps the required version for cryptography to match what's currently needed by the software server.

Closes #301