### PR TITLE
Update payload management

### DIFF
--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -14,83 +14,64 @@
 # under the License.
 
 from kmip.core.factories.payloads import PayloadFactory
-
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import rekey_key_pair
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 
 class RequestPayloadFactory(PayloadFactory):
 
     def _create_create_payload(self):
-        return create.CreateRequestPayload()
+        return payloads.CreateRequestPayload()
 
     def _create_create_key_pair_payload(self):
-        return create_key_pair.CreateKeyPairRequestPayload()
+        return payloads.CreateKeyPairRequestPayload()
 
     def _create_register_payload(self):
-        return register.RegisterRequestPayload()
+        return payloads.RegisterRequestPayload()
 
     def _create_derive_key_payload(self):
-        return derive_key.DeriveKeyRequestPayload()
+        return payloads.DeriveKeyRequestPayload()
 
     def _create_rekey_key_pair_payload(self):
-        return rekey_key_pair.RekeyKeyPairRequestPayload()
+        return payloads.RekeyKeyPairRequestPayload()
 
     def _create_locate_payload(self):
-        return locate.LocateRequestPayload()
+        return payloads.LocateRequestPayload()
 
     def _create_get_payload(self):
-        return get.GetRequestPayload()
+        return payloads.GetRequestPayload()
 
     def _create_get_attribute_list_payload(self):
-        return get_attribute_list.GetAttributeListRequestPayload()
+        return payloads.GetAttributeListRequestPayload()
 
     def _create_get_attributes_payload(self):
-        return get_attributes.GetAttributesRequestPayload()
+        return payloads.GetAttributesRequestPayload()
 
     def _create_destroy_payload(self):
-        return destroy.DestroyRequestPayload()
+        return payloads.DestroyRequestPayload()
 
     def _create_query_payload(self):
-        return query.QueryRequestPayload()
+        return payloads.QueryRequestPayload()
 
     def _create_discover_versions_payload(self):
-        return discover_versions.DiscoverVersionsRequestPayload()
+        return payloads.DiscoverVersionsRequestPayload()
 
     def _create_activate_payload(self):
-        return activate.ActivateRequestPayload()
+        return payloads.ActivateRequestPayload()
 
     def _create_revoke_payload(self):
-        return revoke.RevokeRequestPayload()
+        return payloads.RevokeRequestPayload()
 
     def _create_mac_payload(self):
-        return mac.MACRequestPayload()
+        return payloads.MACRequestPayload()
 
     def _create_encrypt_payload(self):
-        return encrypt.EncryptRequestPayload()
+        return payloads.EncryptRequestPayload()
 
     def _create_decrypt_payload(self):
-        return decrypt.DecryptRequestPayload()
+        return payloads.DecryptRequestPayload()
 
     def _create_sign_payload(self):
-        return sign.SignRequestPayload()
+        return payloads.SignRequestPayload()
 
     def _create_signature_verify_payload(self):
-        return signature_verify.SignatureVerifyRequestPayload()
+        return payloads.SignatureVerifyRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -14,83 +14,64 @@
 # under the License.
 
 from kmip.core.factories.payloads import PayloadFactory
-
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import rekey_key_pair
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import mac
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
+from kmip.core.messages import payloads
 
 
 class ResponsePayloadFactory(PayloadFactory):
 
     def _create_create_payload(self):
-        return create.CreateResponsePayload()
+        return payloads.CreateResponsePayload()
 
     def _create_create_key_pair_payload(self):
-        return create_key_pair.CreateKeyPairResponsePayload()
+        return payloads.CreateKeyPairResponsePayload()
 
     def _create_register_payload(self):
-        return register.RegisterResponsePayload()
+        return payloads.RegisterResponsePayload()
 
     def _create_derive_key_payload(self):
-        return derive_key.DeriveKeyResponsePayload()
+        return payloads.DeriveKeyResponsePayload()
 
     def _create_rekey_key_pair_payload(self):
-        return rekey_key_pair.RekeyKeyPairResponsePayload()
+        return payloads.RekeyKeyPairResponsePayload()
 
     def _create_locate_payload(self):
-        return locate.LocateResponsePayload()
+        return payloads.LocateResponsePayload()
 
     def _create_get_payload(self):
-        return get.GetResponsePayload()
+        return payloads.GetResponsePayload()
 
     def _create_get_attribute_list_payload(self):
-        return get_attribute_list.GetAttributeListResponsePayload()
+        return payloads.GetAttributeListResponsePayload()
 
     def _create_get_attributes_payload(self):
-        return get_attributes.GetAttributesResponsePayload()
+        return payloads.GetAttributesResponsePayload()
 
     def _create_destroy_payload(self):
-        return destroy.DestroyResponsePayload()
+        return payloads.DestroyResponsePayload()
 
     def _create_query_payload(self):
-        return query.QueryResponsePayload()
+        return payloads.QueryResponsePayload()
 
     def _create_discover_versions_payload(self):
-        return discover_versions.DiscoverVersionsResponsePayload()
+        return payloads.DiscoverVersionsResponsePayload()
 
     def _create_activate_payload(self):
-        return activate.ActivateResponsePayload()
+        return payloads.ActivateResponsePayload()
 
     def _create_revoke_payload(self):
-        return revoke.RevokeResponsePayload()
+        return payloads.RevokeResponsePayload()
 
     def _create_mac_payload(self):
-        return mac.MACResponsePayload()
+        return payloads.MACResponsePayload()
 
     def _create_encrypt_payload(self):
-        return encrypt.EncryptResponsePayload()
+        return payloads.EncryptResponsePayload()
 
     def _create_decrypt_payload(self):
-        return decrypt.DecryptResponsePayload()
+        return payloads.DecryptResponsePayload()
 
     def _create_sign_payload(self):
-        return sign.SignResponsePayload()
+        return payloads.SignResponsePayload()
 
     def _create_signature_verify_payload(self):
-        return signature_verify.SignatureVerifyResponsePayload()
+        return payloads.SignatureVerifyResponsePayload()

--- a/kmip/core/messages/payloads/__init__.py
+++ b/kmip/core/messages/payloads/__init__.py
@@ -13,4 +13,121 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__all__ = ['create', 'destroy', 'get', 'locate', 'register']
+from kmip.core.messages.payloads.activate import (
+    ActivateRequestPayload,
+    ActivateResponsePayload
+)
+from kmip.core.messages.payloads.create import (
+    CreateRequestPayload,
+    CreateResponsePayload
+)
+from kmip.core.messages.payloads.create_key_pair import (
+    CreateKeyPairRequestPayload,
+    CreateKeyPairResponsePayload
+)
+from kmip.core.messages.payloads.decrypt import (
+    DecryptRequestPayload,
+    DecryptResponsePayload
+)
+from kmip.core.messages.payloads.derive_key import (
+    DeriveKeyRequestPayload,
+    DeriveKeyResponsePayload
+)
+from kmip.core.messages.payloads.destroy import (
+    DestroyRequestPayload,
+    DestroyResponsePayload
+)
+from kmip.core.messages.payloads.discover_versions import (
+    DiscoverVersionsRequestPayload,
+    DiscoverVersionsResponsePayload
+)
+from kmip.core.messages.payloads.encrypt import (
+    EncryptRequestPayload,
+    EncryptResponsePayload
+)
+from kmip.core.messages.payloads.get import (
+    GetRequestPayload,
+    GetResponsePayload
+)
+from kmip.core.messages.payloads.get_attribute_list import (
+    GetAttributeListRequestPayload,
+    GetAttributeListResponsePayload
+)
+from kmip.core.messages.payloads.get_attributes import (
+    GetAttributesRequestPayload,
+    GetAttributesResponsePayload
+)
+from kmip.core.messages.payloads.locate import (
+    LocateRequestPayload,
+    LocateResponsePayload
+)
+from kmip.core.messages.payloads.mac import (
+    MACRequestPayload,
+    MACResponsePayload
+)
+from kmip.core.messages.payloads.query import (
+    QueryRequestPayload,
+    QueryResponsePayload
+)
+from kmip.core.messages.payloads.register import (
+    RegisterRequestPayload,
+    RegisterResponsePayload
+)
+from kmip.core.messages.payloads.rekey_key_pair import (
+    RekeyKeyPairRequestPayload,
+    RekeyKeyPairResponsePayload
+)
+from kmip.core.messages.payloads.revoke import (
+    RevokeRequestPayload,
+    RevokeResponsePayload
+)
+from kmip.core.messages.payloads.sign import (
+    SignRequestPayload,
+    SignResponsePayload
+)
+from kmip.core.messages.payloads.signature_verify import (
+    SignatureVerifyRequestPayload,
+    SignatureVerifyResponsePayload
+)
+
+
+__all__ = [
+    "ActivateRequestPayload",
+    "ActivateResponsePayload",
+    "CreateRequestPayload",
+    "CreateResponsePayload",
+    "CreateKeyPairRequestPayload",
+    "CreateKeyPairResponsePayload",
+    "DecryptRequestPayload",
+    "DecryptResponsePayload",
+    "DeriveKeyRequestPayload",
+    "DeriveKeyResponsePayload",
+    "DestroyRequestPayload",
+    "DestroyResponsePayload",
+    "DiscoverVersionsRequestPayload",
+    "DiscoverVersionsResponsePayload",
+    "EncryptRequestPayload",
+    "EncryptResponsePayload",
+    "GetRequestPayload",
+    "GetResponsePayload",
+    "GetAttributeListRequestPayload",
+    "GetAttributeListResponsePayload",
+    "GetAttributesRequestPayload",
+    "GetAttributesResponsePayload",
+    "LocateRequestPayload",
+    "LocateResponsePayload",
+    "MACRequestPayload",
+    "MACResponsePayload",
+    "QueryRequestPayload",
+    "QueryResponsePayload",
+    "RegisterRequestPayload",
+    "RegisterResponsePayload",
+    "RekeyKeyPairRequestPayload",
+    "RekeyKeyPairResponsePayload",
+    "RevokeRequestPayload",
+    "RevokeResponsePayload",
+    "SignRequestPayload",
+    "SignResponsePayload",
+    "SignatureVerifyRequestPayload",
+    "SignatureVerifyResponsePayload"
+]

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -48,25 +48,7 @@ from kmip.core.messages.contents import ProtocolVersion
 
 from kmip.core.messages import messages
 
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import rekey_key_pair
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 from kmip.services.server.kmip_protocol import KMIPProtocol
 
@@ -349,7 +331,7 @@ class KMIPProxy(KMIP):
                                      | context for the operation result.
         """
         operation = Operation(OperationEnum.DERIVE_KEY)
-        request_payload = derive_key.DeriveKeyRequestPayload(
+        request_payload = payloads.DeriveKeyRequestPayload(
             object_type=object_type,
             unique_identifiers=unique_identifiers,
             derivation_method=derivation_method,
@@ -563,7 +545,7 @@ class KMIPProxy(KMIP):
         """
         operation = Operation(OperationEnum.ENCRYPT)
 
