### PR TITLE
Update key wrapping data structures to support dict arguments

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -715,8 +715,10 @@ class EncryptionKeyInformation(Struct):
 
     @cryptographic_parameters.setter
     def cryptographic_parameters(self, value):
-        if value is None:
+        if not value:
             self._cryptographic_parameters = None
+        elif isinstance(value, dict):
+            self._cryptographic_parameters = CryptographicParameters(**value)
         elif isinstance(value, CryptographicParameters):
             self._cryptographic_parameters = value
         else:
@@ -871,8 +873,10 @@ class MACSignatureKeyInformation(primitives.Struct):
 
     @cryptographic_parameters.setter
     def cryptographic_parameters(self, value):
-        if value is None:
+        if not value:
             self._cryptographic_parameters = None
+        elif isinstance(value, dict):
+            self._cryptographic_parameters = CryptographicParameters(**value)
         elif isinstance(value, CryptographicParameters):
             self._cryptographic_parameters = value
         else:
@@ -1051,8 +1055,11 @@ class KeyWrappingData(Struct):
 
     @encryption_key_information.setter
     def encryption_key_information(self, value):
-        if value is None:
+        if not value:
             self._encryption_key_information = None
+        elif isinstance(value, dict):
+            self._encryption_key_information = \
+                EncryptionKeyInformation(**value)
         elif isinstance(value, EncryptionKeyInformation):
             self._encryption_key_information = value
         else:
@@ -1067,8 +1074,11 @@ class KeyWrappingData(Struct):
 
     @mac_signature_key_information.setter
     def mac_signature_key_information(self, value):
-        if value is None:
+        if not value:
             self._mac_signature_key_information = None
+        elif isinstance(value, dict):
+            self._mac_signature_key_information = \
+                MACSignatureKeyInformation(**value)
         elif isinstance(value, MACSignatureKeyInformation):
             self._mac_signature_key_information = value
         else:

--- a/kmip/tests/unit/core/objects/test_objects.py
+++ b/kmip/tests/unit/core/objects/test_objects.py
@@ -385,6 +385,27 @@ class TestEncryptionKeyInformation(testtools.TestCase):
             parameters.block_cipher_mode
         )
 
+        encryption_key_information = objects.EncryptionKeyInformation(
+            unique_identifier="00000000-1111-2222-3333-444444444444",
+            cryptographic_parameters={
+                'block_cipher_mode': enums.BlockCipherMode.CTR
+            }
+        )
+
+        self.assertEqual(
+            "00000000-1111-2222-3333-444444444444",
+            encryption_key_information.unique_identifier
+        )
+        self.assertIsInstance(
+            encryption_key_information.cryptographic_parameters,
+            attributes.CryptographicParameters
+        )
+        parameters = encryption_key_information.cryptographic_parameters
+        self.assertEqual(
+            enums.BlockCipherMode.CTR,
+            parameters.block_cipher_mode
+        )
+
     def test_invalid_unique_identifier(self):
         """
         Test that a TypeError is raised when an invalid value is used to set
@@ -821,6 +842,27 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         mac_signature_key_information = objects.MACSignatureKeyInformation(
             unique_identifier="00000000-1111-2222-3333-444444444444",
             cryptographic_parameters=cryptographic_parameters
+        )
+
+        self.assertEqual(
+            "00000000-1111-2222-3333-444444444444",
+            mac_signature_key_information.unique_identifier
+        )
+        self.assertIsInstance(
+            mac_signature_key_information.cryptographic_parameters,
+            attributes.CryptographicParameters
+        )
+        parameters = mac_signature_key_information.cryptographic_parameters
+        self.assertEqual(
+            enums.BlockCipherMode.CTR,
+            parameters.block_cipher_mode
+        )
+
+        mac_signature_key_information = objects.MACSignatureKeyInformation(
+            unique_identifier="00000000-1111-2222-3333-444444444444",
+            cryptographic_parameters={
+                'block_cipher_mode': enums.BlockCipherMode.CTR
+            }
         )
 
         self.assertEqual(
@@ -1317,6 +1359,70 @@ class TestKeyWrappingData(testtools.TestCase):
                     block_cipher_mode=enums.BlockCipherMode.NIST_KEY_WRAP
                 )
             ),
+            mac_signature=b'\x01',
+            iv_counter_nonce=b'\x02',
+            encoding_option=enums.EncodingOption.TTLV_ENCODING
+        )
+
+        self.assertEqual(
+            enums.WrappingMethod.ENCRYPT,
+            key_wrapping_data.wrapping_method
+        )
+        self.assertIsInstance(
+            key_wrapping_data.encryption_key_information,
+            objects.EncryptionKeyInformation
+        )
+        e = key_wrapping_data.encryption_key_information
+        self.assertEqual(
+            "12345678-9012-3456-7890-123456789012",
+            e.unique_identifier
+        )
+        self.assertIsInstance(
+            e.cryptographic_parameters,
+            attributes.CryptographicParameters
+        )
+        self.assertEqual(
+            enums.BlockCipherMode.CTR,
+            e.cryptographic_parameters.block_cipher_mode
+        )
+        self.assertIsInstance(
+            key_wrapping_data.mac_signature_key_information,
+            objects.MACSignatureKeyInformation
+        )
+        m = key_wrapping_data.mac_signature_key_information
+        self.assertEqual(
+            "00000000-1111-2222-3333-444444444444",
+            m.unique_identifier
+        )
+        self.assertIsInstance(
+            m.cryptographic_parameters,
+            attributes.CryptographicParameters
+        )
+        self.assertEqual(
+            enums.BlockCipherMode.NIST_KEY_WRAP,
+            m.cryptographic_parameters.block_cipher_mode
+        )
+        self.assertEqual(b'\x01', key_wrapping_data.mac_signature)
+        self.assertEqual(b'\x02', key_wrapping_data.iv_counter_nonce)
+        self.assertEqual(
+            enums.EncodingOption.TTLV_ENCODING,
+            key_wrapping_data.encoding_option
+        )
+
+        key_wrapping_data = objects.KeyWrappingData(
+            wrapping_method=enums.WrappingMethod.ENCRYPT,
+            encryption_key_information={
+                'unique_identifier': "12345678-9012-3456-7890-123456789012",
+                'cryptographic_parameters': {
+                    'block_cipher_mode': enums.BlockCipherMode.CTR
+                }
+            },
+            mac_signature_key_information={
+                'unique_identifier': "00000000-1111-2222-3333-444444444444",
+                'cryptographic_parameters': {
+                    'block_cipher_mode': enums.BlockCipherMode.NIST_KEY_WRAP
+                }
+            },
             mac_signature=b'\x01',
             iv_counter_nonce=b'\x02',
             encoding_option=enums.EncodingOption.TTLV_ENCODING


### PR DESCRIPTION
This change makes several minor updates to different structs pertaining to key wrapping, allowing these structs to accept and process dict arguments. Unit tests have been updated to reflect this change.