### PR TITLE
Update the kmip package to allow importing enums globally

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -16,6 +16,8 @@
 import os
 import re
 
+from kmip.core import enums
+
 # Dynamically set __version__
 version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'version.py')
@@ -24,4 +26,9 @@ with open(version_path, 'r') as version_file:
     __version__ = mo.group(1)
 
 
-__all__ = ['core', 'demos', 'services']
+__all__ = [
+    'core',
+    'demos',
+    'enums',
+    'services'
+]


### PR DESCRIPTION
This change updates the root-level kmip package, allowing users to now import enums directly from the kmip package:

from kmip import enums

Enumerations are used throughout the codebase and user applications and this will simplify usage and help obfuscate internal package details that may change in the future.