-        request_payload = encrypt.EncryptRequestPayload(
+        request_payload = payloads.EncryptRequestPayload(
             unique_identifier=unique_identifier,
             data=data,
             cryptographic_parameters=cryptographic_parameters,
@@ -639,7 +621,7 @@ class KMIPProxy(KMIP):
         """
         operation = Operation(OperationEnum.DECRYPT)
 
-        request_payload = decrypt.DecryptRequestPayload(
+        request_payload = payloads.DecryptRequestPayload(
             unique_identifier=unique_identifier,
             data=data,
             cryptographic_parameters=cryptographic_parameters,
@@ -714,7 +696,7 @@ class KMIPProxy(KMIP):
         """
         operation = Operation(OperationEnum.SIGNATURE_VERIFY)
 
-        request_payload = signature_verify.SignatureVerifyRequestPayload(
+        request_payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=cryptographic_parameters,
             data=message,
@@ -781,7 +763,7 @@ class KMIPProxy(KMIP):
         """
         operation = Operation(OperationEnum.SIGN)
 
-        request_payload = sign.SignRequestPayload(
+        request_payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=cryptographic_parameters,
             data=data
@@ -831,7 +813,7 @@ class KMIPProxy(KMIP):
         if object_type is None:
             raise ValueError('object_type cannot be None')
 
-        req_pl = create.CreateRequestPayload(
+        req_pl = payloads.CreateRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute)
         batch_item = messages.RequestBatchItem(operation=operation,
@@ -867,7 +849,7 @@ class KMIPProxy(KMIP):
                                           private_key_template_attribute=None,
                                           public_key_template_attribute=None):
         operation = Operation(OperationEnum.CREATE_KEY_PAIR)
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template_attribute=common_template_attribute,
             private_key_template_attribute=private_key_template_attribute,
             public_key_template_attribute=public_key_template_attribute)
@@ -881,7 +863,7 @@ class KMIPProxy(KMIP):
                                          private_key_template_attribute=None,
                                          public_key_template_attribute=None):
         operation = Operation(OperationEnum.REKEY_KEY_PAIR)
-        payload = rekey_key_pair.RekeyKeyPairRequestPayload(
+        payload = payloads.RekeyKeyPairRequestPayload(
             private_key_uuid, offset,
             common_template_attribute=common_template_attribute,
             private_key_template_attribute=private_key_template_attribute,
@@ -892,7 +874,7 @@ class KMIPProxy(KMIP):
 
     def _build_query_batch_item(self, query_functions=None):
         operation = Operation(OperationEnum.QUERY)
-        payload = query.QueryRequestPayload(query_functions)
+        payload = payloads.QueryRequestPayload(query_functions)
         batch_item = messages.RequestBatchItem(
             operation=operation, request_payload=payload)
         return batch_item
@@ -903,7 +885,7 @@ class KMIPProxy(KMIP):
             attribute_names=None
     ):
         operation = Operation(OperationEnum.GET_ATTRIBUTES)
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             uuid,
             attribute_names
         )
@@ -915,7 +897,7 @@ class KMIPProxy(KMIP):
 
     def _build_get_attribute_list_batch_item(self, uid=None):
         operation = Operation(OperationEnum.GET_ATTRIBUTE_LIST)
-        payload = get_attribute_list.GetAttributeListRequestPayload(uid)
+        payload = payloads.GetAttributeListRequestPayload(uid)
         batch_item = messages.RequestBatchItem(
             operation=operation, request_payload=payload)
         return batch_item
@@ -923,7 +905,7 @@ class KMIPProxy(KMIP):
     def _build_discover_versions_batch_item(self, protocol_versions=None):
         operation = Operation(OperationEnum.DISCOVER_VERSIONS)
 
-        payload = discover_versions.DiscoverVersionsRequestPayload(
+        payload = payloads.DiscoverVersionsRequestPayload(
             protocol_versions)
 
         batch_item = messages.RequestBatchItem(
@@ -1084,7 +1066,7 @@ class KMIPProxy(KMIP):
         if key_wrapping_specification is not None:
             kws = objects.KeyWrappingSpecification(key_wrapping_specification)
 
-        req_pl = get.GetRequestPayload(
+        req_pl = payloads.GetRequestPayload(
             unique_identifier=unique_identifier,
             key_format_type=key_format_type,
             key_compression_type=key_compression_type,
@@ -1126,7 +1108,7 @@ class KMIPProxy(KMIP):
         if unique_identifier is not None:
             uuid = attr.UniqueIdentifier(unique_identifier)
 
-        payload = activate.ActivateRequestPayload(unique_identifier=uuid)
+        payload = payloads.ActivateRequestPayload(unique_identifier=uuid)
 
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=payload)
@@ -1159,7 +1141,7 @@ class KMIPProxy(KMIP):
         if unique_identifier is not None:
             uuid = attr.UniqueIdentifier(unique_identifier)
 
-        payload = destroy.DestroyRequestPayload(unique_identifier=uuid)
+        payload = payloads.DestroyRequestPayload(unique_identifier=uuid)
 
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=payload)
@@ -1194,7 +1176,7 @@ class KMIPProxy(KMIP):
         if unique_identifier is not None:
             uuid = attr.UniqueIdentifier(unique_identifier)
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=uuid,
             revocation_reason=reason,
             compromise_occurrence_date=compromise_occurrence_date)
@@ -1231,7 +1213,7 @@ class KMIPProxy(KMIP):
         if object_type is None:
             raise ValueError('object_type cannot be None')
 
-        req_pl = register.RegisterRequestPayload(
+        req_pl = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
             secret=secret)
@@ -1271,18 +1253,18 @@ class KMIPProxy(KMIP):
         objgrp = None
 
         if maximum_items is not None:
-            mxi = locate.LocateRequestPayload.MaximumItems(maximum_items)
+            mxi = payloads.LocateRequestPayload.MaximumItems(maximum_items)
         if storage_status_mask is not None:
             m = storage_status_mask
-            ssmask = locate.LocateRequestPayload.StorageStatusMask(m)
+            ssmask = payloads.LocateRequestPayload.StorageStatusMask(m)
         if object_group_member is not None:
             o = object_group_member
-            objgrp = locate.LocateRequestPayload.ObjectGroupMember(o)
+            objgrp = payloads.LocateRequestPayload.ObjectGroupMember(o)
 
-        payload = locate.LocateRequestPayload(maximum_items=mxi,
-                                              storage_status_mask=ssmask,
-                                              object_group_member=objgrp,
-                                              attributes=attributes)
+        payload = payloads.LocateRequestPayload(maximum_items=mxi,
+                                                storage_status_mask=ssmask,
+                                                object_group_member=objgrp,
+                                                attributes=attributes)
 
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=payload)
@@ -1315,7 +1297,7 @@ class KMIPProxy(KMIP):
              credential=None):
         operation = Operation(OperationEnum.MAC)
 
-        req_pl = mac.MACRequestPayload(
+        req_pl = payloads.MACRequestPayload(
             unique_identifier=attr.UniqueIdentifier(unique_identifier),
             cryptographic_parameters=cryptographic_parameters,
             data=objects.Data(data))

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -38,24 +38,7 @@ from kmip.core.factories import secrets
 from kmip.core.messages import contents
 from kmip.core.messages import messages
 
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import mac
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
+from kmip.core.messages import payloads
 
 from kmip.core import misc
 
@@ -1086,7 +1069,7 @@ class KmipEngine(object):
             )
         )
 
-        response_payload = create.CreateResponsePayload(
+        response_payload = payloads.CreateResponsePayload(
             object_type=payload.object_type,
             unique_identifier=attributes.UniqueIdentifier(
                 str(managed_object.unique_identifier)
@@ -1262,7 +1245,7 @@ class KmipEngine(object):
             )
         )
 
-        response_payload = create_key_pair.CreateKeyPairResponsePayload(
+        response_payload = payloads.CreateKeyPairResponsePayload(
             private_key_uuid=attributes.PrivateKeyUniqueIdentifier(
                 str(private_key.unique_identifier)
             ),
@@ -1332,7 +1315,7 @@ class KmipEngine(object):
             )
         )
 
-        response_payload = register.RegisterResponsePayload(
+        response_payload = payloads.RegisterResponsePayload(
             unique_identifier=attributes.UniqueIdentifier(
                 str(managed_object.unique_identifier)
             )
@@ -1521,7 +1504,7 @@ class KmipEngine(object):
         )
         self._id_placeholder = str(managed_object.unique_identifier)
 
-        response_payload = derive_key.DeriveKeyResponsePayload(
+        response_payload = payloads.DeriveKeyResponsePayload(
             unique_identifier=str(managed_object.unique_identifier)
         )
         return response_payload
@@ -1562,7 +1545,7 @@ class KmipEngine(object):
                             str(managed_object.unique_identifier))
                             for managed_object in managed_objects]
 
-        response_payload = locate.LocateResponsePayload(
+        response_payload = payloads.LocateResponsePayload(
             unique_identifiers=unique_identifiers
         )
 
@@ -1716,7 +1699,7 @@ class KmipEngine(object):
         else:
             core_secret = self._build_core_object(managed_object)
 
-        response_payload = get.GetResponsePayload(
+        response_payload = payloads.GetResponsePayload(
             object_type=managed_object._object_type,
             unique_identifier=unique_identifier,
             secret=core_secret
@@ -1742,7 +1725,7 @@ class KmipEngine(object):
             payload.attribute_names
         )
 
-        response_payload = get_attributes.GetAttributesResponsePayload(
+        response_payload = payloads.GetAttributesResponsePayload(
             unique_identifier=unique_identifier,
             attributes=attrs
         )
@@ -1771,7 +1754,7 @@ class KmipEngine(object):
         for object_attribute in object_attributes:
             attribute_names.append(object_attribute.attribute_name.value)
 
-        response_payload = get_attribute_list.GetAttributeListResponsePayload(
+        response_payload = payloads.GetAttributeListResponsePayload(
             unique_identifier=unique_identifier,
             attribute_names=attribute_names
         )
@@ -1809,7 +1792,7 @@ class KmipEngine(object):
         managed_object.state = enums.State.ACTIVE
         self._data_session.commit()
 
-        response_payload = activate.ActivateResponsePayload(
+        response_payload = payloads.ActivateResponsePayload(
             unique_identifier=attributes.UniqueIdentifier(unique_identifier)
         )
 
@@ -1864,7 +1847,7 @@ class KmipEngine(object):
                 managed_object.state = enums.State.DEACTIVATED
         self._data_session.commit()
 
-        response_payload = revoke.RevokeResponsePayload(
+        response_payload = payloads.RevokeResponsePayload(
             unique_identifier=attributes.UniqueIdentifier(unique_identifier)
         )
 
@@ -1904,7 +1887,7 @@ class KmipEngine(object):
             objects.ManagedObject.unique_identifier == unique_identifier
         ).delete()
 
-        response_payload = destroy.DestroyResponsePayload(
+        response_payload = payloads.DestroyResponsePayload(
             unique_identifier=attributes.UniqueIdentifier(unique_identifier)
         )
 
@@ -1968,7 +1951,7 @@ class KmipEngine(object):
         if enums.QueryFunction.QUERY_EXTENSION_MAP in queries:
             extensions = list()
 
-        response_payload = query.QueryResponsePayload(
+        response_payload = payloads.QueryResponsePayload(
             operations=operations,
             object_types=objects,
             vendor_identification=vendor_identification,
@@ -1991,7 +1974,7 @@ class KmipEngine(object):
         else:
             supported_versions = self._protocol_versions
 
-        response_payload = discover_versions.DiscoverVersionsResponsePayload(
+        response_payload = payloads.DiscoverVersionsResponsePayload(
             protocol_versions=supported_versions
         )
 
@@ -2053,7 +2036,7 @@ class KmipEngine(object):
             iv_nonce=payload.iv_counter_nonce
         )
 
-        response_payload = encrypt.EncryptResponsePayload(
+        response_payload = payloads.EncryptResponsePayload(
             unique_identifier,
             result.get('cipher_text'),
             result.get('iv_nonce')
@@ -2116,7 +2099,7 @@ class KmipEngine(object):
             iv_nonce=payload.iv_counter_nonce
         )
 
-        response_payload = decrypt.DecryptResponsePayload(
+        response_payload = payloads.DecryptResponsePayload(
             unique_identifier,
             result
         )
@@ -2184,7 +2167,7 @@ class KmipEngine(object):
         else:
             validity = enums.ValidityIndicator.INVALID
 
-        response_payload = signature_verify.SignatureVerifyResponsePayload(
+        response_payload = payloads.SignatureVerifyResponsePayload(
             unique_identifier=unique_identifier,
             validity_indicator=validity
         )
@@ -2256,7 +2239,7 @@ class KmipEngine(object):
             data
         )
 
-        response_payload = mac.MACResponsePayload(
+        response_payload = payloads.MACResponsePayload(
             unique_identifier=attributes.UniqueIdentifier(unique_identifier),
             mac_data=MACData(result)
         )
@@ -2312,7 +2295,7 @@ class KmipEngine(object):
             data=payload.data
         )
 
-        response_payload = sign.SignResponsePayload(
+        response_payload = payloads.SignResponsePayload(
             unique_identifier=unique_identifier,
             signature_data=result
         )

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -18,25 +18,7 @@ import testtools
 from kmip.core import enums
 from kmip.core.factories.payloads.request import RequestPayloadFactory
 
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import rekey_key_pair
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 
 class TestRequestPayloadFactory(testtools.TestCase):
@@ -57,25 +39,25 @@ class TestRequestPayloadFactory(testtools.TestCase):
 
     def test_create_create_payload(self):
         payload = self.factory.create(enums.Operation.CREATE)
-        self._test_payload_type(payload, create.CreateRequestPayload)
+        self._test_payload_type(payload, payloads.CreateRequestPayload)
 
     def test_create_create_key_pair_payload(self):
         payload = self.factory.create(enums.Operation.CREATE_KEY_PAIR)
         self._test_payload_type(
             payload,
-            create_key_pair.CreateKeyPairRequestPayload
+            payloads.CreateKeyPairRequestPayload
         )
 
     def test_create_register_payload(self):
         payload = self.factory.create(enums.Operation.REGISTER)
-        self._test_payload_type(payload, register.RegisterRequestPayload)
+        self._test_payload_type(payload, payloads.RegisterRequestPayload)
 
     def test_create_rekey_payload(self):
         self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
 
     def test_create_derive_key_payload(self):
         payload = self.factory.create(enums.Operation.DERIVE_KEY)
-        self._test_payload_type(payload, derive_key.DeriveKeyRequestPayload)
+        self._test_payload_type(payload, payloads.DeriveKeyRequestPayload)
 
     def test_create_certify_payload(self):
         self._test_not_implemented(
@@ -91,27 +73,27 @@ class TestRequestPayloadFactory(testtools.TestCase):
 
     def test_create_locate_payload(self):
         payload = self.factory.create(enums.Operation.LOCATE)
-        self._test_payload_type(payload, locate.LocateRequestPayload)
+        self._test_payload_type(payload, payloads.LocateRequestPayload)
 
     def test_create_check_payload(self):
         self._test_not_implemented(self.factory.create, enums.Operation.CHECK)
 
     def test_create_get_payload(self):
         payload = self.factory.create(enums.Operation.GET)
-        self._test_payload_type(payload, get.GetRequestPayload)
+        self._test_payload_type(payload, payloads.GetRequestPayload)
 
     def test_create_get_attributes_payload(self):
         payload = self.factory.create(enums.Operation.GET_ATTRIBUTES)
         self._test_payload_type(
             payload,
-            get_attributes.GetAttributesRequestPayload
+            payloads.GetAttributesRequestPayload
         )
 
     def test_create_get_attributes_list_payload(self):
         payload = self.factory.create(enums.Operation.GET_ATTRIBUTE_LIST)
         self._test_payload_type(
             payload,
-            get_attribute_list.GetAttributeListRequestPayload
+            payloads.GetAttributeListRequestPayload
         )
 
     def test_create_add_attribute_payload(self):
@@ -146,15 +128,15 @@ class TestRequestPayloadFactory(testtools.TestCase):
 
     def test_create_activate_payload(self):
         payload = self.factory.create(enums.Operation.ACTIVATE)
-        self._test_payload_type(payload, activate.ActivateRequestPayload)
+        self._test_payload_type(payload, payloads.ActivateRequestPayload)
 
     def test_create_revoke_payload(self):
         payload = self.factory.create(enums.Operation.REVOKE)
-        self._test_payload_type(payload, revoke.RevokeRequestPayload)
+        self._test_payload_type(payload, payloads.RevokeRequestPayload)
 
     def test_create_destroy_payload(self):
         payload = self.factory.create(enums.Operation.DESTROY)
-        self._test_payload_type(payload, destroy.DestroyRequestPayload)
+        self._test_payload_type(payload, payloads.DestroyRequestPayload)
 
     def test_create_archive_payload(self):
         self._test_not_implemented(
@@ -176,7 +158,7 @@ class TestRequestPayloadFactory(testtools.TestCase):
 
     def test_create_query_payload(self):
         payload = self.factory.create(enums.Operation.QUERY)
-        self._test_payload_type(payload, query.QueryRequestPayload)
+        self._test_payload_type(payload, payloads.QueryRequestPayload)
 
     def test_create_cancel_payload(self):
         self._test_not_implemented(
@@ -200,38 +182,38 @@ class TestRequestPayloadFactory(testtools.TestCase):
         payload = self.factory.create(enums.Operation.REKEY_KEY_PAIR)
         self._test_payload_type(
             payload,
-            rekey_key_pair.RekeyKeyPairRequestPayload
+            payloads.RekeyKeyPairRequestPayload
         )
 
     def test_create_discover_versions_payload(self):
         payload = self.factory.create(enums.Operation.DISCOVER_VERSIONS)
         self._test_payload_type(
             payload,
-            discover_versions.DiscoverVersionsRequestPayload
+            payloads.DiscoverVersionsRequestPayload
         )
 
     def test_create_encrypt_payload(self):
         payload = self.factory.create(enums.Operation.ENCRYPT)
-        self._test_payload_type(payload, encrypt.EncryptRequestPayload)
+        self._test_payload_type(payload, payloads.EncryptRequestPayload)
 
     def test_create_decrypt_payload(self):
         payload = self.factory.create(enums.Operation.DECRYPT)
-        self._test_payload_type(payload, decrypt.DecryptRequestPayload)
+        self._test_payload_type(payload, payloads.DecryptRequestPayload)
 
     def test_create_sign_payload(self):
         payload = self.factory.create(enums.Operation.SIGN)
-        self._test_payload_type(payload, sign.SignRequestPayload)
+        self._test_payload_type(payload, payloads.SignRequestPayload)
 
     def test_create_signature_verify_payload(self):
         payload = self.factory.create(enums.Operation.SIGNATURE_VERIFY)
         self._test_payload_type(
             payload,
-            signature_verify.SignatureVerifyRequestPayload
+            payloads.SignatureVerifyRequestPayload
         )
 
     def test_create_mac_payload(self):
         payload = self.factory.create(enums.Operation.MAC)
-        self._test_payload_type(payload, mac.MACRequestPayload)
+        self._test_payload_type(payload, payloads.MACRequestPayload)
 
     def test_create_mac_verify_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -18,25 +18,7 @@ import testtools
 from kmip.core import enums
 from kmip.core.factories.payloads.response import ResponsePayloadFactory
 
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import rekey_key_pair
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 
 class TestResponsePayloadFactory(testtools.TestCase):
@@ -57,25 +39,25 @@ class TestResponsePayloadFactory(testtools.TestCase):
 
     def test_create_create_payload(self):
         payload = self.factory.create(enums.Operation.CREATE)
-        self._test_payload_type(payload, create.CreateResponsePayload)
+        self._test_payload_type(payload, payloads.CreateResponsePayload)
 
     def test_create_create_key_pair_payload(self):
         payload = self.factory.create(enums.Operation.CREATE_KEY_PAIR)
         self._test_payload_type(
             payload,
-            create_key_pair.CreateKeyPairResponsePayload
+            payloads.CreateKeyPairResponsePayload
         )
 
     def test_create_register_payload(self):
         payload = self.factory.create(enums.Operation.REGISTER)
-        self._test_payload_type(payload, register.RegisterResponsePayload)
+        self._test_payload_type(payload, payloads.RegisterResponsePayload)
 
     def test_create_rekey_payload(self):
         self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
 
     def test_create_derive_key_payload(self):
         payload = self.factory.create(enums.Operation.DERIVE_KEY)
-        self._test_payload_type(payload, derive_key.DeriveKeyResponsePayload)
+        self._test_payload_type(payload, payloads.DeriveKeyResponsePayload)
 
     def test_create_certify_payload(self):
         self._test_not_implemented(
@@ -91,27 +73,27 @@ class TestResponsePayloadFactory(testtools.TestCase):
 
     def test_create_locate_payload(self):
         payload = self.factory.create(enums.Operation.LOCATE)
-        self._test_payload_type(payload, locate.LocateResponsePayload)
+        self._test_payload_type(payload, payloads.LocateResponsePayload)
 
     def test_create_check_payload(self):
         self._test_not_implemented(self.factory.create, enums.Operation.CHECK)
 
     def test_create_get_payload(self):
         payload = self.factory.create(enums.Operation.GET)
-        self._test_payload_type(payload, get.GetResponsePayload)
+        self._test_payload_type(payload, payloads.GetResponsePayload)
 
     def test_create_get_attributes_payload(self):
         payload = self.factory.create(enums.Operation.GET_ATTRIBUTES)
         self._test_payload_type(
             payload,
-            get_attributes.GetAttributesResponsePayload
+            payloads.GetAttributesResponsePayload
         )
 
     def test_create_get_attributes_list_payload(self):
         payload = self.factory.create(enums.Operation.GET_ATTRIBUTE_LIST)
         self._test_payload_type(
             payload,
-            get_attribute_list.GetAttributeListResponsePayload
+            payloads.GetAttributeListResponsePayload
         )
 
     def test_create_add_attribute_payload(self):
@@ -144,15 +126,15 @@ class TestResponsePayloadFactory(testtools.TestCase):
 
     def test_create_activate_payload(self):
         payload = self.factory.create(enums.Operation.ACTIVATE)
-        self._test_payload_type(payload, activate.ActivateResponsePayload)
+        self._test_payload_type(payload, payloads.ActivateResponsePayload)
 
     def test_create_revoke_payload(self):
         payload = self.factory.create(enums.Operation.REVOKE)
-        self._test_payload_type(payload, revoke.RevokeResponsePayload)
+        self._test_payload_type(payload, payloads.RevokeResponsePayload)
 
     def test_create_destroy_payload(self):
         payload = self.factory.create(enums.Operation.DESTROY)
-        self._test_payload_type(payload, destroy.DestroyResponsePayload)
+        self._test_payload_type(payload, payloads.DestroyResponsePayload)
 
     def test_create_archive_payload(self):
         self._test_not_implemented(
@@ -174,7 +156,7 @@ class TestResponsePayloadFactory(testtools.TestCase):
 
     def test_create_query_payload(self):
         payload = self.factory.create(enums.Operation.QUERY)
-        self._test_payload_type(payload, query.QueryResponsePayload)
+        self._test_payload_type(payload, payloads.QueryResponsePayload)
 
     def test_create_cancel_payload(self):
         self._test_not_implemented(
@@ -198,40 +180,40 @@ class TestResponsePayloadFactory(testtools.TestCase):
         payload = self.factory.create(enums.Operation.REKEY_KEY_PAIR)
         self._test_payload_type(
             payload,
-            rekey_key_pair.RekeyKeyPairResponsePayload
+            payloads.RekeyKeyPairResponsePayload
         )
 
     def test_create_discover_versions_payload(self):
         payload = self.factory.create(enums.Operation.DISCOVER_VERSIONS)
         self._test_payload_type(
             payload,
-            discover_versions.DiscoverVersionsResponsePayload
+            payloads.DiscoverVersionsResponsePayload
         )
 
     def test_create_encrypt_payload(self):
         payload = self.factory.create(enums.Operation.ENCRYPT)
-        self._test_payload_type(payload, encrypt.EncryptResponsePayload)
+        self._test_payload_type(payload, payloads.EncryptResponsePayload)
 
     def test_create_decrypt_payload(self):
         payload = self.factory.create(enums.Operation.DECRYPT)
-        self._test_payload_type(payload, decrypt.DecryptResponsePayload)
+        self._test_payload_type(payload, payloads.DecryptResponsePayload)
 
     def test_create_sign_payload(self):
         payload = self.factory.create(enums.Operation.SIGN)
-        self._test_payload_type(payload, sign.SignResponsePayload)
+        self._test_payload_type(payload, payloads.SignResponsePayload)
 
     def test_create_signature_verify_payload(self):
         payload = self.factory.create(enums.Operation.SIGNATURE_VERIFY)
         self._test_payload_type(
             payload,
-            signature_verify.SignatureVerifyResponsePayload
+            payloads.SignatureVerifyResponsePayload
         )
 
     def test_create_mac_payload(self):
         payload = self.factory.create(enums.Operation.MAC)
         self._test_payload_type(
             payload,
-            mac.MACResponsePayload
+            payloads.MACResponsePayload
         )
 
     def test_create_mac_verify_payload(self):

--- a/kmip/tests/unit/core/messages/payloads/test_activate.py
+++ b/kmip/tests/unit/core/messages/payloads/test_activate.py
@@ -18,7 +18,7 @@ from testtools import TestCase
 from kmip.core import utils
 from kmip.core import attributes
 
-from kmip.core.messages.payloads import activate
+from kmip.core.messages import payloads
 
 
 class TestActivateRequestPayload(TestCase):
@@ -49,14 +49,14 @@ class TestActivateRequestPayload(TestCase):
         Test that a ActivateRequestPayload object can be constructed with no
         specified value.
         """
-        activate.ActivateRequestPayload()
+        payloads.ActivateRequestPayload()
 
     def test_init_with_args(self):
         """
         Test that a ActivateRequestPayload object can be constructed with valid
         values.
         """
-        activate.ActivateRequestPayload(unique_identifier=self.uuid)
+        payloads.ActivateRequestPayload(unique_identifier=self.uuid)
 
     def test_validate_with_bad_uuid_type(self):
         """
@@ -65,14 +65,14 @@ class TestActivateRequestPayload(TestCase):
         """
         self.assertRaisesRegexp(
             TypeError, "invalid unique identifier",
-            activate.ActivateRequestPayload, "not-a-uuid")
+            payloads.ActivateRequestPayload, "not-a-uuid")
 
     def test_read_with_known_uuid(self):
         """
         Test that a ActivateRequestPayload object with known UUID can be read
         from a data stream.
         """
-        payload = activate.ActivateRequestPayload()
+        payload = payloads.ActivateRequestPayload()
         payload.read(self.encoding_a)
         expected = '668eff89-3010-4258-bc0e-8c402309c746'
         observed = payload.unique_identifier.value
@@ -88,7 +88,7 @@ class TestActivateRequestPayload(TestCase):
         written to a data stream.
         """
         stream = utils.BytearrayStream()
-        payload = activate.ActivateRequestPayload(self.uuid)
+        payload = payloads.ActivateRequestPayload(self.uuid)
         payload.write(stream)
 
         length_expected = len(self.encoding_a)
@@ -132,14 +132,14 @@ class TestActivateResponsePayload(TestCase):
         Test that a ActivateResponsePayload object can be constructed with no
         specified value.
         """
-        activate.ActivateResponsePayload()
+        payloads.ActivateResponsePayload()
 
     def test_init_with_args(self):
         """
         Test that a ActivateResponsePayload object can be constructed with
         valid values.
         """
-        activate.ActivateResponsePayload(unique_identifier=self.uuid)
+        payloads.ActivateResponsePayload(unique_identifier=self.uuid)
 
     def test_validate_with_invalid_uuid(self):
         """
@@ -148,14 +148,14 @@ class TestActivateResponsePayload(TestCase):
         """
         self.assertRaisesRegexp(
             TypeError, "invalid unique identifier",
-            activate.ActivateResponsePayload, "not-a-uuid")
+            payloads.ActivateResponsePayload, "not-a-uuid")
 
     def test_read_with_known_uuid(self):
         """
         Test that a ActivateResponsePayload object with known UUID can be read
         from a data stream.
         """
-        payload = activate.ActivateResponsePayload()
+        payload = payloads.ActivateResponsePayload()
         payload.read(self.encoding_a)
         expected = '668eff89-3010-4258-bc0e-8c402309c746'
         observed = payload.unique_identifier.value
@@ -171,7 +171,7 @@ class TestActivateResponsePayload(TestCase):
         written to a data stream.
         """
         stream = utils.BytearrayStream()
-        payload = activate.ActivateResponsePayload(self.uuid)
+        payload = payloads.ActivateResponsePayload(self.uuid)
         payload.write(stream)
 
         length_expected = len(self.encoding_a)

--- a/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
@@ -19,7 +19,7 @@ from kmip.core import attributes
 from kmip.core import objects
 from kmip.core import utils
 
-from kmip.core.messages.payloads import create_key_pair
+from kmip.core.messages import payloads
 
 
 class TestCreateKeyPairRequestPayload(TestCase):
@@ -44,10 +44,10 @@ class TestCreateKeyPairRequestPayload(TestCase):
         super(TestCreateKeyPairRequestPayload, self).tearDown()
 
     def test_init_with_none(self):
-        create_key_pair.CreateKeyPairRequestPayload()
+        payloads.CreateKeyPairRequestPayload()
 
     def test_init_with_args(self):
-        create_key_pair.CreateKeyPairRequestPayload(
+        payloads.CreateKeyPairRequestPayload(
             self.common_template_attribute,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -58,7 +58,7 @@ class TestCreateKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid common template attribute",
-            create_key_pair.CreateKeyPairRequestPayload, **kwargs)
+            payloads.CreateKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_private_key_template_attribute(self):
         kwargs = {'common_template_attribute': None,
@@ -66,7 +66,7 @@ class TestCreateKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key template attribute",
-            create_key_pair.CreateKeyPairRequestPayload, **kwargs)
+            payloads.CreateKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_public_key_template_attribute(self):
         kwargs = {'common_template_attribute': None,
@@ -74,7 +74,7 @@ class TestCreateKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': 'invalid'}
         self.assertRaises(
             TypeError, "invalid public key template attribute",
-            create_key_pair.CreateKeyPairRequestPayload, **kwargs)
+            payloads.CreateKeyPairRequestPayload, **kwargs)
 
     def _test_read(self, stream, payload, common_template_attribute,
                    private_key_template_attribute,
@@ -103,13 +103,13 @@ class TestCreateKeyPairRequestPayload(TestCase):
 
     def test_read_with_none(self):
         stream = self.encoding_empty
-        payload = create_key_pair.CreateKeyPairRequestPayload()
+        payload = payloads.CreateKeyPairRequestPayload()
 
         self._test_read(stream, payload, None, None, None)
 
     def test_read_with_args(self):
         stream = self.encoding_full
-        payload = create_key_pair.CreateKeyPairRequestPayload()
+        payload = payloads.CreateKeyPairRequestPayload()
 
         self._test_read(stream, payload, self.common_template_attribute,
                         self.private_key_template_attribute,
@@ -133,13 +133,13 @@ class TestCreateKeyPairRequestPayload(TestCase):
 
     def test_write_with_none(self):
         stream = utils.BytearrayStream()
-        payload = create_key_pair.CreateKeyPairRequestPayload()
+        payload = payloads.CreateKeyPairRequestPayload()
 
         self._test_write(stream, payload, self.encoding_empty)
 
     def test_write_with_args(self):
         stream = utils.BytearrayStream()
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             self.common_template_attribute,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -182,10 +182,10 @@ class TestCreateKeyPairResponsePayload(TestCase):
         super(TestCreateKeyPairResponsePayload, self).tearDown()
 
     def test_init_with_none(self):
-        create_key_pair.CreateKeyPairResponsePayload()
+        payloads.CreateKeyPairResponsePayload()
 
     def test_init_with_args(self):
-        create_key_pair.CreateKeyPairResponsePayload(
+        payloads.CreateKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -197,7 +197,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key unique identifier",
-            create_key_pair.CreateKeyPairResponsePayload, **kwargs)
+            payloads.CreateKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_public_key_unique_identifier(self):
         kwargs = {'private_key_uuid': None,
@@ -206,7 +206,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid public key unique identifier",
-            create_key_pair.CreateKeyPairResponsePayload, **kwargs)
+            payloads.CreateKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_private_key_template_attribute(self):
         kwargs = {'private_key_uuid': self.private_key_uuid,
@@ -215,7 +215,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key template attribute",
-            create_key_pair.CreateKeyPairResponsePayload, **kwargs)
+            payloads.CreateKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_public_key_template_attribute(self):
         kwargs = {'private_key_uuid': self.private_key_uuid,
@@ -224,7 +224,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid public key template attribute",
-            create_key_pair.CreateKeyPairResponsePayload, **kwargs)
+            payloads.CreateKeyPairResponsePayload, **kwargs)
 
     def _test_read(self, stream, payload, private_key_uuid, public_key_uuid,
                    private_key_template_attribute,
@@ -257,14 +257,14 @@ class TestCreateKeyPairResponsePayload(TestCase):
 
     def test_read_with_none(self):
         stream = self.encoding_empty
-        payload = create_key_pair.CreateKeyPairResponsePayload()
+        payload = payloads.CreateKeyPairResponsePayload()
 
         self._test_read(stream, payload, self.empty_private_key_uuid,
                         self.empty_public_key_uuid, None, None)
 
     def test_read_with_args(self):
         stream = self.encoding_full
-        payload = create_key_pair.CreateKeyPairResponsePayload(
+        payload = payloads.CreateKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -292,13 +292,13 @@ class TestCreateKeyPairResponsePayload(TestCase):
 
     def test_write_with_none(self):
         stream = utils.BytearrayStream()
-        payload = create_key_pair.CreateKeyPairResponsePayload()
+        payload = payloads.CreateKeyPairResponsePayload()
 
         self._test_write(stream, payload, self.encoding_empty)
 
     def test_write_with_args(self):
         stream = utils.BytearrayStream()
-        payload = create_key_pair.CreateKeyPairResponsePayload(
+        payload = payloads.CreateKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)

--- a/kmip/tests/unit/core/messages/payloads/test_decrypt.py
+++ b/kmip/tests/unit/core/messages/payloads/test_decrypt.py
@@ -19,7 +19,7 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import utils
 
-from kmip.core.messages.payloads import decrypt
+from kmip.core.messages import payloads
 
 
 class TestDecryptRequestPayload(testtools.TestCase):
@@ -98,7 +98,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a Decrypt request payload can be constructed with no
         arguments.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -110,7 +110,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a Decrypt request payload can be constructed with valid
         values
         """
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier='00000000-1111-2222-3333-444444444444',
             cryptographic_parameters=attributes.CryptographicParameters(),
             data=b'\x01\x02\x03',
@@ -133,7 +133,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the unique identifier of a Decrypt request payload.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -147,7 +147,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the cryptographic parameters of a Decrypt request payload.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         args = (payload, 'cryptographic_parameters', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -162,7 +162,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the data of a Decrypt request payload.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         args = (payload, 'data', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -176,7 +176,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the IV/counter/nonce of a Decrypt request payload.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         args = (payload, 'iv_counter_nonce', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -189,7 +189,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         Test that a Decrypt request payload can be read from a data stream.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -251,7 +251,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a Decrypt request payload can be read from a partial data
         stream containing the minimum required attributes.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -270,7 +270,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when a required Decrypt request
         payload attribute is missing from the payload encoding.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         args = (self.empty_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -283,7 +283,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         Test that a Decrypt request payload can be written to a data stream.
         """
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -315,7 +315,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a partially defined Decrypt request payload can be written
         to a data stream.
         """
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             data=b'\x01\x02\x03\x04\x05\x06\x07\x08'
         )
         stream = utils.BytearrayStream()
@@ -329,7 +329,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when a required Decrypt request
         payload attribute is missing when encoding the payload.
         """
-        payload = decrypt.DecryptRequestPayload()
+        payload = payloads.DecryptRequestPayload()
         stream = utils.BytearrayStream()
         args = (stream, )
         self.assertRaisesRegexp(
@@ -344,13 +344,13 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         Decrypt request payloads with the same data.
         """
-        a = decrypt.DecryptRequestPayload()
-        b = decrypt.DecryptRequestPayload()
+        a = payloads.DecryptRequestPayload()
+        b = payloads.DecryptRequestPayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -371,7 +371,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -401,10 +401,10 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt request payloads with different unique identifiers.
         """
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             unique_identifier='a'
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             unique_identifier='b'
         )
 
@@ -416,12 +416,12 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt request payloads with different cryptographic parameters.
         """
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC
             )
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 hashing_algorithm=enums.HashingAlgorithm.MD5
             )
@@ -435,8 +435,8 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt request payloads with different data.
         """
-        a = decrypt.DecryptRequestPayload(data=b'\x11')
-        b = decrypt.DecryptRequestPayload(data=b'\xFF')
+        a = payloads.DecryptRequestPayload(data=b'\x11')
+        b = payloads.DecryptRequestPayload(data=b'\xFF')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -446,8 +446,8 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt request payloads with different IV/counter/nonce values.
         """
-        a = decrypt.DecryptRequestPayload(iv_counter_nonce=b'\x22')
-        b = decrypt.DecryptRequestPayload(iv_counter_nonce=b'\xAA')
+        a = payloads.DecryptRequestPayload(iv_counter_nonce=b'\x22')
+        b = payloads.DecryptRequestPayload(iv_counter_nonce=b'\xAA')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -457,7 +457,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt request payloads with different types.
         """
-        a = decrypt.DecryptRequestPayload()
+        a = payloads.DecryptRequestPayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -468,13 +468,13 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         Decrypt request payloads with the same data.
         """
-        a = decrypt.DecryptRequestPayload()
-        b = decrypt.DecryptRequestPayload()
+        a = payloads.DecryptRequestPayload()
+        b = payloads.DecryptRequestPayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -495,7 +495,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -525,10 +525,10 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt request payloads with different unique identifiers.
         """
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             unique_identifier='a'
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             unique_identifier='b'
         )
 
@@ -540,12 +540,12 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt request payloads with different cryptographic parameters.
         """
-        a = decrypt.DecryptRequestPayload(
+        a = payloads.DecryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC
             )
         )
-        b = decrypt.DecryptRequestPayload(
+        b = payloads.DecryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 hashing_algorithm=enums.HashingAlgorithm.MD5
             )
@@ -559,8 +559,8 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt request payloads with different data.
         """
-        a = decrypt.DecryptRequestPayload(data=b'\x11')
-        b = decrypt.DecryptRequestPayload(data=b'\xFF')
+        a = payloads.DecryptRequestPayload(data=b'\x11')
+        b = payloads.DecryptRequestPayload(data=b'\xFF')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -570,8 +570,8 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt request payloads with different IV/counter/nonce values.
         """
-        a = decrypt.DecryptRequestPayload(iv_counter_nonce=b'\x22')
-        b = decrypt.DecryptRequestPayload(iv_counter_nonce=b'\xAA')
+        a = payloads.DecryptRequestPayload(iv_counter_nonce=b'\x22')
+        b = payloads.DecryptRequestPayload(iv_counter_nonce=b'\xAA')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -581,7 +581,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt request payloads with different types.
         """
-        a = decrypt.DecryptRequestPayload()
+        a = payloads.DecryptRequestPayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -591,7 +591,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         Test that repr can be applied to an Decrypt request payload.
         """
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -657,7 +657,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
             counter_length=0,
             initial_counter_value=1
         )
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=cryptographic_parameters,
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
@@ -724,7 +724,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that an Decrypt response payload can be constructed with no
         arguments.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.data)
