### PR TITLE
Update the MACSignatureKeyInformation struct

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -815,21 +815,160 @@ class EncryptionKeyInformation(Struct):
         })
 
 
-class MACSignatureKeyInformation(KeyInformation):
+class MACSignatureKeyInformation(primitives.Struct):
+    """
+    A set of values detailing how an MAC/signed value was MAC/signed.
+    """
 
     def __init__(self,
                  unique_identifier=None,
-                 cryptographic_parameters=None,
-                 tag=Tags.MAC_SIGNATURE_KEY_INFORMATION):
+                 cryptographic_parameters=None):
+        """
+        Construct a MACSignatureKeyInformation struct.
+
+        Args:
+            unique_identifier (string): The ID of the managed object (e.g.,
+                a symmetric key) used for MAC/signing. Required for encoding
+                and decoding.
+            cryptographic_parameters (CryptographicParameters): A
+                CryptographicParameters struct containing the settings for
+                the MAC/signing process. Optional, defaults to None. If not
+                included, the CryptographicParameters associated with the
+                managed object will be used instead.
+        """
         super(MACSignatureKeyInformation, self).__init__(
-            unique_identifier, cryptographic_parameters, tag)
+            tag=Tags.MAC_SIGNATURE_KEY_INFORMATION
+        )
 
-    def validate(self):
-        self.__validate()
+        self._unique_identifier = None
+        self._cryptographic_parameters = None
 
-    def __validate(self):
-        # TODO (peter-hamilton) Finish implementation.
-        pass
+        self.unique_identifier = unique_identifier
+        self.cryptographic_parameters = cryptographic_parameters
+
+    @property
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
+        else:
+            return None
+
+    @unique_identifier.setter
+    def unique_identifier(self, value):
+        if value is None:
+            self._unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Unique identifier must be a string.")
+
+    @property
+    def cryptographic_parameters(self):
+        return self._cryptographic_parameters
+
+    @cryptographic_parameters.setter
+    def cryptographic_parameters(self, value):
+        if value is None:
+            self._cryptographic_parameters = None
+        elif isinstance(value, CryptographicParameters):
+            self._cryptographic_parameters = value
+        else:
+            raise TypeError(
+                "Cryptographic parameters must be a CryptographicParameters "
+                "struct."
+            )
+
+    def read(self, input_stream):
+        """
+        Read the data encoding the MACSignatureKeyInformation struct and
+        decode it into its constituent parts.
+
+        Args:
+            input_stream (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
+        """
+        super(MACSignatureKeyInformation, self).read(input_stream)
+        local_stream = BytearrayStream(input_stream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
+            self._unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            self._unique_identifier.read(local_stream)
+        else:
+            raise ValueError(
+                "Invalid struct missing the unique identifier attribute."
+            )
+
+        if self.is_tag_next(
+                enums.Tags.CRYPTOGRAPHIC_PARAMETERS,
+                local_stream
+        ):
+            self._cryptographic_parameters = CryptographicParameters()
+            self._cryptographic_parameters.read(local_stream)
+
+        self.is_oversized(local_stream)
+
+    def write(self, output_stream):
+        """
+        Write the data encoding the MACSignatureKeyInformation struct to a
+        stream.
+
+        Args:
+            output_stream (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
+        """
+        local_stream = BytearrayStream()
+
+        if self._unique_identifier:
+            self._unique_identifier.write(local_stream)
+        else:
+            raise ValueError(
+                "Invalid struct missing the unique identifier attribute."
+            )
+
+        if self._cryptographic_parameters:
+            self._cryptographic_parameters.write(local_stream)
+
+        self.length = local_stream.length()
+        super(MACSignatureKeyInformation, self).write(output_stream)
+        output_stream.write(local_stream.buffer)
+
+    def __eq__(self, other):
+        if isinstance(other, MACSignatureKeyInformation):
+            if self.unique_identifier != other.unique_identifier:
+                return False
+            elif self.cryptographic_parameters != \
+                    other.cryptographic_parameters:
+                return False
+            else:
+                return True
+
+    def __ne__(self, other):
+        if isinstance(other, MACSignatureKeyInformation):
+            return not self == other
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        args = ", ".join([
+            "unique_identifier='{0}'".format(self.unique_identifier),
+            "cryptographic_parameters={0}".format(
+                repr(self.cryptographic_parameters)
+            )
+        ])
+        return "MACSignatureKeyInformation({0})".format(args)
+
+    def __str__(self):
+        return str({
+            'unique_identifier': self.unique_identifier,
+            'cryptographic_parameters': self.cryptographic_parameters
+        })
 
 
 class KeyWrappingData(Struct):


### PR DESCRIPTION
This change updates the MACSignatureKeyInformation struct to conform with current library styles. This struct is used for key wrapping functionality and will be leveraged by future patches. Updated unit tests matching the new additions are included.