### PR TITLE
Rename the CertificateTypeEnum enum to CertificateType

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -17,7 +17,6 @@ import six
 
 from kmip.core import enums
 
-from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import HashingAlgorithm as HashingAlgorithmEnum
 from kmip.core.enums import KeyFormatType as KeyFormatTypeEnum
 from kmip.core.enums import Tags
@@ -781,17 +780,17 @@ class CertificateType(Enumeration):
     information.
     """
 
-    def __init__(self, value=CertificateTypeEnum.X_509):
+    def __init__(self, value=enums.CertificateType.X_509):
         """
         Construct a CertificateType object.
 
         Args:
-            value (CertificateTypeEnum): A CertificateTypeEnum enumeration
-                value, (e.g., CertificateTypeEnum.PGP). Optional, defaults to
-                CertificateTypeEnum.X_509.
+            value (CertificateType): A CertificateType enumeration
+                value, (e.g., CertificateType.PGP). Optional, defaults to
+                CertificateType.X_509.
         """
         super(CertificateType, self).__init__(
-            enums.CertificateTypeEnum, value, Tags.CERTIFICATE_TYPE)
+            enums.CertificateType, value, Tags.CERTIFICATE_TYPE)
 
 
 class DigestValue(ByteString):

--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -137,7 +137,7 @@ class CertificateRequestType(enum.Enum):
     PGP    = 0x00000004  # DEPRECATED
 
 
-class CertificateTypeEnum(enum.Enum):
+class CertificateType(enum.Enum):
     X_509 = 0x00000001
     PGP   = 0x00000002  # Deprecated as of KMIP 1.4
 

--- a/kmip/core/secrets.py
+++ b/kmip/core/secrets.py
@@ -52,7 +52,7 @@ class Certificate(Struct):
         Construct a Certificate object.
 
         Args:
-            certificate_type (CertificateTypeEnum): The type of the
+            certificate_type (CertificateType): The type of the
                 certificate. Optional, defaults to None.
             certificate_value (bytes): The bytes of the certificate. Optional,
                 defaults to None.

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -22,7 +22,7 @@ from kmip.core.attributes import CryptographicAlgorithm
 from kmip.core.attributes import CryptographicLength
 
 from kmip.core.enums import AttributeType
-from kmip.core.enums import CertificateTypeEnum
+from kmip.core.enums import CertificateType
 from kmip.core.enums import CryptographicAlgorithm as CryptoAlgorithmEnum
 from kmip.core.enums import CryptographicUsageMask
 from kmip.core.enums import ObjectType
@@ -302,7 +302,7 @@ def build_object(logger, object_type, key_format_type):
     if object_type == ObjectType.CERTIFICATE:
         value = build_secret_value(logger, object_type)
         return Certificate(
-            certificate_type=CertificateTypeEnum.X_509,
+            certificate_type=CertificateType.X_509,
             certificate_value=value)
     else:
         return build_key(logger, object_type, key_format_type)

--- a/kmip/pie/factory.py
+++ b/kmip/pie/factory.py
@@ -75,7 +75,7 @@ class ObjectFactory:
         certificate_type = cert.certificate_type.value
         value = cert.certificate_value.value
 
-        if certificate_type == enums.CertificateTypeEnum.X_509:
+        if certificate_type == enums.CertificateType.X_509:
             return pobjects.X509Certificate(value)
         else:
             raise TypeError("core certificate type not supported")

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -1072,7 +1072,7 @@ class Certificate(CryptographicObject):
                                ForeignKey('crypto_objects.uid'),
                                primary_key=True)
     certificate_type = Column(
-        'certificate_type', sql.EnumType(enums.CertificateTypeEnum))
+        'certificate_type', sql.EnumType(enums.CertificateType))
 
     __mapper_args__ = {
         'polymorphic_identity': 'Certificate'
@@ -1129,8 +1129,8 @@ class Certificate(CryptographicObject):
         if not isinstance(self.value, bytes):
             raise TypeError("certificate value must be bytes")
         elif not isinstance(self.certificate_type,
-                            enums.CertificateTypeEnum):
-            raise TypeError("certificate type must be a CertificateTypeEnum "
+                            enums.CertificateType):
+            raise TypeError("certificate type must be a CertificateType "
                             "enumeration")
 
         mask_count = len(self.cryptographic_usage_masks)
@@ -1192,7 +1192,7 @@ class X509Certificate(Certificate):
             name(string): The string name of the certificate.
         """
         super(X509Certificate, self).__init__(
-            enums.CertificateTypeEnum.X_509, value, masks, name)
+            enums.CertificateType.X_509, value, masks, name)
 
         # All remaining attributes are not considered part of the public API
         # and are subject to change.

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -24,7 +24,7 @@ from kmip.core.enums import AttributeType
 from kmip.core.enums import CryptographicAlgorithm as CryptoAlgorithmEnum
 from kmip.core.enums import CryptographicUsageMask
 from kmip.core.enums import KeyFormatType as KeyFormatTypeEnum
