### PR TITLE
Add a logging level configuration option

### DIFF
--- a/examples/server.conf
+++ b/examples/server.conf
@@ -11,3 +11,4 @@ tls_cipher_suites=
     EXAMPLE_CIPHER_SUITE_1
     EXAMPLE_CIPHER_SUITE_2
     EXAMPLE_CIPHER_SUITE_3
+logging_level=INFO

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -95,7 +95,7 @@ class TestKmipServer(testtools.TestCase):
         open_mock.assert_called_once_with('/test/path/server.log', 'w')
 
         self.assertTrue(s._logger.addHandler.called)
-        s._logger.setLevel.assert_called_once_with(logging.DEBUG)
+        s._logger.setLevel.assert_any_call(logging.DEBUG)
 
     @mock.patch('kmip.services.server.engine.KmipEngine')
     @mock.patch('kmip.services.auth.TLS12AuthenticationSuite')
@@ -121,7 +121,8 @@ class TestKmipServer(testtools.TestCase):
             'Basic',
             '/etc/pykmip/policies',
             False,
-            'TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA'
+            'TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA',
+            'DEBUG'
         )
 
         s.config.load_settings.assert_called_with('/etc/pykmip/server.conf')
@@ -155,6 +156,7 @@ class TestKmipServer(testtools.TestCase):
                 'TLS_RSA_WITH_AES_256_CBC_SHA'
             ]
         )
+        s.config.set_setting.assert_any_call('logging_level', 'DEBUG')
 
         # Test that an attempt is made to instantiate the TLS 1.2 auth suite
         s = server.KmipServer(


### PR DESCRIPTION
This change adds a logging level configuration option for the server, allowing the admin to control what server activity gets collected for logging. Unit tests have been added and updated to cover this new configuration setting.