### PR TITLE
Fix bug generating detached instance errors in server tests

### DIFF
--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -83,7 +83,8 @@ class TestKmipEngine(testtools.TestCase):
         )
         sqltypes.Base.metadata.create_all(self.engine)
         self.session_factory = sqlalchemy.orm.sessionmaker(
-            bind=self.engine
+            bind=self.engine,
+            expire_on_commit=False
         )
 
         self.temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This patch fixes a bug that generates intermittent sqlalchemy DetachedInstanceErrors during the KMIP server engine unit test execution. Specifically, this fix disables instance expiration on commit for the sqlalchemy sessions used throughout the unit tests, allowing access to instance attributes even if the instance is detached from a session.

Fixes #312