### PR TITLE
Updating the ProxyKmipClient to simplify closing

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -134,11 +134,10 @@ class ProxyKmipClient(api.KmipClient):
         Close the client connection.
 
         Raises:
-            ClientConnectionNotOpen: if the client connection is not open
             Exception: if an error occurs while trying to close the connection
         """
         if not self._is_open:
-            raise exceptions.ClientConnectionNotOpen()
+            return
         else:
             try:
                 self.proxy.close()

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -115,11 +115,10 @@ class TestProxyKmipClient(testtools.TestCase):
                 mock.MagicMock(spec_set=KMIPProxy))
     def test_close_on_close(self):
         """
-        Test that a ClientConnectionNotOpen exception is raised when trying
-        to close a closed client connection.
+        Test that a closed client connection can be closed with no error.
         """
         client = ProxyKmipClient()
-        self.assertRaises(ClientConnectionNotOpen, client.close)
+        client.close()
 
     @mock.patch('kmip.pie.client.KMIPProxy',
                 mock.MagicMock(spec_set=KMIPProxy))


### PR DESCRIPTION
This change updates the ProxyKmipClient close method, allowing it to be called without error even when the client connection is not open. The client unit tests have been updated to reflect this.