-from kmip.core.enums import CertificateTypeEnum
+from kmip.core.enums import CertificateType
 from kmip.core.enums import NameType
 from kmip.core.enums import ObjectType
 from kmip.core.enums import OpaqueDataType
@@ -838,7 +838,7 @@ class TestIntegration(TestCase):
         cert_template_attribute = TemplateAttribute(
             attributes=cert_attributes)
 
-        cert_format_type = CertificateTypeEnum.X_509
+        cert_format_type = CertificateType.X_509
 
         cert_data = (
             b'\x30\x82\x03\x12\x30\x82\x01\xFA\xA0\x03\x02\x01\x02\x02\x01\x01'

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -26,7 +26,6 @@ from kmip.core.attributes import Name
 from kmip.core.attributes import OperationPolicyName
 
 from kmip.core import enums
-from kmip.core.enums import CertificateTypeEnum
 from kmip.core.enums import HashingAlgorithm as HashingAlgorithmEnum
 from kmip.core.enums import NameType
 
@@ -310,10 +309,10 @@ class TestCertificateType(TestCase):
         super(TestCertificateType, self).tearDown()
 
     def _test_init(self, value):
-        if (isinstance(value, CertificateTypeEnum)) or (value is None):
+        if (isinstance(value, enums.CertificateType)) or (value is None):
             if value is None:
                 certificate_type = CertificateType()
-                value = CertificateTypeEnum.X_509
+                value = enums.CertificateType.X_509
             else:
                 certificate_type = CertificateType(value)
 
@@ -335,7 +334,7 @@ class TestCertificateType(TestCase):
         Test that a CertificateType object can be constructed with valid byte
         data.
         """
-        self._test_init(CertificateTypeEnum.PGP)
+        self._test_init(enums.CertificateType.PGP)
 
 
 class TestDigestValue(TestCase):

--- a/kmip/tests/unit/core/secrets/test_certificate.py
+++ b/kmip/tests/unit/core/secrets/test_certificate.py
@@ -16,7 +16,7 @@
 from testtools import TestCase
 
 from kmip.core.attributes import CertificateType
-from kmip.core.enums import CertificateTypeEnum
+from kmip.core import enums
 from kmip.core.misc import CertificateValue
 from kmip.core.secrets import Certificate
 from kmip.core.utils import BytearrayStream
@@ -31,7 +31,7 @@ class TestCertificate(TestCase):
         super(TestCertificate, self).setUp()
 
         self.certificate_type_a = None
-        self.certificate_type_b = CertificateTypeEnum.X_509
+        self.certificate_type_b = enums.CertificateType.X_509
 
         # Encodings obtained from Section 13.2 of KMIP 1.1 Test Cases document.
         self.certificate_value_a = None

--- a/kmip/tests/unit/pie/objects/test_certificate.py
+++ b/kmip/tests/unit/pie/objects/test_certificate.py
@@ -171,7 +171,7 @@ class TestCertificate(testtools.TestCase):
         """
         Test that direct instantiation of a Certificate fails.
         """
-        args = (enums.CertificateTypeEnum.X_509, self.bytes_a)
+        args = (enums.CertificateType.X_509, self.bytes_a)
         self.assertRaises(TypeError, objects.Certificate, *args)
 
     def test_init(self):
@@ -179,10 +179,10 @@ class TestCertificate(testtools.TestCase):
         Test that a complete subclass of Certificate can be instantiated.
         """
         certificate = DummyCertificate(
-            enums.CertificateTypeEnum.X_509, self.bytes_a)
+            enums.CertificateType.X_509, self.bytes_a)
 
         self.assertEqual(
-            certificate.certificate_type, enums.CertificateTypeEnum.X_509)
+            certificate.certificate_type, enums.CertificateType.X_509)
         self.assertEqual(certificate.value, self.bytes_a)
         self.assertEqual(certificate.cryptographic_usage_masks, list())
         self.assertEqual(certificate.names, ['Certificate'])
