### PR TITLE
Add REVOKE to list of supported server ops

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1936,6 +1936,7 @@ class KmipEngine(object):
                 contents.Operation(enums.Operation.GET_ATTRIBUTES),
                 contents.Operation(enums.Operation.GET_ATTRIBUTE_LIST),
                 contents.Operation(enums.Operation.ACTIVATE),
+                contents.Operation(enums.Operation.REVOKE),
                 contents.Operation(enums.Operation.DESTROY),
                 contents.Operation(enums.Operation.QUERY)
             ])

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -6356,88 +6356,6 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.info.assert_called_once_with("Processing operation: Query")
         self.assertIsInstance(result, query.QueryResponsePayload)
         self.assertIsNotNone(result.operations)
-        self.assertEqual(11, len(result.operations))
-        self.assertEqual(
-            enums.Operation.CREATE,
-            result.operations[0].value
-        )
-        self.assertEqual(
-            enums.Operation.CREATE_KEY_PAIR,
-            result.operations[1].value
-        )
-        self.assertEqual(
-            enums.Operation.REGISTER,
-            result.operations[2].value
-        )
-        self.assertEqual(
-            enums.Operation.DERIVE_KEY,
-            result.operations[3].value
-        )
-        self.assertEqual(
-            enums.Operation.LOCATE,
-            result.operations[4].value
-        )
-        self.assertEqual(
-            enums.Operation.GET,
-            result.operations[5].value
-        )
-        self.assertEqual(
-            enums.Operation.GET_ATTRIBUTES,
-            result.operations[6].value
-        )
-        self.assertEqual(
-            enums.Operation.GET_ATTRIBUTE_LIST,
-            result.operations[7].value
-        )
-        self.assertEqual(
-            enums.Operation.ACTIVATE,
-            result.operations[8].value
-        )
-        self.assertEqual(
-            enums.Operation.DESTROY,
-            result.operations[9].value
-        )
-        self.assertEqual(
-            enums.Operation.QUERY,
-            result.operations[10].value
-        )
-        self.assertEqual(list(), result.object_types)
-        self.assertIsNotNone(result.vendor_identification)
-        self.assertEqual(
-            "PyKMIP {0} Software Server".format(kmip.__version__),
-            result.vendor_identification.value
-        )
-        self.assertIsNone(result.server_information)
-        self.assertEqual(list(), result.application_namespaces)
-        self.assertEqual(list(), result.extension_information)
-
-    def test_query_1_1(self):
-        """
-        Test that a Query request can be processed correctly, for KMIP 1.1.
-        """
-        e = engine.KmipEngine()
-
-        e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 1)
-
-        payload = query.QueryRequestPayload([
-            misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
-            misc.QueryFunction(enums.QueryFunction.QUERY_OBJECTS),
-            misc.QueryFunction(
-                enums.QueryFunction.QUERY_SERVER_INFORMATION
-            ),
-            misc.QueryFunction(
-                enums.QueryFunction.QUERY_APPLICATION_NAMESPACES
-            ),
-            misc.QueryFunction(enums.QueryFunction.QUERY_EXTENSION_LIST),
-            misc.QueryFunction(enums.QueryFunction.QUERY_EXTENSION_MAP)
-        ])
-
-        result = e._process_query(payload)
-
-        e._logger.info.assert_called_once_with("Processing operation: Query")
-        self.assertIsInstance(result, query.QueryResponsePayload)
-        self.assertIsNotNone(result.operations)
         self.assertEqual(12, len(result.operations))
         self.assertEqual(
             enums.Operation.CREATE,
@@ -6476,16 +6394,106 @@ class TestKmipEngine(testtools.TestCase):
             result.operations[8].value
         )
         self.assertEqual(
-            enums.Operation.DESTROY,
+            enums.Operation.REVOKE,
             result.operations[9].value
         )
         self.assertEqual(
-            enums.Operation.QUERY,
+            enums.Operation.DESTROY,
             result.operations[10].value
         )
         self.assertEqual(
-            enums.Operation.DISCOVER_VERSIONS,
+            enums.Operation.QUERY,
             result.operations[11].value
+        )
+        self.assertEqual(list(), result.object_types)
+        self.assertIsNotNone(result.vendor_identification)
+        self.assertEqual(
+            "PyKMIP {0} Software Server".format(kmip.__version__),
+            result.vendor_identification.value
+        )
+        self.assertIsNone(result.server_information)
+        self.assertEqual(list(), result.application_namespaces)
+        self.assertEqual(list(), result.extension_information)
+
+    def test_query_1_1(self):
+        """
+        Test that a Query request can be processed correctly, for KMIP 1.1.
+        """
+        e = engine.KmipEngine()
+
+        e._logger = mock.MagicMock()
+        e._protocol_version = contents.ProtocolVersion.create(1, 1)
+
+        payload = query.QueryRequestPayload([
+            misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
+            misc.QueryFunction(enums.QueryFunction.QUERY_OBJECTS),
+            misc.QueryFunction(
+                enums.QueryFunction.QUERY_SERVER_INFORMATION
+            ),
+            misc.QueryFunction(
+                enums.QueryFunction.QUERY_APPLICATION_NAMESPACES
+            ),
+            misc.QueryFunction(enums.QueryFunction.QUERY_EXTENSION_LIST),
+            misc.QueryFunction(enums.QueryFunction.QUERY_EXTENSION_MAP)
+        ])
+
+        result = e._process_query(payload)
+
+        e._logger.info.assert_called_once_with("Processing operation: Query")
+        self.assertIsInstance(result, query.QueryResponsePayload)
+        self.assertIsNotNone(result.operations)
+        self.assertEqual(13, len(result.operations))
+        self.assertEqual(
+            enums.Operation.CREATE,
+            result.operations[0].value
+        )
+        self.assertEqual(
+            enums.Operation.CREATE_KEY_PAIR,
+            result.operations[1].value
+        )
+        self.assertEqual(
+            enums.Operation.REGISTER,
+            result.operations[2].value
+        )
+        self.assertEqual(
+            enums.Operation.DERIVE_KEY,
+            result.operations[3].value
+        )
+        self.assertEqual(
+            enums.Operation.LOCATE,
+            result.operations[4].value
+        )
+        self.assertEqual(
+            enums.Operation.GET,
+            result.operations[5].value
+        )
+        self.assertEqual(
+            enums.Operation.GET_ATTRIBUTES,
+            result.operations[6].value
+        )
+        self.assertEqual(
+            enums.Operation.GET_ATTRIBUTE_LIST,
+            result.operations[7].value
+        )
+        self.assertEqual(
+            enums.Operation.ACTIVATE,
+            result.operations[8].value
+        )
+        self.assertEqual(
+            enums.Operation.REVOKE,
+            result.operations[9].value
+        )
+        self.assertEqual(
+            enums.Operation.DESTROY,
+            result.operations[10].value
+        )
+        self.assertEqual(
+            enums.Operation.QUERY,
+            result.operations[11].value
+        )
+        self.assertEqual(
+            enums.Operation.DISCOVER_VERSIONS,
+            result.operations[12].value
         )
         self.assertEqual(list(), result.object_types)
         self.assertIsNotNone(result.vendor_identification)
