### PR TITLE
Add server support for Getting wrapped keys

### DIFF
--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -57,6 +57,28 @@ class CryptographicFailure(KmipError):
         )
 
 
+class EncodingOptionError(KmipError):
+    """
+    An encoding error generated during key wrapping.
+
+    This error is generated during key wrapping when a requested encoding
+    option is not supported or is incompatible with other settings in the
+    key wrapping request (e.g., attributes are requested with the key but
+    the encoding does not support wrapping attributes with the key value).
+    """
+    def __init__(self, message):
+        """
+        Create an EncodingOptionError.
+
+        Args:
+            message (string): A string containing information about the error.
+        """
+        super(EncodingOptionError, self).__init__(
+            reason=enums.ResultReason.ENCODING_OPTION_ERROR,
+            message=message
+        )
+
+
 class IllegalOperation(KmipError):
     """
     An error generated when an improper operation is attempted. The operation


### PR DESCRIPTION
This change adds support for retrieving wrapped keys from the KMIP server. The only supported key wrapping algorithm currently is the AES-based NIST Key Wrap algorithm (RFC 3394). MAC/signing is not supported for key wrapping. Attribute-bundling with the wrapped key value is not supported. Wrapping of the entire key block TTLV encoding is not supported. Various additional error cases are included and checked for.

Unit tests covering the additions to Get are work-in-progress.