### PR TITLE
Enforce server support for DeriveKey truncation

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1473,6 +1473,8 @@ class KmipEngine(object):
                 "The specified length exceeds the output of the derivation "
                 "method."
             )
+        if len(derived_data) > derivation_length:
+            derived_data = derived_data[:derivation_length]
 
         if payload.object_type == enums.ObjectType.SYMMETRIC_KEY:
             managed_object = objects.SymmetricKey(


### PR DESCRIPTION
This change updates DeriveKey support in the software server to enforce key truncation. If the derived key is longer than the requested cryptographic length, the derived key is truncated to fit the requested length. A unit test has been added to cover this update.