@@ -734,7 +734,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that a Decrypt response payload can be constructed with valid
         values
         """
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='00000000-1111-2222-3333-444444444444',
             data=b'\x01\x02\x03'
         )
@@ -750,7 +750,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the unique identifier of a Decrypt response payload.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -764,7 +764,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the data of a Decrypt response payload.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
         args = (payload, 'data', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -777,7 +777,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         Test that a Decrypt response payload can be read from a data stream.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.data)
@@ -795,7 +795,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when required Decrypt response
         payload attributes are missing from the payload encoding.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
         args = (self.empty_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -804,7 +804,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
             *args
         )
 
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
         args = (self.incomplete_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -817,7 +817,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         Test that a Decrypt response payload can be written to a data stream.
         """
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
@@ -832,7 +832,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when required Decrypt response
         payload attributes are missing when encoding the payload.
         """
-        payload = decrypt.DecryptResponsePayload()
+        payload = payloads.DecryptResponsePayload()
         self.assertIsNone(payload.unique_identifier)
         stream = utils.BytearrayStream()
         args = (stream, )
@@ -843,7 +843,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
             *args
         )
 
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959'
         )
         stream = utils.BytearrayStream()
@@ -860,17 +860,17 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         Decrypt response payloads with the same data.
         """
-        a = decrypt.DecryptResponsePayload()
-        b = decrypt.DecryptResponsePayload()
+        a = payloads.DecryptResponsePayload()
+        b = payloads.DecryptResponsePayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = decrypt.DecryptResponsePayload(
+        a = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
-        b = decrypt.DecryptResponsePayload(
+        b = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
@@ -883,10 +883,10 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt response payloads with different unique identifiers.
         """
-        a = decrypt.DecryptResponsePayload(
+        a = payloads.DecryptResponsePayload(
             unique_identifier='a'
         )
-        b = decrypt.DecryptResponsePayload(
+        b = payloads.DecryptResponsePayload(
             unique_identifier='b'
         )
 
@@ -898,8 +898,8 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt response payloads with different data.
         """
-        a = decrypt.DecryptResponsePayload(data=b'\x11')
-        b = decrypt.DecryptResponsePayload(data=b'\xFF')
+        a = payloads.DecryptResponsePayload(data=b'\x11')
+        b = payloads.DecryptResponsePayload(data=b'\xFF')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -909,7 +909,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Decrypt response payloads with different types.
         """
-        a = decrypt.DecryptResponsePayload()
+        a = payloads.DecryptResponsePayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -920,17 +920,17 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         Decrypt response payloads with the same data.
         """
-        a = decrypt.DecryptResponsePayload()
-        b = decrypt.DecryptResponsePayload()
+        a = payloads.DecryptResponsePayload()
+        b = payloads.DecryptResponsePayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = decrypt.DecryptResponsePayload(
+        a = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
-        b = decrypt.DecryptResponsePayload(
+        b = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
@@ -943,10 +943,10 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt response payloads with different unique identifiers.
         """
-        a = decrypt.DecryptResponsePayload(
+        a = payloads.DecryptResponsePayload(
             unique_identifier='a'
         )
-        b = decrypt.DecryptResponsePayload(
+        b = payloads.DecryptResponsePayload(
             unique_identifier='b'
         )
 
@@ -958,8 +958,8 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt response payloads with different data.
         """
-        a = decrypt.DecryptResponsePayload(data=b'\x11')
-        b = decrypt.DecryptResponsePayload(data=b'\xFF')
+        a = payloads.DecryptResponsePayload(data=b'\x11')
+        b = payloads.DecryptResponsePayload(data=b'\xFF')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -969,7 +969,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Decrypt response payloads with different types.
         """
-        a = decrypt.DecryptResponsePayload()
+        a = payloads.DecryptResponsePayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -979,7 +979,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         Test that repr can be applied to a Decrypt response payload.
         """
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )
@@ -996,7 +996,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         Test that str can be applied to a Decrypt response payload
         """
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF'
         )

--- a/kmip/tests/unit/core/messages/payloads/test_derive_key.py
+++ b/kmip/tests/unit/core/messages/payloads/test_derive_key.py
@@ -21,7 +21,7 @@ from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
 
-from kmip.core.messages.payloads import derive_key
+from kmip.core.messages import payloads
 
 
 class TestDeriveKeyRequestPayload(testtools.TestCase):
@@ -150,7 +150,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a DeriveKey request payload can be constructed with no
         arguments.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -163,7 +163,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a DeriveKey request payload can be constructed with valid
         values
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=['00000000-1111-2222-3333-444444444444'],
             derivation_method=enums.DerivationMethod.HASH,
@@ -197,7 +197,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the object type of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'object_type', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -211,7 +211,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when invalid values are used to set
         the unique identifiers of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'unique_identifiers', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -241,7 +241,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the derivation method of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'derivation_method', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -255,7 +255,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the derivation parameters of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'derivation_parameters', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -269,7 +269,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the template attribute of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'template_attribute', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -282,7 +282,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         Test that a DeriveKey request payload can be read from a data stream.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -347,7 +347,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey request
         payload encoding missing the object type.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -368,7 +368,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey request
         payload encoding missing the unique identifiers.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -389,7 +389,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey request
         payload encoding missing the derivation method.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -410,7 +410,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey request
         payload encoding missing the derivation parameters.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -431,7 +431,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey request
         payload encoding missing the template attribute.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifiers)
@@ -451,7 +451,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         Test that a DeriveKey request payload can be written to a data stream.
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -501,7 +501,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey request
         payload missing the object type.
         """
-        payload = derive_key.DeriveKeyRequestPayload()
+        payload = payloads.DeriveKeyRequestPayload()
 
         args = (utils.BytearrayStream(), )
         self.assertRaisesRegexp(
@@ -516,7 +516,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey request
         payload missing the unique identifiers.
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY
         )
 
@@ -533,7 +533,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey request
         payload missing the derivation method.
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -555,7 +555,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey request
         payload missing the derivation parameters.
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -578,7 +578,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey request
         payload missing the template attribute.
         """
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -608,13 +608,13 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         DeriveKey request payloads with the same data.
         """
-        a = derive_key.DeriveKeyRequestPayload()
-        b = derive_key.DeriveKeyRequestPayload()
+        a = payloads.DeriveKeyRequestPayload()
+        b = payloads.DeriveKeyRequestPayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -653,7 +653,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -701,10 +701,10 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different object types.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SECRET_DATA
         )
 
@@ -716,24 +716,24 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different sets of unique identifiers.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=['fb4b5b9c-6188-4c63-8142-fe9c328129fc']
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             unique_identifiers=['5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3']
         )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40'
             ]
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
@@ -744,14 +744,14 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40'
             ]
         )
-        b = derive_key.DeriveKeyRequestPayload(unique_identifiers=[])
+        b = payloads.DeriveKeyRequestPayload(unique_identifiers=[])
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -761,10 +761,10 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different derivation methods.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_method=enums.DerivationMethod.HASH
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_method=enums.DerivationMethod.PBKDF2
         )
 
@@ -776,7 +776,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different derivation parameters.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -785,7 +785,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 derivation_data=b'\xFA\xD9\x8B\x6A\xCA\x6D\x87\xDD'
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_1
@@ -798,7 +798,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -807,15 +807,15 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 derivation_data=b'\xFA\xD9\x8B\x6A\xCA\x6D\x87\xDD'
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters()
         )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(derivation_parameters=None)
-        b = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(derivation_parameters=None)
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -833,7 +833,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different template attributes.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -858,7 +858,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -887,7 +887,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -912,15 +912,15 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute()
         )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyRequestPayload(template_attribute=None)
-        b = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(template_attribute=None)
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -954,7 +954,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey request payloads with different types.
         """
-        a = derive_key.DeriveKeyRequestPayload()
+        a = payloads.DeriveKeyRequestPayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -965,13 +965,13 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         DeriveKey request payloads with the same data.
         """
-        a = derive_key.DeriveKeyRequestPayload()
-        b = derive_key.DeriveKeyRequestPayload()
+        a = payloads.DeriveKeyRequestPayload()
+        b = payloads.DeriveKeyRequestPayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -1010,7 +1010,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -1058,10 +1058,10 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different object types.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SECRET_DATA
         )
 
@@ -1073,24 +1073,24 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different sets of unique identifiers.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=['fb4b5b9c-6188-4c63-8142-fe9c328129fc']
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             unique_identifiers=['5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3']
         )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40'
             ]
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
@@ -1101,14 +1101,14 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
                 '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3',
                 '1703250b-4d40-4de2-93a0-c494a1d4ae40'
             ]
         )
-        b = derive_key.DeriveKeyRequestPayload(unique_identifiers=[])
+        b = payloads.DeriveKeyRequestPayload(unique_identifiers=[])
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -1118,10 +1118,10 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different derivation methods.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_method=enums.DerivationMethod.HASH
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_method=enums.DerivationMethod.PBKDF2
         )
 
@@ -1133,7 +1133,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different derivation parameters.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -1142,7 +1142,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 derivation_data=b'\xFA\xD9\x8B\x6A\xCA\x6D\x87\xDD'
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_1
@@ -1155,7 +1155,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -1164,15 +1164,15 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 derivation_data=b'\xFA\xD9\x8B\x6A\xCA\x6D\x87\xDD'
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters()
         )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(derivation_parameters=None)
-        b = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(derivation_parameters=None)
+        b = payloads.DeriveKeyRequestPayload(
             derivation_parameters=attributes.DerivationParameters(
                 cryptographic_parameters=attributes.CryptographicParameters(
                     hashing_algorithm=enums.HashingAlgorithm.SHA_256
@@ -1190,7 +1190,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different template attribute.
         """
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1215,7 +1215,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1244,7 +1244,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1269,15 +1269,15 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyRequestPayload(
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute()
         )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyRequestPayload(template_attribute=None)
-        b = derive_key.DeriveKeyRequestPayload(
+        a = payloads.DeriveKeyRequestPayload(template_attribute=None)
+        b = payloads.DeriveKeyRequestPayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1311,7 +1311,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey request payloads with different types.
         """
-        a = derive_key.DeriveKeyRequestPayload()
+        a = payloads.DeriveKeyRequestPayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -1351,7 +1351,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 )
             ]
         )
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -1417,7 +1417,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
                 )
             ]
         )
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 'fb4b5b9c-6188-4c63-8142-fe9c328129fc',
@@ -1506,7 +1506,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a DeriveKey response payload can be constructed with no
         arguments.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.template_attribute)
@@ -1516,7 +1516,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a DeriveKey response payload can be constructed with valid
         values
         """
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='00000000-1111-2222-3333-444444444444',
             template_attribute=objects.TemplateAttribute()
         )
@@ -1535,7 +1535,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when invalid values are used to set
         the unique identifier of a DeriveKey request payload.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -1549,7 +1549,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the template attribute of a DeriveKey response payload.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
         args = (payload, 'template_attribute', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -1562,7 +1562,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         """
         Test that a DeriveKey response payload can be read from a data stream.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.template_attribute)
@@ -1605,7 +1605,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when decoding a DeriveKey response
         payload encoding missing the unique identifier.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.template_attribute)
@@ -1624,7 +1624,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a DeriveKey response payload missing a template attribute
         can be read from a data stream.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.template_attribute)
@@ -1641,7 +1641,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         """
         Test that a DeriveKey response payload can be written to a data stream.
         """
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=objects.TemplateAttribute(
                 attributes=[
@@ -1678,7 +1678,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey response
         payload missing the unique identifier.
         """
-        payload = derive_key.DeriveKeyResponsePayload()
+        payload = payloads.DeriveKeyResponsePayload()
 
         args = (utils.BytearrayStream(), )
         self.assertRaisesRegexp(
@@ -1693,7 +1693,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when encoding a DeriveKey response
         payload missing the template attribute.
         """
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc'
         )
         stream = utils.BytearrayStream()
@@ -1714,13 +1714,13 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         DeriveKey response payloads with the same data.
         """
-        a = derive_key.DeriveKeyResponsePayload()
-        b = derive_key.DeriveKeyResponsePayload()
+        a = payloads.DeriveKeyResponsePayload()
+        b = payloads.DeriveKeyResponsePayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=objects.TemplateAttribute(
                 attributes=[
@@ -1746,7 +1746,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=objects.TemplateAttribute(
                 attributes=[
@@ -1781,20 +1781,20 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey response payloads with different unique identifiers.
         """
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc'
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             unique_identifier='5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3'
         )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='1703250b-4d40-4de2-93a0-c494a1d4ae40'
         )
-        b = derive_key.DeriveKeyResponsePayload(unique_identifier=None)
+        b = payloads.DeriveKeyResponsePayload(unique_identifier=None)
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -1804,7 +1804,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey response payloads with different template attributes.
         """
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1829,7 +1829,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1858,7 +1858,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1883,15 +1883,15 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute()
         )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
 
-        a = derive_key.DeriveKeyResponsePayload(template_attribute=None)
-        b = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(template_attribute=None)
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -1925,7 +1925,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         DeriveKey response payloads with different types.
         """
-        a = derive_key.DeriveKeyResponsePayload()
+        a = payloads.DeriveKeyResponsePayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -1936,13 +1936,13 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         DeriveKey response payloads with the same data.
         """
-        a = derive_key.DeriveKeyResponsePayload()
-        b = derive_key.DeriveKeyResponsePayload()
+        a = payloads.DeriveKeyResponsePayload()
+        b = payloads.DeriveKeyResponsePayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=objects.TemplateAttribute(
                 attributes=[
@@ -1968,7 +1968,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=objects.TemplateAttribute(
                 attributes=[
@@ -2006,20 +2006,20 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey response payloads with different unique identifiers.
         """
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc'
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             unique_identifier='5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3'
         )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             unique_identifier='1703250b-4d40-4de2-93a0-c494a1d4ae40'
         )
-        b = derive_key.DeriveKeyResponsePayload(unique_identifier=None)
+        b = payloads.DeriveKeyResponsePayload(unique_identifier=None)
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -2029,7 +2029,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey response payloads with different template attribute.
         """
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -2054,7 +2054,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -2083,7 +2083,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -2108,15 +2108,15 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 ]
             )
         )
-        b = derive_key.DeriveKeyResponsePayload(
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute()
         )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
 
-        a = derive_key.DeriveKeyResponsePayload(template_attribute=None)
-        b = derive_key.DeriveKeyResponsePayload(
+        a = payloads.DeriveKeyResponsePayload(template_attribute=None)
+        b = payloads.DeriveKeyResponsePayload(
             template_attribute=objects.TemplateAttribute(
                 attributes=[
                     objects.Attribute(
@@ -2150,7 +2150,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         DeriveKey response payloads with different types.
         """
-        a = derive_key.DeriveKeyResponsePayload()
+        a = payloads.DeriveKeyResponsePayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -2183,7 +2183,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 )
             ]
         )
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=template_attribute
         )
@@ -2228,7 +2228,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
                 )
             ]
         )
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='fb4b5b9c-6188-4c63-8142-fe9c328129fc',
             template_attribute=template_attribute
         )

--- a/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
+++ b/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
@@ -20,7 +20,7 @@ from testtools import TestCase
 from kmip.core import utils
 
 from kmip.core.messages.contents import ProtocolVersion
-from kmip.core.messages.payloads import discover_versions
+from kmip.core.messages import payloads
 
 
 class TestDiscoverVersionsRequestPayload(TestCase):
@@ -54,23 +54,23 @@ class TestDiscoverVersionsRequestPayload(TestCase):
         super(TestDiscoverVersionsRequestPayload, self).tearDown()
 
     def test_init_with_none(self):
-        discover_versions.DiscoverVersionsRequestPayload()
+        payloads.DiscoverVersionsRequestPayload()
 
     def test_init_with_args(self):
-        discover_versions.DiscoverVersionsRequestPayload(
+        payloads.DiscoverVersionsRequestPayload(
             self.protocol_versions_empty)
 
     def test_validate_with_invalid_protocol_versions(self):
         kwargs = {'protocol_versions': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid protocol versions list",
-            discover_versions.DiscoverVersionsRequestPayload, **kwargs)
+            payloads.DiscoverVersionsRequestPayload, **kwargs)
 
     def test_validate_with_invalid_protocol_version(self):
         kwargs = {'protocol_versions': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid protocol version",
-            discover_versions.DiscoverVersionsRequestPayload, **kwargs)
+            payloads.DiscoverVersionsRequestPayload, **kwargs)
 
     def _test_read(self, stream, payload, protocol_versions):
         payload.read(stream)
