### PR TITLE
Update the kmip package to support importing the client

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -17,6 +17,9 @@ import os
 import re
 
 from kmip.core import enums
+from kmip.pie import client
+from kmip.pie import objects
+from kmip.pie.client import ProxyKmipClient as KmipClient
 
 # Dynamically set __version__
 version_path = os.path.join(os.path.dirname(
@@ -27,8 +30,11 @@ with open(version_path, 'r') as version_file:
 
 
 __all__ = [
+    'client',
     'core',
     'demos',
     'enums',
+    'KmipClient',
+    'objects',
     'services'
 ]

--- a/kmip/pie/__init__.py
+++ b/kmip/pie/__init__.py
@@ -12,3 +12,10 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+from kmip.pie.client import ProxyKmipClient
+
+
+__all__ = [
+    "ProxyKmipClient"
+]


### PR DESCRIPTION
This change updates the root-level kmip package, allowing users to now import the client directly from the kmip package:

from kmip import KmipClient

The KmipClient is an alias for the ProxyKmipClient located in kmip.pie.client. This will simplify usage and help obfuscate internal package details that may change in the future.