@@ -193,14 +193,14 @@ class TestCertificate(testtools.TestCase):
         all arguments.
         """
         cert = DummyCertificate(
-            enums.CertificateTypeEnum.X_509,
+            enums.CertificateType.X_509,
             self.bytes_a,
             masks=[enums.CryptographicUsageMask.ENCRYPT,
                    enums.CryptographicUsageMask.VERIFY],
             name='Test Certificate')
 
         self.assertEqual(
-            cert.certificate_type, enums.CertificateTypeEnum.X_509)
+            cert.certificate_type, enums.CertificateType.X_509)
         self.assertEqual(cert.value, self.bytes_a)
         self.assertEqual(cert.cryptographic_usage_masks,
                          [enums.CryptographicUsageMask.ENCRYPT,
@@ -213,7 +213,7 @@ class TestCertificate(testtools.TestCase):
         of Certificate.
         """
         expected = enums.ObjectType.CERTIFICATE
-        cert = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        cert = DummyCertificate(enums.CertificateType.X_509, self.bytes_a)
         observed = cert.object_type
         self.assertEqual(expected, observed)
 
@@ -230,7 +230,7 @@ class TestCertificate(testtools.TestCase):
         Test that a TypeError is raised when an invalid length value is used
         to construct a complete subclass of Certificate.
         """
-        args = (enums.CertificateTypeEnum.X_509, 0)
+        args = (enums.CertificateType.X_509, 0)
         self.assertRaises(TypeError, DummyCertificate, *args)
 
     def test_validate_on_invalid_masks(self):
@@ -238,7 +238,7 @@ class TestCertificate(testtools.TestCase):
         Test that a TypeError is raised when an invalid masks value is used to
         construct a complete subclass of Certificate.
         """
-        args = (enums.CertificateTypeEnum.X_509, self.bytes_a)
+        args = (enums.CertificateType.X_509, self.bytes_a)
         kwargs = {'masks': 'invalid'}
         self.assertRaises(TypeError, DummyCertificate, *args, **kwargs)
 
@@ -247,7 +247,7 @@ class TestCertificate(testtools.TestCase):
         Test that a TypeError is raised when an invalid mask value is used to
         construct a complete subclass of Certificate.
         """
-        args = (enums.CertificateTypeEnum.X_509, self.bytes_a)
+        args = (enums.CertificateType.X_509, self.bytes_a)
         kwargs = {'masks': ['invalid']}
         self.assertRaises(TypeError, DummyCertificate, *args, **kwargs)
 
@@ -256,7 +256,7 @@ class TestCertificate(testtools.TestCase):
         Test that a TypeError is raised when an invalid name value is used to
         construct a complete subclass of Certificate.
         """
-        args = (enums.CertificateTypeEnum.X_509, self.bytes_a)
+        args = (enums.CertificateType.X_509, self.bytes_a)
         kwargs = {'name': 0}
         self.assertRaises(TypeError, DummyCertificate, *args, **kwargs)
 
@@ -264,14 +264,14 @@ class TestCertificate(testtools.TestCase):
         """
         Test that repr can be applied to a complete subclass of Certificate.
         """
-        dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        dummy = DummyCertificate(enums.CertificateType.X_509, self.bytes_a)
         repr(dummy)
 
     def test_str(self):
         """
         Test that str can be applied to a complete subclass of Certificate.
         """
-        dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        dummy = DummyCertificate(enums.CertificateType.X_509, self.bytes_a)
         str(dummy)
 
     def test_eq(self):