@@ -92,21 +92,21 @@ class TestDiscoverVersionsRequestPayload(TestCase):
 
     def test_read_with_empty_protocol_list(self):
         stream = self.encoding_empty
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         protocol_versions = self.protocol_versions_empty
 
         self._test_read(stream, payload, protocol_versions)
 
     def test_read_with_one_protocol_version(self):
         stream = self.encoding_one
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         protocol_versions = self.protocol_versions_one
 
         self._test_read(stream, payload, protocol_versions)
 
     def test_read_with_two_protocol_versions(self):
         stream = self.encoding_two
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         protocol_versions = self.protocol_versions_two
 
         self._test_read(stream, payload, protocol_versions)
@@ -129,21 +129,21 @@ class TestDiscoverVersionsRequestPayload(TestCase):
         self.assertEqual(expected, stream, msg)
 
     def test_write_with_empty_protocol_list(self):
-        payload = discover_versions.DiscoverVersionsRequestPayload(
+        payload = payloads.DiscoverVersionsRequestPayload(
             self.protocol_versions_empty)
         expected = self.encoding_empty
 
         self._test_write(payload, expected)
 
     def test_write_with_one_protocol_version(self):
-        payload = discover_versions.DiscoverVersionsRequestPayload(
+        payload = payloads.DiscoverVersionsRequestPayload(
             self.protocol_versions_one)
         expected = self.encoding_one
 
         self._test_write(payload, expected)
 
     def test_write_with_two_protocol_versions(self):
-        payload = discover_versions.DiscoverVersionsRequestPayload(
+        payload = payloads.DiscoverVersionsRequestPayload(
             self.protocol_versions_two)
         expected = self.encoding_two
 
@@ -181,23 +181,23 @@ class TestDiscoverVersionsResponsePayload(TestCase):
         super(TestDiscoverVersionsResponsePayload, self).tearDown()
 
     def test_init_with_none(self):
-        discover_versions.DiscoverVersionsResponsePayload()
+        payloads.DiscoverVersionsResponsePayload()
 
     def test_init_with_args(self):
-        discover_versions.DiscoverVersionsResponsePayload(
+        payloads.DiscoverVersionsResponsePayload(
             self.protocol_versions_empty)
 
     def test_validate_with_invalid_protocol_versions(self):
         kwargs = {'protocol_versions': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid protocol versions list",
-            discover_versions.DiscoverVersionsResponsePayload, **kwargs)
+            payloads.DiscoverVersionsResponsePayload, **kwargs)
 
     def test_validate_with_invalid_protocol_version(self):
         kwargs = {'protocol_versions': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid protocol version",
-            discover_versions.DiscoverVersionsResponsePayload, **kwargs)
+            payloads.DiscoverVersionsResponsePayload, **kwargs)
 
     def _test_read(self, stream, payload, protocol_versions):
         payload.read(stream)
@@ -219,21 +219,21 @@ class TestDiscoverVersionsResponsePayload(TestCase):
 
     def test_read_with_empty_protocol_list(self):
         stream = self.encoding_empty
-        payload = discover_versions.DiscoverVersionsResponsePayload()
+        payload = payloads.DiscoverVersionsResponsePayload()
         protocol_versions = self.protocol_versions_empty
 
         self._test_read(stream, payload, protocol_versions)
 
     def test_read_with_one_protocol_version(self):
         stream = self.encoding_one
-        payload = discover_versions.DiscoverVersionsResponsePayload()
+        payload = payloads.DiscoverVersionsResponsePayload()
         protocol_versions = self.protocol_versions_one
 
         self._test_read(stream, payload, protocol_versions)
 
     def test_read_with_two_protocol_versions(self):
         stream = self.encoding_two
-        payload = discover_versions.DiscoverVersionsResponsePayload()
+        payload = payloads.DiscoverVersionsResponsePayload()
         protocol_versions = self.protocol_versions_two
 
         self._test_read(stream, payload, protocol_versions)
@@ -256,21 +256,21 @@ class TestDiscoverVersionsResponsePayload(TestCase):
         self.assertEqual(expected, stream, msg)
 
     def test_write_with_empty_protocol_list(self):
-        payload = discover_versions.DiscoverVersionsResponsePayload(
+        payload = payloads.DiscoverVersionsResponsePayload(
             self.protocol_versions_empty)
         expected = self.encoding_empty
 
         self._test_write(payload, expected)
 
     def test_write_with_one_protocol_version(self):
-        payload = discover_versions.DiscoverVersionsResponsePayload(
+        payload = payloads.DiscoverVersionsResponsePayload(
             self.protocol_versions_one)
         expected = self.encoding_one
 
         self._test_write(payload, expected)
 
     def test_write_with_two_protocol_versions(self):
-        payload = discover_versions.DiscoverVersionsResponsePayload(
+        payload = payloads.DiscoverVersionsResponsePayload(
             self.protocol_versions_two)
         expected = self.encoding_two
 

--- a/kmip/tests/unit/core/messages/payloads/test_encrypt.py
+++ b/kmip/tests/unit/core/messages/payloads/test_encrypt.py
@@ -19,7 +19,7 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import utils
 
-from kmip.core.messages.payloads import encrypt
+from kmip.core.messages import payloads
 
 
 class TestEncryptRequestPayload(testtools.TestCase):
@@ -98,7 +98,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that an Encrypt request payload can be constructed with no
         arguments.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -110,7 +110,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that an Encrypt request payload can be constructed with valid
         values
         """
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier='00000000-1111-2222-3333-444444444444',
             cryptographic_parameters=attributes.CryptographicParameters(),
             data=b'\x01\x02\x03',
@@ -133,7 +133,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the unique identifier of an Encrypt request payload.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -147,7 +147,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the cryptographic parameters of an Encrypt request payload.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         args = (payload, 'cryptographic_parameters', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
@@ -162,7 +162,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the data of an Encrypt request payload.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         args = (payload, 'data', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -176,7 +176,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the IV/counter/nonce of an Encrypt request payload.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         args = (payload, 'iv_counter_nonce', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -189,7 +189,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         Test that an Encrypt request payload can be read from a data stream.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -251,7 +251,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that an Encrypt request payload can be read from a partial data
         stream containing the minimum required attributes.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.cryptographic_parameters)
@@ -270,7 +270,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when a required Encrypt request
         payload attribute is missing from the payload encoding.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         args = (self.empty_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -283,7 +283,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         Test that an Encrypt request payload can be written to a data stream.
         """
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -315,7 +315,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a partially defined Encrypt request payload can be written
         to a data stream.
         """
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             data=b'\x01\x02\x03\x04\x05\x06\x07\x08'
         )
         stream = utils.BytearrayStream()
@@ -329,7 +329,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that a ValueError gets raised when a required Encrypt request
         payload attribute is missing when encoding the payload.
         """
-        payload = encrypt.EncryptRequestPayload()
+        payload = payloads.EncryptRequestPayload()
         stream = utils.BytearrayStream()
         args = (stream, )
         self.assertRaisesRegexp(
@@ -344,13 +344,13 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         Encrypt request payloads with the same data.
         """
-        a = encrypt.EncryptRequestPayload()
-        b = encrypt.EncryptRequestPayload()
+        a = payloads.EncryptRequestPayload()
+        b = payloads.EncryptRequestPayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -371,7 +371,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -401,10 +401,10 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt request payloads with different unique identifiers.
         """
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             unique_identifier='a'
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             unique_identifier='b'
         )
 
@@ -416,12 +416,12 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt request payloads with different cryptographic parameters.
         """
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC
             )
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 hashing_algorithm=enums.HashingAlgorithm.MD5
             )
@@ -435,8 +435,8 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt request payloads with different data.
         """
-        a = encrypt.EncryptRequestPayload(data=b'\x11')
-        b = encrypt.EncryptRequestPayload(data=b'\xFF')
+        a = payloads.EncryptRequestPayload(data=b'\x11')
+        b = payloads.EncryptRequestPayload(data=b'\xFF')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -446,8 +446,8 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt request payloads with different IV/counter/nonce values.
         """
-        a = encrypt.EncryptRequestPayload(iv_counter_nonce=b'\x22')
-        b = encrypt.EncryptRequestPayload(iv_counter_nonce=b'\xAA')
+        a = payloads.EncryptRequestPayload(iv_counter_nonce=b'\x22')
+        b = payloads.EncryptRequestPayload(iv_counter_nonce=b'\xAA')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -457,7 +457,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt request payloads with different types.
         """
-        a = encrypt.EncryptRequestPayload()
+        a = payloads.EncryptRequestPayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -468,13 +468,13 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         Encrypt request payloads with the same data.
         """
-        a = encrypt.EncryptRequestPayload()
-        b = encrypt.EncryptRequestPayload()
+        a = payloads.EncryptRequestPayload()
+        b = payloads.EncryptRequestPayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -495,7 +495,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -525,10 +525,10 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt request payloads with different unique identifiers.
         """
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             unique_identifier='a'
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             unique_identifier='b'
         )
 
@@ -540,12 +540,12 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt request payloads with different cryptographic parameters.
         """
-        a = encrypt.EncryptRequestPayload(
+        a = payloads.EncryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC
             )
         )
-        b = encrypt.EncryptRequestPayload(
+        b = payloads.EncryptRequestPayload(
             cryptographic_parameters=attributes.CryptographicParameters(
                 hashing_algorithm=enums.HashingAlgorithm.MD5
             )
@@ -559,8 +559,8 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt request payloads with different data.
         """
-        a = encrypt.EncryptRequestPayload(data=b'\x11')
-        b = encrypt.EncryptRequestPayload(data=b'\xFF')
+        a = payloads.EncryptRequestPayload(data=b'\x11')
+        b = payloads.EncryptRequestPayload(data=b'\xFF')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -570,8 +570,8 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt request payloads with different IV/counter/nonce values.
         """
-        a = encrypt.EncryptRequestPayload(iv_counter_nonce=b'\x22')
-        b = encrypt.EncryptRequestPayload(iv_counter_nonce=b'\xAA')
+        a = payloads.EncryptRequestPayload(iv_counter_nonce=b'\x22')
+        b = payloads.EncryptRequestPayload(iv_counter_nonce=b'\xAA')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -581,7 +581,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt request payloads with different types.
         """
-        a = encrypt.EncryptRequestPayload()
+        a = payloads.EncryptRequestPayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -591,7 +591,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         Test that repr can be applied to an Encrypt request payload.
         """
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -657,7 +657,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
             counter_length=0,
             initial_counter_value=1
         )
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             cryptographic_parameters=cryptographic_parameters,
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
@@ -738,7 +738,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that an Encrypt response payload can be constructed with no
         arguments.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.data)
@@ -749,7 +749,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that an Encrypt response payload can be constructed with valid
         values
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='00000000-1111-2222-3333-444444444444',
             data=b'\x01\x02\x03',
             iv_counter_nonce=b'\x01'
@@ -767,7 +767,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the unique identifier of an Encrypt response payload.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -781,7 +781,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the data of an Encrypt response payload.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         args = (payload, 'data', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -795,7 +795,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid value is used to set
         the IV/counter/nonce of an Encrypt response payload.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         args = (payload, 'iv_counter_nonce', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -808,7 +808,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         Test that an Encrypt response payload can be read from a data stream.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.data)
@@ -828,7 +828,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that an Encrypt response payload can be read from a partial data
         stream containing the minimum required attributes.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.data)
@@ -848,7 +848,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when required Encrypt response
         payload attributes are missing from the payload encoding.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         args = (self.empty_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -857,7 +857,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
             *args
         )
 
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         args = (self.incomplete_encoding, )
         self.assertRaisesRegexp(
             ValueError,
@@ -870,7 +870,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         Test that an Encrypt response payload can be written to a data stream.
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
@@ -886,7 +886,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a partially defined Encrypt response payload can be written
         to a data stream.
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x02\x03\x04\x05\x06\x07\x08'
         )
@@ -901,7 +901,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when required Encrypt response
         payload attributes are missing when encoding the payload.
         """
-        payload = encrypt.EncryptResponsePayload()
+        payload = payloads.EncryptResponsePayload()
         self.assertIsNone(payload.unique_identifier)
         stream = utils.BytearrayStream()
         args = (stream, )
@@ -912,7 +912,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
             *args
         )
 
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959'
         )
         stream = utils.BytearrayStream()
@@ -929,18 +929,18 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         Encrypt response payloads with the same data.
         """
-        a = encrypt.EncryptResponsePayload()
-        b = encrypt.EncryptResponsePayload()
+        a = payloads.EncryptResponsePayload()
+        b = payloads.EncryptResponsePayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = encrypt.EncryptResponsePayload(
+        a = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = encrypt.EncryptResponsePayload(
+        b = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
@@ -954,10 +954,10 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt response payloads with different unique identifiers.
         """
-        a = encrypt.EncryptResponsePayload(
+        a = payloads.EncryptResponsePayload(
             unique_identifier='a'
         )
-        b = encrypt.EncryptResponsePayload(
+        b = payloads.EncryptResponsePayload(
             unique_identifier='b'
         )
 
@@ -969,8 +969,8 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt response payloads with different data.
         """
-        a = encrypt.EncryptResponsePayload(data=b'\x11')
-        b = encrypt.EncryptResponsePayload(data=b'\xFF')
+        a = payloads.EncryptResponsePayload(data=b'\x11')
+        b = payloads.EncryptResponsePayload(data=b'\xFF')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -980,8 +980,8 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt response payloads with different IV/counter/nonce values.
         """
-        a = encrypt.EncryptResponsePayload(iv_counter_nonce=b'\x22')
-        b = encrypt.EncryptResponsePayload(iv_counter_nonce=b'\xAA')
+        a = payloads.EncryptResponsePayload(iv_counter_nonce=b'\x22')
+        b = payloads.EncryptResponsePayload(iv_counter_nonce=b'\xAA')
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -991,7 +991,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         Encrypt response payloads with different types.
         """
-        a = encrypt.EncryptResponsePayload()
+        a = payloads.EncryptResponsePayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -1002,18 +1002,18 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         Encrypt response payloads with the same data.
         """
-        a = encrypt.EncryptResponsePayload()
-        b = encrypt.EncryptResponsePayload()
+        a = payloads.EncryptResponsePayload()
+        b = payloads.EncryptResponsePayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = encrypt.EncryptResponsePayload(
+        a = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
         )
-        b = encrypt.EncryptResponsePayload(
+        b = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
@@ -1027,10 +1027,10 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt response payloads with different unique identifiers.
         """
-        a = encrypt.EncryptResponsePayload(
+        a = payloads.EncryptResponsePayload(
             unique_identifier='a'
         )
-        b = encrypt.EncryptResponsePayload(
+        b = payloads.EncryptResponsePayload(
             unique_identifier='b'
         )
 
@@ -1042,8 +1042,8 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt response payloads with different data.
         """
-        a = encrypt.EncryptResponsePayload(data=b'\x11')
-        b = encrypt.EncryptResponsePayload(data=b'\xFF')
+        a = payloads.EncryptResponsePayload(data=b'\x11')
+        b = payloads.EncryptResponsePayload(data=b'\xFF')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -1053,8 +1053,8 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt response payloads with different IV/counter/nonce values.
         """
-        a = encrypt.EncryptResponsePayload(iv_counter_nonce=b'\x22')
-        b = encrypt.EncryptResponsePayload(iv_counter_nonce=b'\xAA')
+        a = payloads.EncryptResponsePayload(iv_counter_nonce=b'\x22')
+        b = payloads.EncryptResponsePayload(iv_counter_nonce=b'\xAA')
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -1064,7 +1064,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         Encrypt response payloads with different types.
         """
-        a = encrypt.EncryptResponsePayload()
+        a = payloads.EncryptResponsePayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -1074,7 +1074,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         Test that repr can be applied to an Encrypt response payload.
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'
@@ -1093,7 +1093,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         Test that str can be applied to an Encrypt response payload
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='b4faee10-aa2a-4446-8ad4-0881f3422959',
             data=b'\x01\x23\x45\x67\x89\xAB\xCD\xEF',
             iv_counter_nonce=b'\x01'

--- a/kmip/tests/unit/core/messages/payloads/test_get.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get.py
@@ -22,7 +22,7 @@ from kmip.core import objects
 from kmip.core import secrets
 from kmip.core import utils
 
-from kmip.core.messages.payloads import get
+from kmip.core.messages import payloads
 
 
 class TestGetRequestPayload(testtools.TestCase):
@@ -95,7 +95,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that a Get request payload can be constructed with no arguments.
         """
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.key_format_type)
@@ -106,7 +106,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that a Get request payload can be constructed with valid values.
         """
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier='00000000-2222-4444-6666-888888888888',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -143,11 +143,11 @@ class TestGetRequestPayload(testtools.TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "Unique identifier must be a string.",
-            get.GetRequestPayload,
+            payloads.GetRequestPayload,
             **kwargs
         )
 
-        args = (get.GetRequestPayload(), 'unique_identifier', 0)
+        args = (payloads.GetRequestPayload(), 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
             "Unique identifier must be a string.",
@@ -164,11 +164,11 @@ class TestGetRequestPayload(testtools.TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "Key format type must be a KeyFormatType enumeration.",
-            get.GetRequestPayload,
+            payloads.GetRequestPayload,
             **kwargs
         )
 
-        args = (get.GetRequestPayload(), 'key_format_type', 'invalid')
+        args = (payloads.GetRequestPayload(), 'key_format_type', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
             "Key format type must be a KeyFormatType enumeration.",
@@ -185,11 +185,15 @@ class TestGetRequestPayload(testtools.TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "Key compression type must be a KeyCompressionType enumeration.",
-            get.GetRequestPayload,
+            payloads.GetRequestPayload,
             **kwargs
         )
 
-        args = (get.GetRequestPayload(), 'key_compression_type', 'invalid')
+        args = (
+            payloads.GetRequestPayload(),
+            'key_compression_type',
+            'invalid'
+        )
         self.assertRaisesRegexp(
             TypeError,
             "Key compression type must be a KeyCompressionType enumeration.",
@@ -207,12 +211,12 @@ class TestGetRequestPayload(testtools.TestCase):
             TypeError,
             "Key wrapping specification must be a KeyWrappingSpecification "
             "struct.",
-            get.GetRequestPayload,
+            payloads.GetRequestPayload,
             **kwargs
         )
 
         args = (
-            get.GetRequestPayload(),
+            payloads.GetRequestPayload(),
             'key_wrapping_specification',
             'invalid'
         )
@@ -228,7 +232,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that a GetRequestPayload struct can be read from a data stream.
         """
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.key_format_type)
@@ -282,7 +286,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that a GetRequestPayload struct can be read from a partial data
         stream.
         """
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.key_format_type)
@@ -304,7 +308,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that a GetRequestPayload struct can be read from an empty data
         stream.
         """
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
 
         self.assertEqual(None, payload.unique_identifier)
         self.assertEqual(None, payload.key_format_type)
@@ -322,7 +326,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that a GetRequestPayload struct can be written to a data stream.
         """
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -351,7 +355,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that a partially defined GetRequestPayload struct can be written
         to a data stream.
         """
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
         stream = utils.BytearrayStream()
@@ -366,7 +370,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that an empty GetRequestPayload struct can be written to a data
         stream.
         """
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
         stream = utils.BytearrayStream()
 
         payload.write(stream)
@@ -379,13 +383,13 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetRequestPayload structs with the same data.
         """
-        a = get.GetRequestPayload()
-        b = get.GetRequestPayload()
+        a = payloads.GetRequestPayload()
+        b = payloads.GetRequestPayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
 
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -402,7 +406,7 @@ class TestGetRequestPayload(testtools.TestCase):
                 encoding_option=enums.EncodingOption.NO_ENCODING
             )
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -428,10 +432,10 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different unique identifiers.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c303f'
         )
 
@@ -443,10 +447,10 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different key format types.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_format_type=enums.KeyFormatType.RAW
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_format_type=enums.KeyFormatType.OPAQUE
         )
 
@@ -458,11 +462,11 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different key compression types.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_compression_type=enums.KeyCompressionType.
             EC_PUBLIC_KEY_TYPE_UNCOMPRESSED
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_compression_type=enums.KeyCompressionType.
             EC_PUBLIC_KEY_TYPE_X9_62_HYBRID
         )
@@ -475,7 +479,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different key wrapping specifications.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT_THEN_MAC_SIGN,
                 encryption_key_information=objects.EncryptionKeyInformation(
@@ -488,7 +492,7 @@ class TestGetRequestPayload(testtools.TestCase):
                 encoding_option=enums.EncodingOption.NO_ENCODING
             )
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
                 encryption_key_information=objects.EncryptionKeyInformation(
@@ -510,7 +514,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different types.
         """
-        a = get.GetRequestPayload()
+        a = payloads.GetRequestPayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -521,13 +525,13 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         GetRequestPayload structs with the same data.
         """
-        a = get.GetRequestPayload()
-        b = get.GetRequestPayload()
+        a = payloads.GetRequestPayload()
+        b = payloads.GetRequestPayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
 
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -544,7 +548,7 @@ class TestGetRequestPayload(testtools.TestCase):
                 encoding_option=enums.EncodingOption.NO_ENCODING
             )
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -570,10 +574,10 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetRequestPayload structs with different unique identifiers.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c303f'
         )
 
@@ -585,10 +589,10 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetRequestPayload structs with different key format types.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_format_type=enums.KeyFormatType.RAW
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_format_type=enums.KeyFormatType.OPAQUE
         )
 
@@ -600,11 +604,11 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetRequestPayload structs with different key compression types.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_compression_type=enums.KeyCompressionType.
             EC_PUBLIC_KEY_TYPE_UNCOMPRESSED
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_compression_type=enums.KeyCompressionType.
             EC_PUBLIC_KEY_TYPE_X9_62_HYBRID
         )
@@ -617,7 +621,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetRequestPayload structs with different key wrapping specifications.
         """
-        a = get.GetRequestPayload(
+        a = payloads.GetRequestPayload(
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT_THEN_MAC_SIGN,
                 encryption_key_information=objects.EncryptionKeyInformation(
@@ -630,7 +634,7 @@ class TestGetRequestPayload(testtools.TestCase):
                 encoding_option=enums.EncodingOption.NO_ENCODING
             )
         )
-        b = get.GetRequestPayload(
+        b = payloads.GetRequestPayload(
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
                 encryption_key_information=objects.EncryptionKeyInformation(
@@ -652,7 +656,7 @@ class TestGetRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetRequestPayload structs with different types.
         """
-        a = get.GetRequestPayload()
+        a = payloads.GetRequestPayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -662,7 +666,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetRequestPayload struct.
         """
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -717,7 +721,7 @@ class TestGetRequestPayload(testtools.TestCase):
         """
         Test that str can be applied to a GetRequestPayload struct.
         """
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             key_format_type=enums.KeyFormatType.RAW,
             key_compression_type=enums.KeyCompressionType.
@@ -844,7 +848,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a GetRequestPayload struct can be constructed with no
         arguments.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifier)
@@ -855,7 +859,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a GetRequestPayload struct can be constructed with valid
         values.
         """
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='11111111-3333-5555-7777-999999999999',
             secret=secrets.SymmetricKey(
@@ -938,11 +942,11 @@ class TestGetResponsePayload(testtools.TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "Object type must be an ObjectType enumeration.",
-            get.GetResponsePayload,
+            payloads.GetResponsePayload,
             **kwargs
         )
 
-        args = (get.GetResponsePayload(), 'object_type', 'invalid')
+        args = (payloads.GetResponsePayload(), 'object_type', 'invalid')
         self.assertRaisesRegexp(
             TypeError,
             "Object type must be an ObjectType enumeration.",
@@ -959,11 +963,11 @@ class TestGetResponsePayload(testtools.TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "Unique identifier must be a string.",
-            get.GetResponsePayload,
+            payloads.GetResponsePayload,
             **kwargs
         )
 
-        args = (get.GetResponsePayload(), 'unique_identifier', 0)
+        args = (payloads.GetResponsePayload(), 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
             "Unique identifier must be a string.",
@@ -982,11 +986,11 @@ class TestGetResponsePayload(testtools.TestCase):
             "Secret must be one of the following structs: Certificate, "
             "OpaqueObject, PrivateKey, PublicKey, SecretData, SplitKey, "
             "SymmetricKey, Template",
-            get.GetResponsePayload,
+            payloads.GetResponsePayload,
             **kwargs
         )
 
-        args = (get.GetResponsePayload(), 'secret', 0)
+        args = (payloads.GetResponsePayload(), 'secret', 0)
         self.assertRaisesRegexp(
             TypeError,
             "Secret must be one of the following structs: Certificate, "
@@ -1000,7 +1004,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         Test that a GetResponsePayload struct can be read from a data stream.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
 
         self.assertEqual(None, payload.object_type)
         self.assertEqual(None, payload.unique_identifier)
@@ -1061,7 +1065,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when decoding the struct.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_object_type, )
         self.assertRaisesRegexp(
             ValueError,
@@ -1075,7 +1079,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when decoding the struct.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_unique_id, )
         self.assertRaisesRegexp(
             ValueError,
@@ -1089,7 +1093,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when decoding the struct.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_secret, )
         self.assertRaisesRegexp(
             ValueError,
@@ -1102,7 +1106,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         Test that a GetResponsePayload struct can be written to a data stream.
         """
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secrets.SymmetricKey(
@@ -1135,7 +1139,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when encoding the struct.
         """
-        payload = get.GetResponsePayload()
+        payload = payloads.GetResponsePayload()
         stream = utils.BytearrayStream()
         args = (stream, )
         self.assertRaisesRegexp(
@@ -1150,7 +1154,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when encoding the struct.
         """
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY
         )
         stream = utils.BytearrayStream()
@@ -1167,7 +1171,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that a ValueError gets raised when a required GetResponsePayload
         field is missing when encoding the struct.
         """
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
@@ -1185,8 +1189,8 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetResponsePayload structs with the same data.
         """
-        a = get.GetResponsePayload()
-        b = get.GetResponsePayload()
+        a = payloads.GetResponsePayload()
+        b = payloads.GetResponsePayload()
 
         self.assertTrue(a == b)
         self.assertTrue(b == a)
@@ -1212,12 +1216,12 @@ class TestGetResponsePayload(testtools.TestCase):
                 )
             )
 
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secret
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secret
@@ -1231,8 +1235,12 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetResponsePayload structs with different object type fields.
         """
-        a = get.GetResponsePayload(object_type=enums.ObjectType.SYMMETRIC_KEY)
-        b = get.GetResponsePayload(object_type=enums.ObjectType.OPAQUE_DATA)
+        a = payloads.GetResponsePayload(
+            object_type=enums.ObjectType.SYMMETRIC_KEY
+        )
+        b = payloads.GetResponsePayload(
+            object_type=enums.ObjectType.OPAQUE_DATA
+        )
 
         self.assertFalse(a == b)
         self.assertFalse(b == a)
@@ -1242,10 +1250,10 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetResponsePayload structs with different unique identifier fields.
         """
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             unique_identifier='49a1ca88-6bea-4fb2-ffff-7e58802c3038'
         )
 
@@ -1259,7 +1267,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         # TODO (peter-hamilton): Update this test case once SymmetricKeys
         # support proper field-based equality.
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             secret=secrets.SymmetricKey(
                 key_block=objects.KeyBlock(
                     key_format_type=misc.KeyFormatType(
@@ -1279,7 +1287,7 @@ class TestGetResponsePayload(testtools.TestCase):
                 )
             )
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             secret=secrets.SymmetricKey(
                 key_block=objects.KeyBlock(
                     key_format_type=misc.KeyFormatType(
@@ -1308,7 +1316,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the equality operators returns False when comparing two
         GetResponsePayload structs with different types.
         """
-        a = get.GetResponsePayload()
+        a = payloads.GetResponsePayload()
         b = 'invalid'
 
         self.assertFalse(a == b)
@@ -1319,8 +1327,8 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         GetResponsePayload structs with the same data.
         """
-        a = get.GetResponsePayload()
-        b = get.GetResponsePayload()
+        a = payloads.GetResponsePayload()
+        b = payloads.GetResponsePayload()
 
         self.assertFalse(a != b)
         self.assertFalse(b != a)
@@ -1344,12 +1352,12 @@ class TestGetResponsePayload(testtools.TestCase):
             )
         )
 
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secret
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secret
@@ -1363,8 +1371,12 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetResponsePayload structs with different object type fields.
         """
-        a = get.GetResponsePayload(object_type=enums.ObjectType.SYMMETRIC_KEY)
-        b = get.GetResponsePayload(object_type=enums.ObjectType.OPAQUE_DATA)
+        a = payloads.GetResponsePayload(
+            object_type=enums.ObjectType.SYMMETRIC_KEY
+        )
+        b = payloads.GetResponsePayload(
+            object_type=enums.ObjectType.OPAQUE_DATA
+        )
 
         self.assertTrue(a != b)
         self.assertTrue(b != a)
@@ -1374,10 +1386,10 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetResponsePayload structs with different unique identifier fields.
         """
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             unique_identifier='49a1ca88-6bea-4fb2-ffff-7e58802c3038'
         )
 
@@ -1391,7 +1403,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         # TODO (peter-hamilton): Update this test case once SymmetricKeys
         # support proper field-based equality.
-        a = get.GetResponsePayload(
+        a = payloads.GetResponsePayload(
             secret=secrets.SymmetricKey(
                 key_block=objects.KeyBlock(
                     key_format_type=misc.KeyFormatType(
@@ -1411,7 +1423,7 @@ class TestGetResponsePayload(testtools.TestCase):
                 )
             )
         )
-        b = get.GetResponsePayload(
+        b = payloads.GetResponsePayload(
             secret=secrets.SymmetricKey(
                 key_block=objects.KeyBlock(
                     key_format_type=misc.KeyFormatType(
@@ -1440,7 +1452,7 @@ class TestGetResponsePayload(testtools.TestCase):
         Test that the inequality operators returns True when comparing two
         GetResponsePayload structs with different types.
         """
-        a = get.GetResponsePayload()
+        a = payloads.GetResponsePayload()
         b = 'invalid'
 
         self.assertTrue(a != b)
@@ -1450,7 +1462,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetResponsePayload struct.
         """
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secrets.SymmetricKey(
@@ -1506,7 +1518,7 @@ class TestGetResponsePayload(testtools.TestCase):
                 cryptographic_length=attributes.CryptographicLength(168)
             )
         )
-        payload = get.GetResponsePayload(
+        payload = payloads.GetResponsePayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
             secret=secret

--- a/kmip/tests/unit/core/messages/payloads/test_get_attribute_list.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attribute_list.py
@@ -19,7 +19,7 @@ from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import utils
 
-from kmip.core.messages.payloads import get_attribute_list
+from kmip.core.messages import payloads
 
 
 class TestGetAttributeListRequestPayload(testtools.TestCase):
@@ -52,14 +52,14 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a GetAttributeList request payload can be constructed with
         no arguments.
         """
-        get_attribute_list.GetAttributeListRequestPayload()
+        payloads.GetAttributeListRequestPayload()
 
     def test_init_with_args(self):
         """
         Test that a GetAttributeList request payload can be constructed with a
         valid value.
         """
-        get_attribute_list.GetAttributeListRequestPayload(
+        payloads.GetAttributeListRequestPayload(
             'test-unique-identifier',
         )
 
@@ -68,7 +68,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that the unique_identifier attribute of a GetAttributeList
         request payload can be properly set and retrieved.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
 
         self.assertIsNone(payload.unique_identifier)
         self.assertIsNone(payload._unique_identifier)
@@ -89,7 +89,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid ID is used to set
         the unique_identifier attribute of a GetAttributeList request payload.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -103,7 +103,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a GetAttributeList request payload can be read from a data
         stream.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
 
@@ -123,7 +123,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no ID or attribute
         names can be read from a data stream.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
 
@@ -137,7 +137,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a GetAttributeList request payload can be written to a data
         stream.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
         stream = utils.BytearrayStream()
@@ -151,7 +151,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that a GetAttributeList request payload with no ID or attribute
         names can be written to a data stream.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
         stream = utils.BytearrayStream()
         payload.write(stream)
 
@@ -162,7 +162,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetAttributeList request payload.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
         unique_identifier = "unique_identifier={0}".format(
@@ -179,7 +179,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributeList request payload
         with no ID or attribute names.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             None
         )
         unique_identifier = "unique_identifier={0}".format(
@@ -195,7 +195,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         """
         Test that str can be applied to a GetAttributeList request payload.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
         expected = str({
@@ -209,7 +209,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that str can be applied to a GetAttributeList request payload
         with no ID or attribute names.
         """
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             None
         )
         expected = str({
@@ -223,10 +223,10 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetAttributeList request payloads with the same data.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
-        b = get_attribute_list.GetAttributeListRequestPayload(
+        b = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
 
@@ -238,10 +238,10 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributeList request payloads with different IDs.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
-        b = get_attribute_list.GetAttributeListRequestPayload(
+        b = payloads.GetAttributeListRequestPayload(
             'invalid'
         )
 
@@ -254,7 +254,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         GetAttributeList request payload to a non-GetAttributeList request
         payload.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
         b = "invalid"
@@ -267,10 +267,10 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing
         two GetAttributeList request payloads with the same internal data.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
-        b = get_attribute_list.GetAttributeListRequestPayload(
+        b = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
 
@@ -282,10 +282,10 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributeList request payloads with different IDs.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
-        b = get_attribute_list.GetAttributeListRequestPayload(
+        b = payloads.GetAttributeListRequestPayload(
             'invalid'
         )
 
@@ -298,7 +298,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         GetAttributeList request payload to a non-GetAttributeList request
         payload.
         """
-        a = get_attribute_list.GetAttributeListRequestPayload(
+        a = payloads.GetAttributeListRequestPayload(
             self.unique_identifier
         )
         b = "invalid"
@@ -398,14 +398,14 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload can be constructed with
         no arguments.
         """
-        get_attribute_list.GetAttributeListResponsePayload()
+        payloads.GetAttributeListResponsePayload()
 
     def test_init_with_args(self):
         """
         Test that a GetAttributeList response payload can be constructed with a
         valid value.
         """
-        get_attribute_list.GetAttributeListResponsePayload(
+        payloads.GetAttributeListResponsePayload(
             'test-unique-identifier',
             ['test-attribute-name-1', 'test-attribute-name-2']
         )
@@ -415,7 +415,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the unique_identifier attribute of a GetAttributeList
         response payload can be properly set and retrieved.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertIsNone(payload.unique_identifier)
         self.assertIsNone(payload._unique_identifier)
@@ -437,7 +437,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         the unique_identifier attribute of a GetAttributeList response
         payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -451,7 +451,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the attribute_names attribute of a GetAttributeList response
         payload can be properly set and retrieved.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
@@ -485,7 +485,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid list is used to set
         the attribute_names attribute of a GetAttributeList response payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
         args = (payload, 'attribute_names', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -500,7 +500,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         included in the list used to set the attribute_names attribute of a
         GetAttributeList response payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
         args = (
             payload,
             'attribute_names',
@@ -519,7 +519,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that duplicate attribute names are silently removed when setting
         the attribute_names attribute of a GetAttributeList response payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
@@ -554,7 +554,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload can be read from a data
         stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -587,7 +587,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no ID can be read
         from a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -614,7 +614,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no attribute names
         can be read from a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -637,7 +637,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no ID or attribute
         names can be read from a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -654,7 +654,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload can be written to a data
         stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -669,7 +669,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no ID can be
         written to a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             None,
             self.attribute_names
         )
@@ -690,7 +690,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no attribute names
         can be written to a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             None
         )
@@ -705,7 +705,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that a GetAttributeList response payload with no ID or attribute
         names can be written to a data stream.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload()
+        payload = payloads.GetAttributeListResponsePayload()
         stream = utils.BytearrayStream()
         payload.write(stream)
 
@@ -716,7 +716,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetAttributeList response payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -738,7 +738,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributeList response payload
         with no ID.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             None,
             self.attribute_names
         )
@@ -760,7 +760,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributeList response payload
         with no attribute names.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             None
         )
@@ -782,7 +782,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributeList response payload
         with no ID or attribute names.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             None,
             None
         )
@@ -803,7 +803,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         """
         Test that str can be applied to a GetAttributeList response payload.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -819,7 +819,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that str can be applied to a GetAttributeList response payload
         with no ID.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             None,
             self.attribute_names
         )
@@ -835,7 +835,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that str can be applied to a GetAttributeList response payload
         with no attribute names.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             None
         )
@@ -851,7 +851,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that str can be applied to a GetAttributeList response payload
         with no ID or attribute names.
         """
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             None,
             None
         )
@@ -867,11 +867,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetAttributeList response payloads with the same data.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -885,12 +885,12 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         GetAttributeList response payload with the same attribute_name sets
         but with different attribute name orderings.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
         self.attribute_names.reverse()
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -903,11 +903,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributeList response payloads with different IDs.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             'invalid',
             self.attribute_names
         )
@@ -920,11 +920,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributeList response payloads with different attribute names.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             None
         )
@@ -938,7 +938,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         GetAttributeList response payload to a non-GetAttributeList response
         payload.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -952,11 +952,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing
         two GetAttributeList response payloads with the same internal data.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -969,11 +969,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributeList response payloads with different IDs.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             'invalid',
             self.attribute_names
         )
@@ -986,11 +986,11 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributeList response payloads with different attribute names.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attribute_list.GetAttributeListResponsePayload(
+        b = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             None
         )
@@ -1004,7 +1004,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         GetAttributeList response payload to a non-GetAttributeList response
         payload.
         """
-        a = get_attribute_list.GetAttributeListResponsePayload(
+        a = payloads.GetAttributeListResponsePayload(
             self.unique_identifier,
             self.attribute_names
         )

--- a/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
@@ -20,7 +20,7 @@ from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
 
-from kmip.core.messages.payloads import get_attributes
+from kmip.core.messages import payloads
 
 
 class TestGetAttributesRequestPayload(testtools.TestCase):
@@ -82,14 +82,14 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload can be constructed with
         no arguments.
         """
-        get_attributes.GetAttributesRequestPayload()
+        payloads.GetAttributesRequestPayload()
 
     def test_init_with_args(self):
         """
         Test that a GetAttributes request payload can be constructed with a
         valid value.
         """
-        get_attributes.GetAttributesRequestPayload(
+        payloads.GetAttributesRequestPayload(
             'test-unique-identifier',
             ['test-attribute-name-1', 'test-attribute-name-2']
         )
@@ -99,7 +99,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the unique_identifier attribute of a GetAttributes request
         payload can be properly set and retrieved.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertIsNone(payload.unique_identifier)
         self.assertIsNone(payload._unique_identifier)
@@ -120,7 +120,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid ID is used to set
         the unique_identifier attribute of a GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -134,7 +134,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the attribute_names attribute of a GetAttributes request
         payload can be properly set and retrieved.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
@@ -168,7 +168,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid list is used to set
         the attribute_names attribute of a GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
         args = (payload, 'attribute_names', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -183,7 +183,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         included in the list used to set the attribute_names attribute of a
         GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
         args = (
             payload,
             'attribute_names',
@@ -202,7 +202,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that duplicate attribute names are silently removed when setting
         the attribute_names attribute of a GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(list(), payload.attribute_names)
         self.assertEqual(list(), payload._attribute_names)
@@ -237,7 +237,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload can be read from a data
         stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -270,7 +270,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no ID can be read
         from a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -297,7 +297,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no attribute names
         can be read from a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -320,7 +320,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no ID or attribute
         names can be read from a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attribute_names)
@@ -337,7 +337,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload can be written to a data
         stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -352,7 +352,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no ID can be written
         to a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             None,
             self.attribute_names
         )
@@ -373,7 +373,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no attribute names
         can be written to a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             None
         )
@@ -388,7 +388,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that a GetAttributes request payload with no ID or attribute
         names can be written to a data stream.
         """
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
         stream = utils.BytearrayStream()
         payload.write(stream)
 
@@ -399,7 +399,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -421,7 +421,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributes request payload with
         no ID.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             None,
             self.attribute_names
         )
@@ -443,7 +443,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributes request payload with
         no attribute names.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             None
         )
@@ -465,7 +465,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that repr can be applied to a GetAttributes request payload with
         no ID or attribute names.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             None,
             None
         )
@@ -486,7 +486,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         Test that str can be applied to a GetAttributes request payload.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -502,7 +502,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that str can be applied to a GetAttributes request payload with
         no ID.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             None,
             self.attribute_names
         )
@@ -518,7 +518,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that str can be applied to a GetAttributes request payload with
         no attribute names.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             None
         )
@@ -534,7 +534,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that str can be applied to a GetAttributes request payload with
         no ID or attribute names.
         """
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             None,
             None
         )
@@ -550,11 +550,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetAttributes request payloads with the same data.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -568,12 +568,12 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payload with the same attribute_name sets
         but with different attribute name orderings.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
         self.attribute_names.reverse()
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -586,11 +586,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes request payloads with different IDs.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             'invalid',
             self.attribute_names
         )
@@ -603,11 +603,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes request payloads with different attribute names.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             None
         )
@@ -621,7 +621,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payload to a non-GetAttributes request
         payload.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -635,11 +635,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing
         two GetAttributes request payloads with the same internal data.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -652,11 +652,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributes request payloads with different IDs.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             'invalid',
             self.attribute_names
         )
@@ -669,11 +669,11 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributes request payloads with different attribute names.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
-        b = get_attributes.GetAttributesRequestPayload(
+        b = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             None
         )
@@ -687,7 +687,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         GetAttributes request payload to a non-GetAttributes request
         payload.
         """
-        a = get_attributes.GetAttributesRequestPayload(
+        a = payloads.GetAttributesRequestPayload(
             self.unique_identifier,
             self.attribute_names
         )
@@ -791,14 +791,14 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         Test that a GetAttributes response payload can be constructed.
         """
-        get_attributes.GetAttributesResponsePayload()
+        payloads.GetAttributesResponsePayload()
 
     def test_init_with_args(self):
         """
         Test that a GetAttributes response payload can be constructed with a
         valid value.
         """
-        get_attributes.GetAttributesResponsePayload(
+        payloads.GetAttributesResponsePayload(
             'test-unique-identifier',
             [objects.Attribute(), objects.Attribute()]
         )
@@ -808,7 +808,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the unique_identifier attribute of a GetAttributes response
         payload can be properly set and retrieved.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
 
         self.assertIsNone(payload.unique_identifier)
         self.assertIsNone(payload._unique_identifier)
@@ -829,7 +829,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid ID is used to set
         the unique_identifier attribute of a GetAttributes response payload.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -843,7 +843,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the attributes attribute of a GetAttributes response
         payload can be properly set and retrieved.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
 
         self.assertEqual(list(), payload.attributes)
         self.assertEqual(list(), payload._attributes)
@@ -863,7 +863,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a TypeError is raised when an invalid list is used to set
         the attributes attribute of a GetAttributes response payload.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
         args = (payload, 'attributes', 0)
         self.assertRaisesRegexp(
             TypeError,
@@ -878,7 +878,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         in the list used to set the attributes attribute of a GetAttributes
         response payload.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
         args = (
             payload,
             'attributes',
@@ -897,7 +897,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a GetAttributes response payload can be read from a data
         stream.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
@@ -927,7 +927,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that an InvalidKmipEncoding error gets raised when attempting to
         read a GetAttributes response encoding with no ID data.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
@@ -945,7 +945,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a GetAttributes response payload without attribute name
         data can be read from a data stream.
         """
-        payload = get_attributes.GetAttributesResponsePayload()
+        payload = payloads.GetAttributesResponsePayload()
 
         self.assertEqual(None, payload._unique_identifier)
         self.assertEqual(list(), payload._attributes)
@@ -968,7 +968,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a GetAttributes response payload can be written to a data
         stream.
         """
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -983,7 +983,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a GetAttributes request payload with no ID can be written
         to a data stream.
         """
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             None,
             self.attributes
         )
@@ -1002,7 +1002,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that a GetAttributes response payload with no attribute name
         data can be written to a data stream.
         """
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             None
         )
@@ -1016,7 +1016,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         Test that repr can be applied to a GetAttributes response payload.
         """
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1037,7 +1037,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         Test that str can be applied to a GetAttributes response payload.
         """
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1053,11 +1053,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the equality operator returns True when comparing two
         GetAttributes response payloads with the same data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1070,11 +1070,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             'invalid',
             self.attributes
         )
@@ -1087,13 +1087,13 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
         reversed_attributes = copy.deepcopy(self.attributes)
         reversed_attributes.reverse()
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             reversed_attributes
         )
@@ -1106,11 +1106,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             list()
         )
@@ -1123,11 +1123,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the equality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             None
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1141,7 +1141,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payload to a non-GetAttributes response
         payload.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1155,11 +1155,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing
         two GetAttributes response payloads with the same internal data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1172,11 +1172,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the inequality operator returns True when comparing two
         GetAttributes request payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             'invalid',
             self.attributes
         )
@@ -1189,13 +1189,13 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
         reversed_attributes = copy.deepcopy(self.attributes)
         reversed_attributes.reverse()
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             reversed_attributes
         )
@@ -1208,11 +1208,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             list()
         )
@@ -1225,11 +1225,11 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         Test that the inequality operator returns False when comparing two
         GetAttributes response payloads with different data.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             None
         )
-        b = get_attributes.GetAttributesResponsePayload(
+        b = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )
@@ -1243,7 +1243,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         GetAttributes response payload to a non-GetAttributes response
         payload.
         """
-        a = get_attributes.GetAttributesResponsePayload(
+        a = payloads.GetAttributesResponsePayload(
             self.unique_identifier,
             self.attributes
         )

--- a/kmip/tests/unit/core/messages/payloads/test_mac.py
+++ b/kmip/tests/unit/core/messages/payloads/test_mac.py
@@ -20,7 +20,7 @@ from kmip.core import utils
 from kmip.core import enums
 from kmip.core import exceptions
 
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 
 class TestMACRequestPayload(TestCase):
@@ -55,14 +55,14 @@ class TestMACRequestPayload(TestCase):
         super(TestMACRequestPayload, self).tearDown()
 
     def test_init_with_none(self):
-        mac.MACRequestPayload()
+        payloads.MACRequestPayload()
 
     def test_init_valid(self):
         """
         Test that the payload can be properly constructed and the attributes
         cab be properly set and retrieved.
         """
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             self.unique_identifier,
             self.cryptographic_parameters,
             self.data)
@@ -77,7 +77,7 @@ class TestMACRequestPayload(TestCase):
                   'data': None}
         self.assertRaisesRegexp(
             TypeError, "unique identifier must be UniqueIdentifier type",
-            mac.MACRequestPayload, **kwargs)
+            payloads.MACRequestPayload, **kwargs)
 
     def test_init_with_invalid_cryptographic_parameters(self):
         kwargs = {'unique_identifier': None,
@@ -86,7 +86,7 @@ class TestMACRequestPayload(TestCase):
         self.assertRaisesRegexp(
             TypeError,
             "cryptographic parameters must be CryptographicParameters type",
-            mac.MACRequestPayload, **kwargs)
+            payloads.MACRequestPayload, **kwargs)
 
     def test_init_with_invalid_data(self):
         kwargs = {'unique_identifier': None,
@@ -94,11 +94,11 @@ class TestMACRequestPayload(TestCase):
                   'data': 'invalid'}
         self.assertRaises(
             TypeError, "data must be Data type",
-            mac.MACRequestPayload, **kwargs)
+            payloads.MACRequestPayload, **kwargs)
 
     def test_read_valid(self):
         stream = self.encoding_full
-        payload = mac.MACRequestPayload()
+        payload = payloads.MACRequestPayload()
         payload.read(stream)
 
         self.assertEqual(self.unique_identifier, payload.unique_identifier)
@@ -111,7 +111,7 @@ class TestMACRequestPayload(TestCase):
         Test that an InvalidKmipEncoding error gets raised when attempting to
         read a mac request encoding with no data.
         """
-        payload = mac.MACRequestPayload()
+        payload = payloads.MACRequestPayload()
         args = (self.encoding_no_data,)
         self.assertRaisesRegexp(
             exceptions.InvalidKmipEncoding,
@@ -124,7 +124,7 @@ class TestMACRequestPayload(TestCase):
         expected = self.encoding_full
 
         stream = utils.BytearrayStream()
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             self.unique_identifier,
             self.cryptographic_parameters,
             self.data)
@@ -138,7 +138,7 @@ class TestMACRequestPayload(TestCase):
         write a mac request with no data.
         """
         stream = utils.BytearrayStream()
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             self.unique_identifier,
             self.cryptographic_parameters,
             None)
@@ -189,14 +189,14 @@ class TestMACResponsePayload(TestCase):
         super(TestMACResponsePayload, self).tearDown()
 
     def test_init_with_none(self):
-        mac.MACResponsePayload()
+        payloads.MACResponsePayload()
 
     def test_init_valid(self):
         """
         Test that the payload can be properly constructed and the attributes
         can be properly set and retrieved.
         """
-        payload = mac.MACResponsePayload(
+        payload = payloads.MACResponsePayload(
             self.unique_identifier,
             self.mac_data)
         self.assertEqual(payload.unique_identifier, self.unique_identifier)
@@ -207,18 +207,18 @@ class TestMACResponsePayload(TestCase):
                   'mac_data': None}
         self.assertRaisesRegexp(
             TypeError, "unique identifier must be UniqueIdentifier type",
-            mac.MACResponsePayload, **kwargs)
+            payloads.MACResponsePayload, **kwargs)
 
     def test_init_with_invalid_mac_data(self):
         kwargs = {'unique_identifier': None,
                   'mac_data': 'invalid'}
         self.assertRaises(
             TypeError, "data must be MACData type",
-            mac.MACResponsePayload, **kwargs)
+            payloads.MACResponsePayload, **kwargs)
 
     def test_read_valid(self):
         stream = self.encoding_full
-        payload = mac.MACResponsePayload()
+        payload = payloads.MACResponsePayload()
         payload.read(stream)
 
         self.assertEqual(self.unique_identifier, payload.unique_identifier)
@@ -229,7 +229,7 @@ class TestMACResponsePayload(TestCase):
         Test that an InvalidKmipEncoding error gets raised when attempting to
         read a mac response encoding with no unique identifier.
         """
-        payload = mac.MACResponsePayload()
+        payload = payloads.MACResponsePayload()
         args = (self.encoding_no_unique_identifier,)
         self.assertRaisesRegexp(
             exceptions.InvalidKmipEncoding,
@@ -243,7 +243,7 @@ class TestMACResponsePayload(TestCase):
         Test that an InvalidKmipEncoding error gets raised when attempting to
         read a mac response encoding with no mac data.
         """
-        payload = mac.MACResponsePayload()
+        payload = payloads.MACResponsePayload()
         args = (self.encoding_no_mac_data,)
         self.assertRaisesRegexp(
             exceptions.InvalidKmipEncoding,
@@ -256,7 +256,7 @@ class TestMACResponsePayload(TestCase):
         expected = self.encoding_full
 
         stream = utils.BytearrayStream()
-        payload = mac.MACResponsePayload(
+        payload = payloads.MACResponsePayload(
             self.unique_identifier,
             self.mac_data)
         payload.write(stream)
@@ -269,7 +269,7 @@ class TestMACResponsePayload(TestCase):
         write a mac response with no unique identifier.
         """
         stream = utils.BytearrayStream()
-        payload = mac.MACResponsePayload(
+        payload = payloads.MACResponsePayload(
             None,
             self.mac_data)
         args = (stream,)
@@ -286,7 +286,7 @@ class TestMACResponsePayload(TestCase):
         write a mac response with no mac data.
         """
         stream = utils.BytearrayStream()
-        payload = mac.MACResponsePayload(
+        payload = payloads.MACResponsePayload(
             self.unique_identifier,
             None)
         args = (stream,)

--- a/kmip/tests/unit/core/messages/payloads/test_query.py
+++ b/kmip/tests/unit/core/messages/payloads/test_query.py
@@ -26,7 +26,7 @@ from kmip.core.enums import Operation as OperationEnum
 from kmip.core.enums import QueryFunction as QueryFunctionEnum
 
 from kmip.core.messages.contents import Operation
-from kmip.core.messages.payloads import query
+from kmip.core.messages import payloads
 
 from kmip.core.misc import QueryFunction
 from kmip.core.misc import VendorIdentification
@@ -82,16 +82,16 @@ class TestQueryRequestPayload(TestCase):
         Test that a QueryRequestPayload object can be constructed with no
         specified value.
         """
-        query.QueryRequestPayload()
+        payloads.QueryRequestPayload()
 
     def test_init_with_args(self):
         """
         Test that a QueryRequestPayload object can be constructed with valid
         values.
         """
-        query.QueryRequestPayload(self.query_functions_a)
-        query.QueryRequestPayload(self.query_functions_b)
-        query.QueryRequestPayload(self.query_functions_c)
+        payloads.QueryRequestPayload(self.query_functions_a)
+        payloads.QueryRequestPayload(self.query_functions_b)
+        payloads.QueryRequestPayload(self.query_functions_c)
 
     def test_validate_with_invalid_query_functions_list(self):
         """
@@ -101,7 +101,7 @@ class TestQueryRequestPayload(TestCase):
         kwargs = {'query_functions': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid query functions list",
-            query.QueryRequestPayload, **kwargs)
+            payloads.QueryRequestPayload, **kwargs)
 
     def test_validate_with_invalid_query_functions_item(self):
         """
@@ -111,10 +111,10 @@ class TestQueryRequestPayload(TestCase):
         kwargs = {'query_functions': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid query function",
-            query.QueryRequestPayload, **kwargs)
+            payloads.QueryRequestPayload, **kwargs)
 
     def _test_read(self, stream, query_functions):
-        payload = query.QueryRequestPayload()
+        payload = payloads.QueryRequestPayload()
         payload.read(stream)
         expected = len(query_functions)
         observed = len(payload.query_functions)
@@ -155,7 +155,7 @@ class TestQueryRequestPayload(TestCase):
 
     def _test_write(self, encoding, query_functions):
         stream = utils.BytearrayStream()
-        payload = query.QueryRequestPayload(query_functions)
+        payload = payloads.QueryRequestPayload(query_functions)
         payload.write(stream)
 
         length_expected = len(encoding)
@@ -307,14 +307,14 @@ class TestQueryResponsePayload(TestCase):
         Test that a QueryResponsePayload object can be constructed with no
         specified value.
         """
-        query.QueryResponsePayload()
+        payloads.QueryResponsePayload()
 
     def test_init_with_args(self):
         """
         Test that a QueryResponsePayload object can be constructed with valid
         values.
         """
-        query.QueryResponsePayload(
+        payloads.QueryResponsePayload(
             operations=self.operations,
             object_types=self.object_types,
             vendor_identification=self.vendor_identification,
@@ -330,7 +330,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'operations': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid operations list",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_operations_item(self):
         """
@@ -340,7 +340,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'operations': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid operation",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_object_types_list(self):
         """
@@ -350,7 +350,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'object_types': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid object types list",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_object_types_item(self):
         """
@@ -360,7 +360,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'object_types': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid object type",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_vendor_identification(self):
         """
@@ -371,7 +371,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'vendor_identification': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid vendor identification",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_server_information(self):
         """
@@ -382,7 +382,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'server_information': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid server information",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_application_namespaces_list(self):
         """
@@ -393,7 +393,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'application_namespaces': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid application namespaces list",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_application_namespaces_item(self):
         """
@@ -404,7 +404,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'application_namespaces': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid application namespace",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_extension_information_list(self):
         """
@@ -415,7 +415,7 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'extension_information': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid extension information list",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def test_validate_with_invalid_extension_information_item(self):
         """
@@ -426,12 +426,12 @@ class TestQueryResponsePayload(TestCase):
         kwargs = {'extension_information': ['invalid']}
         self.assertRaisesRegexp(
             TypeError, "invalid extension information",
-            query.QueryResponsePayload, **kwargs)
+            payloads.QueryResponsePayload, **kwargs)
 
     def _test_read(self, stream, operations, object_types,
                    vendor_identification, server_information,
                    application_namespaces, extension_information):
-        payload = query.QueryResponsePayload()
+        payload = payloads.QueryResponsePayload()
         payload.read(stream)
 
         # Test decoding of all operations.
@@ -541,7 +541,7 @@ class TestQueryResponsePayload(TestCase):
                     vendor_identification, server_information,
                     application_namespaces, extension_information):
         stream = utils.BytearrayStream()
-        payload = query.QueryResponsePayload(
+        payload = payloads.QueryResponsePayload(
             operations, object_types, vendor_identification,
             server_information, application_namespaces, extension_information)
         payload.write(stream)

--- a/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
@@ -20,7 +20,7 @@ from kmip.core import misc
 from kmip.core import objects
 from kmip.core import utils
 
-from kmip.core.messages.payloads import rekey_key_pair
+from kmip.core.messages import payloads
 
 
 class TestRekeyKeyPairRequestPayload(TestCase):
@@ -53,10 +53,10 @@ class TestRekeyKeyPairRequestPayload(TestCase):
         super(TestRekeyKeyPairRequestPayload, self).tearDown()
 
     def test_init_with_none(self):
-        rekey_key_pair.RekeyKeyPairRequestPayload()
+        payloads.RekeyKeyPairRequestPayload()
 
     def test_init_with_args(self):
-        rekey_key_pair.RekeyKeyPairRequestPayload(
+        payloads.RekeyKeyPairRequestPayload(
             self.private_key_uuid, self.offset, self.common_template_attribute,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -68,7 +68,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key unique identifier",
-            rekey_key_pair.RekeyKeyPairRequestPayload, **kwargs)
+            payloads.RekeyKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_offset(self):
         kwargs = {'private_key_uuid': None, 'offset': 'invalid',
@@ -77,7 +77,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid offset",
-            rekey_key_pair.RekeyKeyPairRequestPayload, **kwargs)
+            payloads.RekeyKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_common_template_attribute(self):
         kwargs = {'private_key_uuid': None, 'offset': None,
@@ -86,7 +86,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid common template attribute",
-            rekey_key_pair.RekeyKeyPairRequestPayload, **kwargs)
+            payloads.RekeyKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_private_key_template_attribute(self):
         kwargs = {'private_key_uuid': None, 'offset': None,
@@ -95,7 +95,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key template attribute",
-            rekey_key_pair.RekeyKeyPairRequestPayload, **kwargs)
+            payloads.RekeyKeyPairRequestPayload, **kwargs)
 
     def test_validate_with_invalid_public_key_template_attribute(self):
         kwargs = {'private_key_uuid': None, 'offset': None,
@@ -104,7 +104,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'public_key_template_attribute': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid public key template attribute",
-            rekey_key_pair.RekeyKeyPairRequestPayload, **kwargs)
+            payloads.RekeyKeyPairRequestPayload, **kwargs)
 
     def _test_read(self, stream, payload, private_key_uuid, offset,
                    common_template_attribute, private_key_template_attribute,
@@ -142,13 +142,13 @@ class TestRekeyKeyPairRequestPayload(TestCase):
 
     def test_read_with_none(self):
         stream = self.encoding_empty
-        payload = rekey_key_pair.RekeyKeyPairRequestPayload()
+        payload = payloads.RekeyKeyPairRequestPayload()
 
         self._test_read(stream, payload, None, None, None, None, None)
 
     def test_read_with_args(self):
         stream = self.encoding_full
-        payload = rekey_key_pair.RekeyKeyPairRequestPayload()
+        payload = payloads.RekeyKeyPairRequestPayload()
 
         self._test_read(stream, payload, self.private_key_uuid, self.offset,
                         self.common_template_attribute,
@@ -173,13 +173,13 @@ class TestRekeyKeyPairRequestPayload(TestCase):
 
     def test_write_with_none(self):
         stream = utils.BytearrayStream()
-        payload = rekey_key_pair.RekeyKeyPairRequestPayload()
+        payload = payloads.RekeyKeyPairRequestPayload()
 
         self._test_write(stream, payload, self.encoding_empty)
 
     def test_write_with_args(self):
         stream = utils.BytearrayStream()
-        payload = rekey_key_pair.RekeyKeyPairRequestPayload(
+        payload = payloads.RekeyKeyPairRequestPayload(
             self.private_key_uuid, self.offset, self.common_template_attribute,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -222,10 +222,10 @@ class TestRekeyKeyPairResponsePayload(TestCase):
         super(TestRekeyKeyPairResponsePayload, self).tearDown()
 
     def test_init_with_none(self):
-        rekey_key_pair.RekeyKeyPairResponsePayload()
+        payloads.RekeyKeyPairResponsePayload()
 
     def test_init_with_args(self):
-        rekey_key_pair.RekeyKeyPairResponsePayload(
+        payloads.RekeyKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -237,7 +237,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key unique identifier",
-            rekey_key_pair.RekeyKeyPairResponsePayload, **kwargs)
+            payloads.RekeyKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_public_key_unique_identifier(self):
         kwargs = {'private_key_uuid': None,
@@ -246,7 +246,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid public key unique identifier",
-            rekey_key_pair.RekeyKeyPairResponsePayload, **kwargs)
+            payloads.RekeyKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_private_key_template_attribute(self):
         kwargs = {'private_key_uuid': None,
@@ -255,7 +255,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': None}
         self.assertRaisesRegexp(
             TypeError, "invalid private key template attribute",
-            rekey_key_pair.RekeyKeyPairResponsePayload, **kwargs)
+            payloads.RekeyKeyPairResponsePayload, **kwargs)
 
     def test_validate_with_invalid_public_key_template_attribute(self):
         kwargs = {'private_key_uuid': None,
@@ -264,7 +264,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_template_attribute': 'invalid'}
         self.assertRaisesRegexp(
             TypeError, "invalid public key template attribute",
-            rekey_key_pair.RekeyKeyPairResponsePayload, **kwargs)
+            payloads.RekeyKeyPairResponsePayload, **kwargs)
 
     def _test_read(self, stream, payload, private_key_uuid, public_key_uuid,
                    private_key_template_attribute,
@@ -297,14 +297,14 @@ class TestRekeyKeyPairResponsePayload(TestCase):
 
     def test_read_with_none(self):
         stream = self.encoding_empty
-        payload = rekey_key_pair.RekeyKeyPairResponsePayload()
+        payload = payloads.RekeyKeyPairResponsePayload()
 
         self._test_read(stream, payload, self.empty_private_key_uuid,
                         self.empty_public_key_uuid, None, None)
 
     def test_read_with_args(self):
         stream = self.encoding_full
-        payload = rekey_key_pair.RekeyKeyPairResponsePayload(
+        payload = payloads.RekeyKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)
@@ -332,13 +332,13 @@ class TestRekeyKeyPairResponsePayload(TestCase):
 
     def test_write_with_none(self):
         stream = utils.BytearrayStream()
-        payload = rekey_key_pair.RekeyKeyPairResponsePayload()
+        payload = payloads.RekeyKeyPairResponsePayload()
 
         self._test_write(stream, payload, self.encoding_empty)
 
     def test_write_with_args(self):
         stream = utils.BytearrayStream()
-        payload = rekey_key_pair.RekeyKeyPairResponsePayload(
+        payload = payloads.RekeyKeyPairResponsePayload(
             self.private_key_uuid, self.public_key_uuid,
             self.private_key_template_attribute,
             self.public_key_template_attribute)

--- a/kmip/tests/unit/core/messages/payloads/test_revoke.py
+++ b/kmip/tests/unit/core/messages/payloads/test_revoke.py
@@ -21,7 +21,7 @@ from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
 
-from kmip.core.messages.payloads import revoke
+from kmip.core.messages import payloads
 
 
 class TestRevokeRequestPayload(TestCase):
@@ -55,14 +55,14 @@ class TestRevokeRequestPayload(TestCase):
         Test that a RevokeRequestPayload object can be constructed with no
         specified value.
         """
-        revoke.RevokeRequestPayload()
+        payloads.RevokeRequestPayload()
 
     def test_init_with_args(self):
         """
         Test that a RevokeRequestPayload object can be constructed with valid
         values.
         """
-        revoke.RevokeRequestPayload(unique_identifier=self.uuid)
+        payloads.RevokeRequestPayload(unique_identifier=self.uuid)
 
     def test_validate_with_bad_uuid_type(self):
         """
@@ -71,7 +71,7 @@ class TestRevokeRequestPayload(TestCase):
         """
         self.assertRaisesRegexp(
             TypeError, "invalid unique identifier",
-            revoke.RevokeRequestPayload, "not-a-uuid")
+            payloads.RevokeRequestPayload, "not-a-uuid")
 
     def test_validate_with_bad_date_type(self):
         """
@@ -81,7 +81,7 @@ class TestRevokeRequestPayload(TestCase):
         reason = objects.RevocationReason()
         self.assertRaisesRegexp(
             TypeError, "invalid compromise time",
-            revoke.RevokeRequestPayload, self.uuid, reason, "not-a-date")
+            payloads.RevokeRequestPayload, self.uuid, reason, "not-a-date")
 
     def test_validate_with_bad_reason_type(self):
         """
@@ -90,14 +90,14 @@ class TestRevokeRequestPayload(TestCase):
         """
         self.assertRaisesRegexp(
             TypeError, "invalid revocation reason",
-            revoke.RevokeRequestPayload, self.uuid, "not-a-reason")
+            payloads.RevokeRequestPayload, self.uuid, "not-a-reason")
 
     def test_read_with_known_uuid(self):
         """
         Test that a RevokeRequestPayload object with known UUID can be read
         from a data stream.
         """
-        payload = revoke.RevokeRequestPayload()
+        payload = payloads.RevokeRequestPayload()
         payload.read(self.encoding_a)
         expected = '668eff89-3010-4258-bc0e-8c402309c746'
         observed = payload.unique_identifier.value
@@ -118,7 +118,7 @@ class TestRevokeRequestPayload(TestCase):
             tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE, value=6)
 
         stream = utils.BytearrayStream()
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=self.uuid,
             revocation_reason=reason,
             compromise_occurrence_date=date)
@@ -165,14 +165,14 @@ class TestRevokeResponsePayload(TestCase):
         Test that a RevokeResponsePayload object can be constructed with no
         specified value.
         """
-        revoke.RevokeResponsePayload()
+        payloads.RevokeResponsePayload()
 
     def test_init_with_args(self):
         """
         Test that a RevokeResponsePayload object can be constructed with
         valid values.
         """
-        revoke.RevokeResponsePayload(unique_identifier=self.uuid)
+        payloads.RevokeResponsePayload(unique_identifier=self.uuid)
 
     def test_validate_with_invalid_uuid(self):
         """
@@ -181,14 +181,14 @@ class TestRevokeResponsePayload(TestCase):
         """
         self.assertRaisesRegexp(
             TypeError, "invalid unique identifier",
-            revoke.RevokeResponsePayload, "not-a-uuid")
+            payloads.RevokeResponsePayload, "not-a-uuid")
 
     def test_read_with_known_uuid(self):
         """
         Test that a RevokeResponsePayload object with known UUID can be read
         from a data stream.
         """
-        payload = revoke.RevokeResponsePayload()
+        payload = payloads.RevokeResponsePayload()
         payload.read(self.encoding_a)
         expected = '668eff89-3010-4258-bc0e-8c402309c746'
         observed = payload.unique_identifier.value
@@ -204,7 +204,7 @@ class TestRevokeResponsePayload(TestCase):
         written to a data stream.
         """
         stream = utils.BytearrayStream()
-        payload = revoke.RevokeResponsePayload(self.uuid)
+        payload = payloads.RevokeResponsePayload(self.uuid)
         payload.write(stream)
 
         length_expected = len(self.encoding_a)

--- a/kmip/tests/unit/core/messages/test_messages.py
+++ b/kmip/tests/unit/core/messages/test_messages.py
@@ -43,12 +43,7 @@ from kmip.core import objects
 
 from kmip.core.messages import contents
 from kmip.core.messages import messages
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import mac
+from kmip.core.messages import payloads
 
 from kmip.core.misc import KeyFormatType
 from kmip.core.primitives import TextString
@@ -247,8 +242,8 @@ class TestRequestMessage(TestCase):
         request_payload = batch_item.request_payload
         msg = "Bad request payload type: expected {0}, received {1}"
         self.assertIsInstance(request_payload,
-                              create.CreateRequestPayload,
-                              msg.format(create.CreateRequestPayload,
+                              payloads.CreateRequestPayload,
+                              msg.format(payloads.CreateRequestPayload,
                                          type(request_payload)))
 
         object_type = request_payload.object_type
@@ -384,8 +379,10 @@ class TestRequestMessage(TestCase):
 
         temp_attr = objects.TemplateAttribute(attributes=[attr_a, attr_b,
                                                           attr_c])
-        req_pl = create.CreateRequestPayload(object_type=object_type,
-                                             template_attribute=temp_attr)
+        req_pl = payloads.CreateRequestPayload(
+            object_type=object_type,
+            template_attribute=temp_attr
+        )
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=req_pl)
         req_message = messages.RequestMessage(request_header=request_header,
@@ -476,8 +473,8 @@ class TestRequestMessage(TestCase):
         request_payload = batch_item.request_payload
         msg = "Bad request payload type: expected {0}, received {1}"
         self.assertIsInstance(request_payload,
-                              get.GetRequestPayload,
-                              msg.format(get.GetRequestPayload,
+                              payloads.GetRequestPayload,
+                              msg.format(payloads.GetRequestPayload,
                                          type(request_payload)))
 
         # unique_identifier = request_payload.unique_identifier
@@ -501,7 +498,7 @@ class TestRequestMessage(TestCase):
         operation = contents.Operation(enums.Operation.GET)
 
 #        uuid = attr.UniqueIdentifier('49a1ca88-6bea-4fb2-b450-7e58802c3038')
-        request_payload = get.GetRequestPayload(
+        request_payload = payloads.GetRequestPayload(
             unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
         )
         batch_item = messages.RequestBatchItem(operation=operation,
@@ -594,7 +591,7 @@ class TestRequestMessage(TestCase):
 
         request_payload = batch_item.request_payload
         msg = "Bad request payload type: expected {0}, received {1}"
-        exp_type = destroy.DestroyRequestPayload
+        exp_type = payloads.DestroyRequestPayload
         rcv_type = type(request_payload)
         self.assertIsInstance(request_payload, exp_type,
                               msg.format(exp_type, rcv_type))
@@ -620,7 +617,9 @@ class TestRequestMessage(TestCase):
         operation = contents.Operation(enums.Operation.DESTROY)
 
         uuid = attr.UniqueIdentifier('fb4b5b9c-6188-4c63-8142-fe9c328129fc')
-        request_payload = destroy.DestroyRequestPayload(unique_identifier=uuid)
+        request_payload = payloads.DestroyRequestPayload(
+            unique_identifier=uuid
+        )
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=request_payload)
         request_message = messages.RequestMessage(request_header=req_header,
@@ -711,7 +710,7 @@ class TestRequestMessage(TestCase):
 
             request_payload = batch_item.request_payload
             msg = "Bad request payload type: expected {0}, received {1}"
-            exp_type = register.RegisterRequestPayload
+            exp_type = payloads.RegisterRequestPayload
             rcv_type = type(request_payload)
             self.assertIsInstance(request_payload, exp_type,
                                   msg.format(exp_type, rcv_type))
@@ -817,7 +816,7 @@ class TestRequestMessage(TestCase):
 
         template = Template(attributes=attributes)
 
-        request_payload = register.RegisterRequestPayload(
+        request_payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=tmpl_attr,
             secret=template)
@@ -910,7 +909,7 @@ class TestRequestMessage(TestCase):
 
         request_payload = batch_item.request_payload
         msg = "Bad request payload type: expected {0}, received {1}"
-        exp_type = locate.LocateRequestPayload
+        exp_type = payloads.LocateRequestPayload
         rcv_type = type(request_payload)
         self.assertIsInstance(request_payload, exp_type,
                               msg.format(exp_type, rcv_type))
@@ -1056,8 +1055,8 @@ class TestRequestMessage(TestCase):
         request_payload = batch_item.request_payload
         msg = "Bad request payload type: expected {0}, received {1}"
         self.assertIsInstance(request_payload,
-                              mac.MACRequestPayload,
-                              msg.format(mac.MACRequestPayload,
+                              payloads.MACRequestPayload,
+                              msg.format(payloads.MACRequestPayload,
                                          type(request_payload)))
 
         unique_identifier = request_payload.unique_identifier
@@ -1118,7 +1117,7 @@ class TestRequestMessage(TestCase):
         parameters_attribute = attr.CryptographicParameters(
             cryptographic_algorithm=enums.CryptographicAlgorithm.HMAC_SHA512
         )
-        request_payload = mac.MACRequestPayload(
+        request_payload = payloads.MACRequestPayload(
             unique_identifier=uuid,
             cryptographic_parameters=parameters_attribute,
             data=data
@@ -1345,7 +1344,7 @@ class TestResponseMessage(TestCase):
                                              result_status.value))
 
             response_payload = batch_item.response_payload
-            exp_type = create.CreateResponsePayload
+            exp_type = payloads.CreateResponsePayload
             rcv_type = type(response_payload)
             self.assertIsInstance(response_payload, exp_type,
                                   self.msg.format('response payload', 'type',
@@ -1387,8 +1386,10 @@ class TestResponseMessage(TestCase):
 
         uuid = 'fb4b5b9c-6188-4c63-8142-fe9c328129fc'
         uniq_id = attr.UniqueIdentifier(uuid)
-        resp_pl = create.CreateResponsePayload(object_type=object_type,
-                                               unique_identifier=uniq_id)
+        resp_pl = payloads.CreateResponsePayload(
+            object_type=object_type,
+            unique_identifier=uniq_id
+        )
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
                                                 response_payload=resp_pl)
@@ -1494,7 +1495,7 @@ class TestResponseMessage(TestCase):
                                              result_status.value))
 
             response_payload = batch_item.response_payload
-            exp_type = get.GetResponsePayload
+            exp_type = payloads.GetResponsePayload
             rcv_type = type(response_payload)
             self.assertIsInstance(response_payload, exp_type,
                                   self.msg.format('response payload', 'type',
@@ -1610,9 +1611,11 @@ class TestResponseMessage(TestCase):
 
         secret = SymmetricKey(key_block)
 
-        resp_pl = get.GetResponsePayload(object_type=object_type.value,
-                                         unique_identifier=uniq_id.value,
-                                         secret=secret)
+        resp_pl = payloads.GetResponsePayload(
+            object_type=object_type.value,
+            unique_identifier=uniq_id.value,
+            secret=secret
+        )
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
                                                 response_payload=resp_pl)
@@ -1726,7 +1729,7 @@ class TestResponseMessage(TestCase):
 
             response_payload = batch_item.response_payload
             msg = "Bad response payload type: expected {0}, received {1}"
-            exp_type = destroy.DestroyResponsePayload
+            exp_type = payloads.DestroyResponsePayload
             rcv_type = type(response_payload)
             self.assertIsInstance(response_payload, exp_type,
                                   msg.format(exp_type, rcv_type))
@@ -1757,7 +1760,7 @@ class TestResponseMessage(TestCase):
         result_status = contents.ResultStatus(enums.ResultStatus.SUCCESS)
 
         uuid = attr.UniqueIdentifier('fb4b5b9c-6188-4c63-8142-fe9c328129fc')
-        resp_pl = destroy.DestroyResponsePayload(unique_identifier=uuid)
+        resp_pl = payloads.DestroyResponsePayload(unique_identifier=uuid)
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
                                                 response_payload=resp_pl)
@@ -1869,7 +1872,7 @@ class TestResponseMessage(TestCase):
 
             response_payload = batch_item.response_payload
             msg = "Bad response payload type: expected {0}, received {1}"
-            exp_type = register.RegisterResponsePayload
+            exp_type = payloads.RegisterResponsePayload
             rcv_type = type(response_payload)
             self.assertIsInstance(response_payload, exp_type,
                                   msg.format(exp_type, rcv_type))
@@ -1900,7 +1903,7 @@ class TestResponseMessage(TestCase):
         result_status = contents.ResultStatus(enums.ResultStatus.SUCCESS)
 
         uuid = attr.UniqueIdentifier('5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3')
-        resp_pl = register.RegisterResponsePayload(unique_identifier=uuid)
+        resp_pl = payloads.RegisterResponsePayload(unique_identifier=uuid)
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
                                                 response_payload=resp_pl)
@@ -1933,7 +1936,7 @@ class TestResponseMessage(TestCase):
         result_status = contents.ResultStatus(enums.ResultStatus.SUCCESS)
         uuid = attr.UniqueIdentifier('49a1ca88-6bea-4fb2-b450-7e58802c3038')
 
-        resp_pl = locate.LocateResponsePayload(unique_identifiers=[uuid])
+        resp_pl = payloads.LocateResponsePayload(unique_identifiers=[uuid])
 
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
@@ -2041,7 +2044,7 @@ class TestResponseMessage(TestCase):
                                              result_status.value))
 
             response_payload = batch_item.response_payload
-            exp_type = mac.MACResponsePayload
+            exp_type = payloads.MACResponsePayload
             rcv_type = type(response_payload)
             self.assertIsInstance(response_payload, exp_type,
                                   self.msg.format('response payload', 'type',
@@ -2103,8 +2106,10 @@ class TestResponseMessage(TestCase):
              b'\xff\x7c')
         mac_data = objects.MACData(value)
 
-        resp_pl = mac.MACResponsePayload(unique_identifier=uniq_id,
-                                         mac_data=mac_data)
+        resp_pl = payloads.MACResponsePayload(
+            unique_identifier=uniq_id,
+            mac_data=mac_data
+        )
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,
                                                 response_payload=resp_pl)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -38,25 +38,7 @@ from kmip.core.factories import attributes as factory
 
 from kmip.core.messages import contents
 from kmip.core.messages import messages
-
-from kmip.core.messages.payloads import activate
-from kmip.core.messages.payloads import revoke
-from kmip.core.messages.payloads import create
-from kmip.core.messages.payloads import create_key_pair
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads import destroy
-from kmip.core.messages.payloads import discover_versions
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import query
-from kmip.core.messages.payloads import register
-from kmip.core.messages.payloads import mac
-from kmip.core.messages.payloads import locate
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
+from kmip.core.messages import payloads
 
 from kmip.pie import objects as pie_objects
 from kmip.pie import sqltypes
@@ -97,7 +79,7 @@ class TestKmipEngine(testtools.TestCase):
         super(TestKmipEngine, self).tearDown()
 
     def _build_request(self):
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         batch = [
             messages.RequestBatchItem(
                 operation=contents.Operation(
@@ -343,7 +325,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         e._process_discover_versions(payload)
 
     def test_version_operation_mismatch(self):
@@ -386,7 +368,7 @@ class TestKmipEngine(testtools.TestCase):
             time_stamp=contents.TimeStamp(int(time.time())),
             batch_count=contents.BatchCount(1)
         )
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         batch = list([
             messages.RequestBatchItem(
                 operation=contents.Operation(
@@ -444,7 +426,7 @@ class TestKmipEngine(testtools.TestCase):
         self.assertIsNone(batch_item.async_correlation_value)
         self.assertIsInstance(
             batch_item.response_payload,
-            discover_versions.DiscoverVersionsResponsePayload
+            payloads.DiscoverVersionsResponsePayload
         )
         self.assertIsNone(batch_item.message_extension)
 
@@ -618,7 +600,7 @@ class TestKmipEngine(testtools.TestCase):
             time_stamp=contents.TimeStamp(int(time.time())),
             batch_count=contents.BatchCount(1)
         )
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         batch = list([
             messages.RequestBatchItem(
                 operation=contents.Operation(
@@ -691,7 +673,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         batch = list([
             messages.RequestBatchItem(
                 operation=contents.Operation(
@@ -718,7 +700,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
         batch = list([
             messages.RequestBatchItem(
                 operation=contents.Operation(
@@ -2412,7 +2394,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type,
             template_attribute
         )
@@ -2474,7 +2456,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
 
         object_type = attributes.ObjectType(enums.ObjectType.PUBLIC_KEY)
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type
         )
 
@@ -2529,7 +2511,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type,
             template_attribute
         )
@@ -2575,7 +2557,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type,
             template_attribute
         )
@@ -2618,7 +2600,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type,
             template_attribute
         )
@@ -2691,7 +2673,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -2823,7 +2805,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -2890,7 +2872,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -2957,7 +2939,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3024,7 +3006,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3089,7 +3071,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3154,7 +3136,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3238,7 +3220,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3308,7 +3290,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -3391,7 +3373,7 @@ class TestKmipEngine(testtools.TestCase):
             )
         )
 
-        payload = register.RegisterRequestPayload(
+        payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
             secret=secret
@@ -3454,7 +3436,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
 
         object_type = attributes.ObjectType(enums.ObjectType.SPLIT_KEY)
-        payload = register.RegisterRequestPayload(object_type=object_type)
+        payload = payloads.RegisterRequestPayload(object_type=object_type)
 
         args = (payload, )
         regex = "The SplitKey object type is not supported."
@@ -3478,7 +3460,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
 
         object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
-        payload = register.RegisterRequestPayload(object_type=object_type)
+        payload = payloads.RegisterRequestPayload(object_type=object_type)
 
         args = (payload, )
         regex = "Cannot register a secret in absentia."
@@ -3518,7 +3500,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Derive a SymmetricKey object.
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.HMAC,
@@ -3603,7 +3585,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         # Derive a SecretData object.
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SECRET_DATA,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.ENCRYPT,
@@ -3691,7 +3673,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Derive a SymmetricKey object.
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.ENCRYPT,
@@ -3767,7 +3749,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._cryptography_engine.logger = mock.MagicMock()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.CERTIFICATE
         )
 
@@ -3800,7 +3782,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SECRET_DATA,
             unique_identifiers=[str(invalid_key.unique_identifier)]
         )
@@ -3840,7 +3822,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SECRET_DATA,
             unique_identifiers=[str(base_key.unique_identifier)]
         )
@@ -3894,7 +3876,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[
                 str(base_key.unique_identifier),
@@ -4002,7 +3984,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.HMAC,
@@ -4059,7 +4041,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.HMAC,
@@ -4120,7 +4102,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.HMAC,
@@ -4180,7 +4162,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        payload = derive_key.DeriveKeyRequestPayload(
+        payload = payloads.DeriveKeyRequestPayload(
             object_type=enums.ObjectType.SYMMETRIC_KEY,
             unique_identifiers=[str(base_key.unique_identifier)],
             derivation_method=enums.DerivationMethod.HMAC,
@@ -4229,7 +4211,7 @@ class TestKmipEngine(testtools.TestCase):
         obj_b = pie_objects.OpaqueObject(b'', enums.OpaqueDataType.NONE)
 
         # locate should return nothing at beginning
-        payload = locate.LocateRequestPayload()
+        payload = payloads.LocateRequestPayload()
         response_payload = e._process_locate(payload)
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
@@ -4249,7 +4231,7 @@ class TestKmipEngine(testtools.TestCase):
 
         id_a = str(obj_a.unique_identifier)
 
-        payload = locate.LocateRequestPayload()
+        payload = payloads.LocateRequestPayload()
         e._logger.reset_mock()
         response_payload = e._process_locate(payload)
         e._data_session.commit()
@@ -4275,7 +4257,7 @@ class TestKmipEngine(testtools.TestCase):
 
         id_b = str(obj_b.unique_identifier)
 
-        payload = locate.LocateRequestPayload()
+        payload = payloads.LocateRequestPayload()
         e._logger.reset_mock()
         response_payload = e._process_locate(payload)
         e._data_session.commit()
@@ -4340,7 +4322,7 @@ class TestKmipEngine(testtools.TestCase):
                 ),
         ]
 
-        payload = locate.LocateRequestPayload(attributes=attrs)
+        payload = payloads.LocateRequestPayload(attributes=attrs)
         e._logger.reset_mock()
         response_payload = e._process_locate(payload)
         e._data_session.commit()
@@ -4374,7 +4356,7 @@ class TestKmipEngine(testtools.TestCase):
                 ),
         ]
 
-        payload = locate.LocateRequestPayload(attributes=attrs)
+        payload = payloads.LocateRequestPayload(attributes=attrs)
         e._logger.reset_mock()
         response_payload = e._process_locate(payload)
         e._data_session.commit()
@@ -4415,7 +4397,7 @@ class TestKmipEngine(testtools.TestCase):
         id_b = str(obj_b.unique_identifier)
 
         # Test by specifying the ID of the object to get.
-        payload = get.GetRequestPayload(unique_identifier=id_a)
+        payload = payloads.GetRequestPayload(unique_identifier=id_a)
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -4445,7 +4427,7 @@ class TestKmipEngine(testtools.TestCase):
         e._id_placeholder = str(id_b)
 
         # Test by using the ID placeholder to specify the object to get.
-        payload = get.GetRequestPayload()
+        payload = payloads.GetRequestPayload()
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -4484,7 +4466,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test that specifying the key compression type generates an error.
         k = enums.KeyCompressionType.EC_PUBLIC_KEY_TYPE_UNCOMPRESSED
-        payload = get.GetRequestPayload(key_compression_type=k)
+        payload = payloads.GetRequestPayload(key_compression_type=k)
 
         args = (payload, )
         regex = "Key compression is not supported."
@@ -4522,7 +4504,7 @@ class TestKmipEngine(testtools.TestCase):
         id_a = str(obj_a.unique_identifier)
 
         # Test that a key can be retrieved with the right key format.
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=id_a,
             key_format_type=enums.KeyFormatType.RAW
         )
@@ -4557,7 +4539,7 @@ class TestKmipEngine(testtools.TestCase):
         # required.
         e._logger.reset_mock()
 
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=id_a,
             key_format_type=enums.KeyFormatType.OPAQUE
         )
@@ -4588,7 +4570,7 @@ class TestKmipEngine(testtools.TestCase):
 
         id_b = str(obj_b.unique_identifier)
 
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=id_b,
             key_format_type=enums.KeyFormatType.RAW
         )
@@ -4625,7 +4607,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         id_a = str(obj_a.unique_identifier)
-        payload = get.GetRequestPayload(unique_identifier=id_a)
+        payload = payloads.GetRequestPayload(unique_identifier=id_a)
 
         # Test by specifying the ID of the object to get.
         args = [payload]
@@ -4680,7 +4662,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -4792,7 +4774,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.MAC_SIGN,
@@ -4858,7 +4840,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -4906,7 +4888,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         unwrapped_key_uuid = str(unwrapped_key.unique_identifier)
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -4954,7 +4936,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5017,7 +4999,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5081,7 +5063,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5146,7 +5128,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5211,7 +5193,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5276,7 +5258,7 @@ class TestKmipEngine(testtools.TestCase):
         cryptographic_parameters = attributes.CryptographicParameters(
             block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
         )
-        payload = get.GetRequestPayload(
+        payload = payloads.GetRequestPayload(
             unique_identifier=unwrapped_key_uuid,
             key_wrapping_specification=objects.KeyWrappingSpecification(
                 wrapping_method=enums.WrappingMethod.ENCRYPT,
@@ -5318,7 +5300,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
 
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             unique_identifier='1',
             attribute_names=['Object Type', 'Cryptographic Algorithm']
         )
@@ -5375,7 +5357,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._id_placeholder = '1'
 
-        payload = get_attributes.GetAttributesRequestPayload()
+        payload = payloads.GetAttributesRequestPayload()
 
         response_payload = e._process_get_attributes(payload)
         e._data_session.commit()
@@ -5456,7 +5438,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         id_a = str(obj_a.unique_identifier)
-        payload = get_attributes.GetAttributesRequestPayload(
+        payload = payloads.GetAttributesRequestPayload(
             unique_identifier=id_a
         )
 
@@ -5490,7 +5472,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session.commit()
         e._data_session = e._data_store_session_factory()
 
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             unique_identifier='1'
         )
 
@@ -5568,7 +5550,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._id_placeholder = '1'
 
-        payload = get_attribute_list.GetAttributeListRequestPayload()
+        payload = payloads.GetAttributeListRequestPayload()
 
         response_payload = e._process_get_attribute_list(payload)
         e._data_session.commit()
@@ -5642,7 +5624,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         id_a = str(obj_a.unique_identifier)
-        payload = get_attribute_list.GetAttributeListRequestPayload(
+        payload = payloads.GetAttributeListRequestPayload(
             unique_identifier=id_a
         )
 
@@ -5680,7 +5662,7 @@ class TestKmipEngine(testtools.TestCase):
         object_id = str(managed_object.unique_identifier)
 
         # Test by specifying the ID of the object to activate.
-        payload = activate.ActivateRequestPayload(
+        payload = payloads.ActivateRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id)
         )
 
@@ -5715,7 +5697,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test that the ID placeholder can also be used to specify activation.
         e._id_placeholder = str(object_id)
-        payload = activate.ActivateRequestPayload()
+        payload = payloads.ActivateRequestPayload()
         args = (payload,)
         regex = "The object state is not pre-active and cannot be activated."
         self.assertRaisesRegexp(
@@ -5747,7 +5729,7 @@ class TestKmipEngine(testtools.TestCase):
         object_id = str(managed_object.unique_identifier)
 
         # Test by specifying the ID of the object to activate.
-        payload = activate.ActivateRequestPayload(
+        payload = payloads.ActivateRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id)
         )
 
@@ -5789,7 +5771,7 @@ class TestKmipEngine(testtools.TestCase):
         object_id = str(managed_object.unique_identifier)
 
         # Test by specifying the ID of the object to activate.
-        payload = activate.ActivateRequestPayload(
+        payload = payloads.ActivateRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id)
         )
 
@@ -5821,7 +5803,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         id_a = str(obj_a.unique_identifier)
-        payload = activate.ActivateRequestPayload(
+        payload = payloads.ActivateRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_a)
         )
 
@@ -5865,7 +5847,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test that reason UNSPECIFIED will put object into state
         # DEACTIVATED
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
             compromise_occurrence_date=date)
@@ -5892,7 +5874,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test that reason KEY_COMPROMISE will put object not in DESTROYED
         # state into state COMPROMISED
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_compromise,
             compromise_occurrence_date=date)
@@ -5926,7 +5908,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._logger.reset_mock()
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_compromise,
             compromise_occurrence_date=date)
@@ -5957,7 +5939,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         e._id_placeholder = str(object_id)
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             revocation_reason=reason_unspecified,
             compromise_occurrence_date=date)
 
@@ -6008,7 +5990,7 @@ class TestKmipEngine(testtools.TestCase):
         date = primitives.DateTime(
             tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE, value=6)
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=None,
             compromise_occurrence_date=date)
@@ -6052,7 +6034,7 @@ class TestKmipEngine(testtools.TestCase):
         date = primitives.DateTime(
             tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE, value=6)
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
             compromise_occurrence_date=date)
@@ -6093,7 +6075,7 @@ class TestKmipEngine(testtools.TestCase):
         date = primitives.DateTime(
             tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE, value=6)
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(object_id),
             revocation_reason=reason_unspecified,
             compromise_occurrence_date=date)
@@ -6137,7 +6119,7 @@ class TestKmipEngine(testtools.TestCase):
         date = primitives.DateTime(
             tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE, value=6)
 
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_a),
             revocation_reason=reason_unspecified,
             compromise_occurrence_date=date)
@@ -6179,7 +6161,7 @@ class TestKmipEngine(testtools.TestCase):
         id_c = str(obj_c.unique_identifier)
 
         # Test by specifying the ID of the object to destroy.
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_a)
         )
 
@@ -6208,7 +6190,7 @@ class TestKmipEngine(testtools.TestCase):
         e._id_placeholder = str(id_b)
 
         # Test by using the ID placeholder to specify the object to destroy.
-        payload = destroy.DestroyRequestPayload()
+        payload = payloads.DestroyRequestPayload()
 
         response_payload = e._process_destroy(payload)
         e._data_session.commit()
@@ -6234,7 +6216,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that compromised object can be destroyed properly
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_c)
         )
         response_payload = e._process_destroy(payload)
@@ -6277,7 +6259,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         id_a = str(obj_a.unique_identifier)
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id_a)
         )
 
@@ -6315,7 +6297,7 @@ class TestKmipEngine(testtools.TestCase):
         id = str(obj.unique_identifier)
 
         # Test by specifying the ID of the object to destroy.
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(id)
         )
 
@@ -6338,7 +6320,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._protocol_version = contents.ProtocolVersion.create(1, 0)
 
-        payload = query.QueryRequestPayload([
+        payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
             misc.QueryFunction(enums.QueryFunction.QUERY_OBJECTS),
             misc.QueryFunction(
@@ -6354,7 +6336,7 @@ class TestKmipEngine(testtools.TestCase):
         result = e._process_query(payload)
 
         e._logger.info.assert_called_once_with("Processing operation: Query")
-        self.assertIsInstance(result, query.QueryResponsePayload)
+        self.assertIsInstance(result, payloads.QueryResponsePayload)
         self.assertIsNotNone(result.operations)
         self.assertEqual(12, len(result.operations))
         self.assertEqual(
@@ -6424,7 +6406,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._protocol_version = contents.ProtocolVersion.create(1, 1)
 
-        payload = query.QueryRequestPayload([
+        payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
             misc.QueryFunction(enums.QueryFunction.QUERY_OBJECTS),
             misc.QueryFunction(
@@ -6440,7 +6422,7 @@ class TestKmipEngine(testtools.TestCase):
         result = e._process_query(payload)
 
         e._logger.info.assert_called_once_with("Processing operation: Query")
-        self.assertIsInstance(result, query.QueryResponsePayload)
+        self.assertIsInstance(result, payloads.QueryResponsePayload)
         self.assertIsNotNone(result.operations)
         self.assertEqual(13, len(result.operations))
         self.assertEqual(
@@ -6514,7 +6496,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._protocol_version = contents.ProtocolVersion.create(1, 2)
 
-        payload = query.QueryRequestPayload([
+        payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
             misc.QueryFunction(enums.QueryFunction.QUERY_OBJECTS),
             misc.QueryFunction(
@@ -6530,7 +6512,7 @@ class TestKmipEngine(testtools.TestCase):
         result = e._process_query(payload)
 
         e._logger.info.assert_called_once_with("Processing operation: Query")
-        self.assertIsInstance(result, query.QueryResponsePayload)
+        self.assertIsInstance(result, payloads.QueryResponsePayload)
         self.assertIsNotNone(result.operations)
         self.assertEqual(18, len(result.operations))
         self.assertEqual(
@@ -6624,7 +6606,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test default request.
         e._logger = mock.MagicMock()
-        payload = discover_versions.DiscoverVersionsRequestPayload()
+        payload = payloads.DiscoverVersionsRequestPayload()
 
         result = e._process_discover_versions(payload)
 
@@ -6633,7 +6615,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         self.assertIsInstance(
             result,
-            discover_versions.DiscoverVersionsResponsePayload
+            payloads.DiscoverVersionsResponsePayload
         )
         self.assertIsNotNone(result.protocol_versions)
         self.assertEqual(3, len(result.protocol_versions))
@@ -6652,7 +6634,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test detailed request.
         e._logger = mock.MagicMock()
-        payload = discover_versions.DiscoverVersionsRequestPayload([
+        payload = payloads.DiscoverVersionsRequestPayload([
             contents.ProtocolVersion.create(1, 0)
         ])
 
@@ -6670,7 +6652,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test disjoint request.
         e._logger = mock.MagicMock()
-        payload = discover_versions.DiscoverVersionsRequestPayload([
+        payload = payloads.DiscoverVersionsRequestPayload([
             contents.ProtocolVersion.create(0, 1)
         ])
 
@@ -6724,7 +6706,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -6790,7 +6772,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = None
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -6848,7 +6830,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -6898,7 +6880,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -6954,7 +6936,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7011,7 +6993,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7070,7 +7052,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7135,7 +7117,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7185,7 +7167,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7241,7 +7223,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7298,7 +7280,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         iv_counter_nonce = b'\xFE\xDC\xBA\x98\x76\x54\x32\x10'
 
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier,
             cryptographic_parameters,
             data,
@@ -7353,7 +7335,7 @@ class TestKmipEngine(testtools.TestCase):
 
         # Test a valid signature
         unique_identifier = str(signing_key.unique_identifier)
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -7401,7 +7383,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Test an invalid signature
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -7488,7 +7470,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             data=b'',
             signature_data=b''
@@ -7524,7 +7506,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -7582,7 +7564,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -7640,7 +7622,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = signature_verify.SignatureVerifyRequestPayload(
+        payload = payloads.SignatureVerifyRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -7692,7 +7674,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Verify when cryptographic_parameters is specified in request
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid),
             cryptographic_parameters=cryptographic_parameters,
             data=objects.Data(data)
@@ -7712,7 +7694,7 @@ class TestKmipEngine(testtools.TestCase):
         self.assertIsInstance(response_payload.mac_data, objects.MACData)
 
         # Verify when cryptographic_parameters is not specified in request
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid),
             cryptographic_parameters=None,
             data=objects.Data(data)
@@ -7759,7 +7741,7 @@ class TestKmipEngine(testtools.TestCase):
             cryptographic_algorithm=algorithm
         )
 
-        payload_no_key = mac.MACRequestPayload(
+        payload_no_key = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid_no_key),
             cryptographic_parameters=cryptographic_parameters,
             data=objects.Data(data)
@@ -7774,7 +7756,7 @@ class TestKmipEngine(testtools.TestCase):
             *args
         )
 
-        payload_no_algorithm = mac.MACRequestPayload(
+        payload_no_algorithm = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid_no_algorithm),
             cryptographic_parameters=None,
             data=objects.Data(data)
@@ -7789,7 +7771,7 @@ class TestKmipEngine(testtools.TestCase):
             *args
         )
 
-        payload_no_data = mac.MACRequestPayload(
+        payload_no_data = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid_no_algorithm),
             cryptographic_parameters=cryptographic_parameters,
             data=None
@@ -7837,7 +7819,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Verify when cryptographic_parameters is specified in request
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid),
             cryptographic_parameters=cryptographic_parameters,
             data=objects.Data(data)
@@ -7885,7 +7867,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Verify when cryptographic_parameters is specified in request
-        payload = mac.MACRequestPayload(
+        payload = payloads.MACRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid),
             cryptographic_parameters=cryptographic_parameters,
             data=objects.Data(data)
@@ -7944,7 +7926,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Create the symmetric key with the corresponding attributes
-        payload = create.CreateRequestPayload(
+        payload = payloads.CreateRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute
         )
@@ -7963,7 +7945,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Retrieve the created key using Get and verify all fields set
-        payload = get.GetRequestPayload(unique_identifier=uid)
+        payload = payloads.GetRequestPayload(unique_identifier=uid)
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -8000,7 +7982,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Destroy the symmetric key and verify it cannot be accessed again
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uid)
         )
 
@@ -8078,7 +8060,7 @@ class TestKmipEngine(testtools.TestCase):
                 )
             ]
         )
-        payload = create_key_pair.CreateKeyPairRequestPayload(
+        payload = payloads.CreateKeyPairRequestPayload(
             common_template,
             private_template,
             public_template
@@ -8100,7 +8082,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Retrieve the created public key using Get and verify all fields set
-        payload = get.GetRequestPayload(unique_identifier=public_id)
+        payload = payloads.GetRequestPayload(unique_identifier=public_id)
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -8133,7 +8115,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Retrieve the created private key using Get and verify all fields set
-        payload = get.GetRequestPayload(unique_identifier=private_id)
+        payload = payloads.GetRequestPayload(unique_identifier=private_id)
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -8168,7 +8150,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Destroy the public key and verify it cannot be accessed again
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(public_id)
         )
 
@@ -8203,7 +8185,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Destroy the private key and verify it cannot be accessed again
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(private_id)
         )
 
@@ -8295,7 +8277,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Register the symmetric key with the corresponding attributes
-        payload = register.RegisterRequestPayload(
+        payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
             secret=secret
@@ -8315,7 +8297,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Retrieve the registered key using Get and verify all fields set
-        payload = get.GetRequestPayload(unique_identifier=uid)
+        payload = payloads.GetRequestPayload(unique_identifier=uid)
 
         response_payload = e._process_get(payload)
         e._data_session.commit()
@@ -8350,7 +8332,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Destroy the symmetric key and verify it cannot be accessed again
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uid)
         )
 
@@ -8436,7 +8418,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Register the symmetric key with the corresponding attributes
-        payload = register.RegisterRequestPayload(
+        payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
             secret=secret
@@ -8456,7 +8438,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Activate the symmetric key
-        payload = activate.ActivateRequestPayload(
+        payload = payloads.ActivateRequestPayload(
             attributes.UniqueIdentifier(uuid)
         )
 
@@ -8472,7 +8454,7 @@ class TestKmipEngine(testtools.TestCase):
         self.assertEqual(uuid, activated_uuid)
 
         # Encrypt some data using the symmetric key
-        payload = encrypt.EncryptRequestPayload(
+        payload = payloads.EncryptRequestPayload(
             unique_identifier=uuid,
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -8511,7 +8493,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Decrypt the encrypted data using the symmetric key
-        payload = decrypt.DecryptRequestPayload(
+        payload = payloads.DecryptRequestPayload(
             unique_identifier=uuid,
             cryptographic_parameters=attributes.CryptographicParameters(
                 block_cipher_mode=enums.BlockCipherMode.CBC,
@@ -8545,7 +8527,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         # Revoke the activated symmetric key to prepare it for deletion
-        payload = revoke.RevokeRequestPayload(
+        payload = payloads.RevokeRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid)
         )
 
@@ -8560,7 +8542,7 @@ class TestKmipEngine(testtools.TestCase):
         self.assertEqual(uuid, response_payload.unique_identifier.value)
 
         # Destroy the symmetric key and verify it cannot be accessed again
-        payload = destroy.DestroyRequestPayload(
+        payload = payloads.DestroyRequestPayload(
             unique_identifier=attributes.UniqueIdentifier(uuid)
         )
 
@@ -8634,7 +8616,7 @@ class TestKmipEngine(testtools.TestCase):
         e.data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = sign.SignRequestPayload(
+        payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -8709,7 +8691,7 @@ class TestKmipEngine(testtools.TestCase):
         e.data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = sign.SignRequestPayload(
+        payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             data=b'',
         )
@@ -8744,7 +8726,7 @@ class TestKmipEngine(testtools.TestCase):
         e.data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = sign.SignRequestPayload(
+        payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -8813,7 +8795,7 @@ class TestKmipEngine(testtools.TestCase):
         e.data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = sign.SignRequestPayload(
+        payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,
@@ -8884,7 +8866,7 @@ class TestKmipEngine(testtools.TestCase):
         e.data_session = e._data_store_session_factory()
 
         unique_identifier = str(signing_key.unique_identifier)
-        payload = sign.SignRequestPayload(
+        payload = payloads.SignRequestPayload(
             unique_identifier=unique_identifier,
             cryptographic_parameters=attributes.CryptographicParameters(
                 padding_method=enums.PaddingMethod.PSS,

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -42,21 +42,7 @@ from kmip.core.messages.contents import ResultStatus
 from kmip.core.messages.contents import ResultReason
 from kmip.core.messages.contents import ResultMessage
 from kmip.core.messages.contents import ProtocolVersion
-from kmip.core.messages.payloads.create_key_pair import \
-    CreateKeyPairRequestPayload, CreateKeyPairResponsePayload
-from kmip.core.messages.payloads import decrypt
-from kmip.core.messages.payloads import derive_key
-from kmip.core.messages.payloads.discover_versions import \
-    DiscoverVersionsRequestPayload, DiscoverVersionsResponsePayload
-from kmip.core.messages.payloads import encrypt
-from kmip.core.messages.payloads import get_attributes
-from kmip.core.messages.payloads import get_attribute_list
-from kmip.core.messages.payloads.query import \
-    QueryRequestPayload, QueryResponsePayload
-from kmip.core.messages.payloads.rekey_key_pair import \
-    RekeyKeyPairRequestPayload, RekeyKeyPairResponsePayload
-from kmip.core.messages.payloads import sign
-from kmip.core.messages.payloads import signature_verify
+from kmip.core.messages import payloads
 
 from kmip.core.misc import Offset
 from kmip.core.misc import QueryFunction
@@ -236,8 +222,12 @@ class TestKMIPClient(TestCase):
 
         payload = batch_item.request_payload
 
-        msg = base.format(CreateKeyPairRequestPayload, payload)
-        self.assertIsInstance(payload, CreateKeyPairRequestPayload, msg)
+        msg = base.format(payloads.CreateKeyPairRequestPayload, payload)
+        self.assertIsInstance(
+            payload,
+            payloads.CreateKeyPairRequestPayload,
+            msg
+        )
 
         common_observed = payload.common_template_attribute
         private_observed = payload.private_key_template_attribute
@@ -285,8 +275,12 @@ class TestKMIPClient(TestCase):
 
         payload = batch_item.request_payload
 
-        msg = base.format(RekeyKeyPairRequestPayload, payload)
-        self.assertIsInstance(payload, RekeyKeyPairRequestPayload, msg)
+        msg = base.format(payloads.RekeyKeyPairRequestPayload, payload)
+        self.assertIsInstance(
+            payload,
+            payloads.RekeyKeyPairRequestPayload,
+            msg
+        )
 
         private_key_uuid_observed = payload.private_key_uuid
         offset_observed = payload.offset
@@ -342,8 +336,8 @@ class TestKMIPClient(TestCase):
         if query_functions is None:
             query_functions = list()
 
-        msg = base.format(QueryRequestPayload, payload)
-        self.assertIsInstance(payload, QueryRequestPayload, msg)
+        msg = base.format(payloads.QueryRequestPayload, payload)
+        self.assertIsInstance(payload, payloads.QueryRequestPayload, msg)
 
         query_functions_observed = payload.query_functions
         self.assertEqual(query_functions, query_functions_observed)
@@ -378,8 +372,12 @@ class TestKMIPClient(TestCase):
         if protocol_versions is None:
             protocol_versions = list()
 
-        msg = base.format(DiscoverVersionsRequestPayload, payload)
-        self.assertIsInstance(payload, DiscoverVersionsRequestPayload, msg)
+        msg = base.format(payloads.DiscoverVersionsRequestPayload, payload)
+        self.assertIsInstance(
+            payload,
+            payloads.DiscoverVersionsRequestPayload,
+            msg
+        )
 
         observed = payload.protocol_versions
 
@@ -413,7 +411,7 @@ class TestKMIPClient(TestCase):
         )
         self.assertIsInstance(
             batch_item.request_payload,
-            get_attributes.GetAttributesRequestPayload
+            payloads.GetAttributesRequestPayload
         )
         self.assertEqual(uuid, batch_item.request_payload.unique_identifier)
         self.assertEqual(
@@ -431,13 +429,13 @@ class TestKMIPClient(TestCase):
             OperationEnum.GET_ATTRIBUTE_LIST, batch_item.operation.value)
         self.assertIsInstance(
             batch_item.request_payload,
-            get_attribute_list.GetAttributeListRequestPayload)
+            payloads.GetAttributeListRequestPayload)
         self.assertEqual(uid, batch_item.request_payload.unique_identifier)
 
     def test_process_batch_items(self):
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.CREATE_KEY_PAIR),
-            response_payload=CreateKeyPairResponsePayload())
+            response_payload=payloads.CreateKeyPairResponsePayload())
         response = ResponseMessage(batch_items=[batch_item, batch_item])
         results = self.client._process_batch_items(response)
 
@@ -522,7 +520,7 @@ class TestKMIPClient(TestCase):
     def test_process_create_key_pair_batch_item(self):
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.CREATE_KEY_PAIR),
-            response_payload=CreateKeyPairResponsePayload())
+            response_payload=payloads.CreateKeyPairResponsePayload())
         result = self.client._process_create_key_pair_batch_item(batch_item)
 
         msg = "expected {0}, received {1}".format(CreateKeyPairResult, result)
@@ -531,7 +529,7 @@ class TestKMIPClient(TestCase):
     def test_process_rekey_key_pair_batch_item(self):
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.REKEY_KEY_PAIR),
-            response_payload=RekeyKeyPairResponsePayload())
+            response_payload=payloads.RekeyKeyPairResponsePayload())
         result = self.client._process_rekey_key_pair_batch_item(batch_item)
 
         msg = "expected {0}, received {1}".format(RekeyKeyPairResult, result)
@@ -546,7 +544,7 @@ class TestKMIPClient(TestCase):
             application_namespaces,
             extension_information):
 
-        payload = QueryResponsePayload(
+        payload = payloads.QueryResponsePayload(
             operations,
             object_types,
             vendor_identification,
@@ -598,7 +596,7 @@ class TestKMIPClient(TestCase):
     def _test_process_discover_versions_batch_item(self, protocol_versions):
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.DISCOVER_VERSIONS),
-            response_payload=DiscoverVersionsResponsePayload(
+            response_payload=payloads.DiscoverVersionsResponsePayload(
                 protocol_versions))
         result = self.client._process_discover_versions_batch_item(batch_item)
 
@@ -624,7 +622,7 @@ class TestKMIPClient(TestCase):
     def test_process_get_attributes_batch_item(self):
         uuid = '00000000-1111-2222-3333-444444444444'
         attributes = []
-        payload = get_attributes.GetAttributesResponsePayload(
+        payload = payloads.GetAttributesResponsePayload(
             unique_identifier=uuid,
             attributes=attributes
         )
@@ -641,7 +639,7 @@ class TestKMIPClient(TestCase):
     def test_process_get_attribute_list_batch_item(self):
         uid = '00000000-1111-2222-3333-444444444444'
         names = ['Cryptographic Algorithm', 'Cryptographic Length']
-        payload = get_attribute_list.GetAttributeListResponsePayload(
+        payload = payloads.GetAttributeListResponsePayload(
             unique_identifier=uid, attribute_names=names)
         batch_item = ResponseBatchItem(
             operation=Operation(OperationEnum.GET_ATTRIBUTE_LIST),
@@ -735,7 +733,7 @@ class TestKMIPClient(TestCase):
         """
         Test that the client can derive a key.
         """
-        payload = derive_key.DeriveKeyResponsePayload(
+        payload = payloads.DeriveKeyResponsePayload(
             unique_identifier='1',
         )
         batch_item = ResponseBatchItem(
@@ -793,7 +791,7 @@ class TestKMIPClient(TestCase):
         """
         Test that the client can encrypt data.
         """
-        payload = encrypt.EncryptResponsePayload(
+        payload = payloads.EncryptResponsePayload(
             unique_identifier='1',
             data=(
                 b'\x6B\x77\xB4\xD6\x30\x06\xDE\xE6'
@@ -856,7 +854,7 @@ class TestKMIPClient(TestCase):
         """
         Test that the client can decrypt data.
         """
-        payload = decrypt.DecryptResponsePayload(
+        payload = payloads.DecryptResponsePayload(
             unique_identifier='1',
             data=(
                 b'\x37\x36\x35\x34\x33\x32\x31\x20'
@@ -918,7 +916,7 @@ class TestKMIPClient(TestCase):
         """
         Test that the client can verify a signature.
         """
-        payload = signature_verify.SignatureVerifyResponsePayload(
+        payload = payloads.SignatureVerifyResponsePayload(
             unique_identifier='1',
             validity_indicator=enums.ValidityIndicator.INVALID
         )
@@ -972,7 +970,7 @@ class TestKMIPClient(TestCase):
         """
         Test that the client can sign data
         """
-        payload = sign.SignResponsePayload(
+        payload = payloads.SignResponsePayload(
             unique_identifier='1',
             signature_data=b'aaaaaaaaaaaaaaaa'
         )


### PR DESCRIPTION
This change updates payload management, streamlining the import process for kmip.core.messages.payloads. Now any request or response payload is accessible by importing payloads. All code importing and using individual payload modules has been updated to use this new approach.