@@ -6524,7 +6532,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.info.assert_called_once_with("Processing operation: Query")
         self.assertIsInstance(result, query.QueryResponsePayload)
         self.assertIsNotNone(result.operations)
-        self.assertEqual(17, len(result.operations))
+        self.assertEqual(18, len(result.operations))
         self.assertEqual(
             enums.Operation.CREATE,
             result.operations[0].value
@@ -6562,36 +6570,40 @@ class TestKmipEngine(testtools.TestCase):
             result.operations[8].value
         )
         self.assertEqual(
-            enums.Operation.DESTROY,
+            enums.Operation.REVOKE,
             result.operations[9].value
         )
         self.assertEqual(
-            enums.Operation.QUERY,
+            enums.Operation.DESTROY,
             result.operations[10].value
         )
         self.assertEqual(
-            enums.Operation.DISCOVER_VERSIONS,
+            enums.Operation.QUERY,
             result.operations[11].value
         )
         self.assertEqual(
-            enums.Operation.ENCRYPT,
+            enums.Operation.DISCOVER_VERSIONS,
             result.operations[12].value
         )
         self.assertEqual(
-            enums.Operation.DECRYPT,
+            enums.Operation.ENCRYPT,
             result.operations[13].value
         )
         self.assertEqual(
-            enums.Operation.SIGN,
+            enums.Operation.DECRYPT,
             result.operations[14].value
         )
         self.assertEqual(
-            enums.Operation.SIGNATURE_VERIFY,
+            enums.Operation.SIGN,
             result.operations[15].value
         )
         self.assertEqual(
-            enums.Operation.MAC,
+            enums.Operation.SIGNATURE_VERIFY,
             result.operations[16].value
+        )
+        self.assertEqual(
+            enums.Operation.MAC,
+            result.operations[17].value
         )
         self.assertEqual(list(), result.object_types)
         self.assertIsNotNone(result.vendor_identification)


### PR DESCRIPTION
As defined in _process_query, the list of supported server operations is missing REVOKE.