@@ -279,7 +279,7 @@ class TestCertificate(testtools.TestCase):
         Test that equality can be applied to a complete subclass of
         Certificate.
         """
-        dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        dummy = DummyCertificate(enums.CertificateType.X_509, self.bytes_a)
         self.assertTrue(dummy == dummy)
 
     def test_ne(self):
@@ -287,5 +287,5 @@ class TestCertificate(testtools.TestCase):
         Test that inequality can be applied to a complete subclass of
         Certificate.
         """
-        dummy = DummyCertificate(enums.CertificateTypeEnum.X_509, self.bytes_a)
+        dummy = DummyCertificate(enums.CertificateType.X_509, self.bytes_a)
         self.assertFalse(dummy != dummy)

--- a/kmip/tests/unit/pie/objects/test_x509_certificate.py
+++ b/kmip/tests/unit/pie/objects/test_x509_certificate.py
@@ -149,7 +149,7 @@ class TestX509Certificate(testtools.TestCase):
         certificate = X509Certificate(self.bytes_a)
 
         self.assertEqual(
-            certificate.certificate_type, enums.CertificateTypeEnum.X_509)
+            certificate.certificate_type, enums.CertificateType.X_509)
         self.assertEqual(certificate.value, self.bytes_a)
         self.assertEqual(certificate.cryptographic_usage_masks, list())
         self.assertEqual(certificate.names, ['X.509 Certificate'])
@@ -166,7 +166,7 @@ class TestX509Certificate(testtools.TestCase):
             name='Test X.509 Certificate')
 
         self.assertEqual(
-            cert.certificate_type, enums.CertificateTypeEnum.X_509)
+            cert.certificate_type, enums.CertificateType.X_509)
         self.assertEqual(cert.value, self.bytes_a)
         self.assertEqual(cert.cryptographic_usage_masks,
                          [enums.CryptographicUsageMask.ENCRYPT,
@@ -223,7 +223,7 @@ class TestX509Certificate(testtools.TestCase):
         """
         cert = X509Certificate(self.bytes_a)
         args = "certificate_type={0}, value={1}".format(
-            enums.CertificateTypeEnum.X_509, binascii.hexlify(self.bytes_a))
+            enums.CertificateType.X_509, binascii.hexlify(self.bytes_a))
         expected = "X509Certificate({0})".format(args)
         observed = repr(cert)
         self.assertEqual(expected, observed)

--- a/kmip/tests/unit/pie/test_factory.py
+++ b/kmip/tests/unit/pie/test_factory.py
@@ -341,7 +341,7 @@ class TestObjectFactory(testtools.TestCase):
         Test that a core certificate can be converted into a Pie certificate.
         """
         core_cert = secrets.Certificate(
-            enums.CertificateTypeEnum.X_509, self.certificate_bytes)
+            enums.CertificateType.X_509, self.certificate_bytes)
         pie_cert = self.factory.convert(core_cert)
 
         self.assertIsInstance(pie_cert, pobjects.X509Certificate)
@@ -526,7 +526,7 @@ class TestObjectFactory(testtools.TestCase):
         unsupported certificate type.
         """
         core_cert = secrets.Certificate(
-            enums.CertificateTypeEnum.PGP, self.certificate_bytes)
+            enums.CertificateType.PGP, self.certificate_bytes)
         args = (core_cert, )
         self.assertRaises(
             TypeError, self.factory._build_pie_certificate, *args)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -1074,7 +1074,7 @@ class TestKmipEngine(testtools.TestCase):
             core_object.certificate_value.value
         )
         self.assertEqual(
-            enums.CertificateTypeEnum.X_509,
+            enums.CertificateType.X_509,
             core_object.certificate_type.value
         )
 
@@ -1592,7 +1592,7 @@ class TestKmipEngine(testtools.TestCase):
             certificate,
             'Certificate Type'
         )
-        self.assertEqual(enums.CertificateTypeEnum.X_509, result)
+        self.assertEqual(enums.CertificateType.X_509, result)
 
         result = e._get_attribute_from_managed_object(
             certificate,


### PR DESCRIPTION
This change renames the CertificateTypeEnum enumeration to CertificateType, matching the naming schemes of all other enumerations. This is a backwards incompatible change and will break any scripts or programs that use the current CertificateTypeEnum name.