### PR TITLE
Fix key wrapping support in the cryptography engine

### DIFF
--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -805,7 +805,7 @@ class CryptographyEngine(api.CryptographicEngine):
     def wrap_key(self,
                  key_material,
                  wrapping_method,
-                 encryption_algorithm,
+                 key_wrap_algorithm,
                  encryption_key):
         """
         Args:
@@ -813,9 +813,9 @@ class CryptographyEngine(api.CryptographicEngine):
             wrapping_method (WrappingMethod): A WrappingMethod enumeration
                 specifying what wrapping technique to use to wrap the key
                 material. Required.
-            encryption_algorithm (CryptographicAlgorithm): A
-                CryptographicAlgorithm enumeration specifying the encryption
-                algorithm to use to encrypt the key material. Required.
+            key_wrap_algorithm (BlockCipherMode): A BlockCipherMode
+                enumeration specifying the key wrapping algorithm to use to
+                wrap the key material. Required.
             encryption_key (bytes): The bytes of the encryption key to use
                 to encrypt the key material. Required.
 
@@ -836,7 +836,7 @@ class CryptographyEngine(api.CryptographicEngine):
             ...         b'\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF'
             ...     )
             ...     wrapping_method=enums.WrappingMethod.ENCRYPT,
-            ...     encryption_algorithm=enums.CryptographicAlgorithm.AES,
+            ...     key_wrap_algorithm=enums.BlockCipherMode.NIST_KEY_WRAP,
             ...     encryption_key=(
             ...         b'\x00\x01\x02\x03\x04\x05\x06\x07'
             ...         b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -847,7 +847,7 @@ class CryptographyEngine(api.CryptographicEngine):
             \xd2\xcf\xe5'
         """
         if wrapping_method == enums.WrappingMethod.ENCRYPT:
-            if encryption_algorithm == enums.CryptographicAlgorithm.AES:
+            if key_wrap_algorithm == enums.BlockCipherMode.NIST_KEY_WRAP:
                 try:
                     wrapped_key = keywrap.aes_key_wrap(
                         encryption_key,
@@ -860,7 +860,7 @@ class CryptographyEngine(api.CryptographicEngine):
             else:
                 raise exceptions.InvalidField(
                     "Encryption algorithm '{0}' is not a supported key "
-                    "wrapping algorithm.".format(encryption_algorithm)
+                    "wrapping algorithm.".format(key_wrap_algorithm)
                 )
         else:
             raise exceptions.InvalidField(

--- a/kmip/tests/unit/services/server/crypto/test_engine.py
+++ b/kmip/tests/unit/services/server/crypto/test_engine.py
@@ -677,7 +677,7 @@ class TestCryptographyEngine(testtools.TestCase):
         """
         engine = crypto.CryptographyEngine()
 
-        args = (b'', 'invalid', enums.CryptographicAlgorithm.AES, b'')
+        args = (b'', 'invalid', enums.BlockCipherMode.NIST_KEY_WRAP, b'')
         self.assertRaisesRegexp(
             exceptions.InvalidField,
             "Wrapping method 'invalid' is not a supported key wrapping "
@@ -712,7 +712,7 @@ class TestCryptographyEngine(testtools.TestCase):
         args = (
             b'',
             enums.WrappingMethod.ENCRYPT,
-            enums.CryptographicAlgorithm.AES,
+            enums.BlockCipherMode.NIST_KEY_WRAP,
             b''
         )
         self.assertRaises(
@@ -1645,7 +1645,7 @@ def test_derive_key(derivation_parameters):
              b'\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1660,7 +1660,7 @@ def test_derive_key(derivation_parameters):
              b'\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1676,7 +1676,7 @@ def test_derive_key(derivation_parameters):
              b'\x88\x99\xAA\xBB\xCC\xDD\xEE\xFF'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1694,7 +1694,7 @@ def test_derive_key(derivation_parameters):
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1712,7 +1712,7 @@ def test_derive_key(derivation_parameters):
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1732,7 +1732,7 @@ def test_derive_key(derivation_parameters):
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
          ),
          'wrapping_method': enums.WrappingMethod.ENCRYPT,
-         'encryption_algorithm': enums.CryptographicAlgorithm.AES,
+         'key_wrap_algorithm': enums.BlockCipherMode.NIST_KEY_WRAP,
          'encryption_key': (
              b'\x00\x01\x02\x03\x04\x05\x06\x07'
              b'\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F'
@@ -1762,7 +1762,7 @@ def test_wrap_key(wrapping_parameters):
     result = engine.wrap_key(
         wrapping_parameters.get('key_material'),
         wrapping_parameters.get('wrapping_method'),
-        wrapping_parameters.get('encryption_algorithm'),
+        wrapping_parameters.get('key_wrap_algorithm'),
         wrapping_parameters.get('encryption_key')
     )
 


### PR DESCRIPTION
This change fixes key wrapping support in the cryptography engine. The original implementation used a CryptographicAlgorithm enum to determine what key wrapping algorithm to use for key wrapping. Closer inspection of the KMIP spec indicates that a BlockCipherMode enum should be used instead. The engine has been updated to reflect this change, as have the corresponding key wrapping unit tests.