### PR TITLE
Add a ProxyKmipClient integation test for registering wrapped keys

### DIFF
--- a/kmip/core/factories/secrets.py
+++ b/kmip/core/factories/secrets.py
@@ -183,11 +183,11 @@ class SecretFactory(object):
                 crypto_length = CryptographicLength(cryptographic_length)
 
             key_wrap_data = None
-            if key_wrapping_data is not None:
+            if key_wrapping_data:
                 # TODO (peter-hamilton) This currently isn't used in the tests
                 # TODO (peter-hamilton) but needs to be updated to properly
                 # TODO (peter-hamilton) create a KeyWrappingData object.
-                key_wrap_data = KeyWrappingData(key_wrapping_data)
+                key_wrap_data = KeyWrappingData(**key_wrapping_data)
 
             key_block = KeyBlock(key_format_type,
                                  key_comp_type,

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -534,21 +534,24 @@ class KmipEngine(object):
                 'cryptographic_algorithm': obj.cryptographic_algorithm,
                 'cryptographic_length': obj.cryptographic_length,
                 'key_format_type': obj.key_format_type,
-                'key_value': obj.value
+                'key_value': obj.value,
+                'key_wrapping_data': obj.key_wrapping_data
             }
         elif object_type == enums.ObjectType.PUBLIC_KEY:
             value = {
                 'cryptographic_algorithm': obj.cryptographic_algorithm,
                 'cryptographic_length': obj.cryptographic_length,
                 'key_format_type': obj.key_format_type,
-                'key_value': obj.value
+                'key_value': obj.value,
+                'key_wrapping_data': obj.key_wrapping_data
             }
         elif object_type == enums.ObjectType.PRIVATE_KEY:
             value = {
                 'cryptographic_algorithm': obj.cryptographic_algorithm,
                 'cryptographic_length': obj.cryptographic_length,
                 'key_format_type': obj.key_format_type,
-                'key_value': obj.value
+                'key_value': obj.value,
+                'key_wrapping_data': obj.key_wrapping_data
             }
         elif object_type == enums.ObjectType.SECRET_DATA:
             value = {


### PR DESCRIPTION
This change adds a ProxyKmipClient integration test that verifies that a wrapped key can be registered with the server and can then be retrieved, along with all of its key wrapping metadata. Minor updates to the underlying metadata handling are included.