### PR TITLE
Add server config option controlling certificate client auth

### DIFF
--- a/examples/server.conf
+++ b/examples/server.conf
@@ -6,3 +6,4 @@ key_path=/etc/pykmip/certs/server_private_key.pem
 ca_path=/etc/pykmip/certs/server_ca_cert.pem
 auth_suite=Basic
 policy_path=/etc/pykmip/policies
+enable_tls_client_auth=True

--- a/kmip/services/server/config.py
+++ b/kmip/services/server/config.py
@@ -34,6 +34,7 @@ class KmipServerConfig(object):
         self._logger = logging.getLogger('kmip.server.config')
 
         self.settings = dict()
+        self.settings['enable_tls_client_auth'] = True
 
         self._expected_settings = [
             'hostname',
@@ -44,7 +45,8 @@ class KmipServerConfig(object):
             'auth_suite'
         ]
         self._optional_settings = [
-            'policy_path'
+            'policy_path',
+            'enable_tls_client_auth'
         ]
 
     def set_setting(self, setting, value):
@@ -80,8 +82,10 @@ class KmipServerConfig(object):
             self._set_ca_path(value)
         elif setting == 'auth_suite':
             self._set_auth_suite(value)
-        else:
+        elif setting == 'policy_path':
             self._set_policy_path(value)
+        else:
+            self._set_enable_tls_client_auth(value)
 
     def load_settings(self, path):
         """
@@ -148,6 +152,10 @@ class KmipServerConfig(object):
             self._set_auth_suite(parser.get('server', 'auth_suite'))
         if parser.has_option('server', 'policy_path'):
             self._set_policy_path(parser.get('server', 'policy_path'))
+        if parser.has_option('server', 'enable_tls_client_auth'):
+            self._set_enable_tls_client_auth(
+                parser.getboolean('server', 'enable_tls_client_auth')
+            )
 
     def _set_hostname(self, value):
         if isinstance(value, six.string_types):
@@ -241,4 +249,15 @@ class KmipServerConfig(object):
             raise exceptions.ConfigurationError(
                 "The policy path, if specified, must be a valid string path "
                 "to a filesystem directory."
+            )
+
+    def _set_enable_tls_client_auth(self, value):
+        if value is None:
+            self.settings['enable_tls_client_auth'] = True
+        elif isinstance(value, bool):
+            self.settings['enable_tls_client_auth'] = value
+        else:
+            raise exceptions.ConfigurationError(
+                "The flag enabling the TLS certificate client auth flag check "
+                "must be a boolean."
             )

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -119,7 +119,8 @@ class TestKmipServer(testtools.TestCase):
             '/etc/pykmip/certs/server.key',
             '/etc/pykmip/certs/ca.crt',
             'Basic',
-            '/etc/pykmip/policies'
+            '/etc/pykmip/policies',
+            False
         )
 
         s.config.load_settings.assert_called_with('/etc/pykmip/server.conf')
@@ -141,6 +142,10 @@ class TestKmipServer(testtools.TestCase):
         s.config.set_setting.assert_any_call(
             'policy_path',
             '/etc/pykmip/policies'
+        )
+        s.config.set_setting.assert_any_call(
+            'enable_tls_client_auth',
+            False
         )
 
         # Test that an attempt is made to instantiate the TLS 1.2 auth suite


### PR DESCRIPTION
This change adds a server configuration option to control the enforcement of TLS certificate client authentication. Before, client TLS certificates had to include the extended key usage extension with the clientAuth bit set to be used as sources of client identity. The new configuration option, enable_tls_client_auth, allows server admins to enable/disable this requirement. The configuration setting is optional and the server defaults to the original enforcing behavior if it is not set. Admins must explicitly set the option to False to disable enforcement.