### PR TITLE
Fixing violations of E722 for flake8 checks

### DIFF
--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -83,7 +83,7 @@ class ConfigHelper(object):
                 self.logger.debug(CONF_MSG.format(return_value,
                                                   CONFIG_FILE,
                                                   config_option_name))
-            except:
+            except Exception:
                 return_value = default_value
                 self.logger.debug(DEFAULT_MSG.format(default_value,
                                                      config_option_name))

--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -678,7 +678,7 @@ class Boolean(Base):
         """
         try:
             value = unpack('!Q', istream.read(self.LENGTH))[0]
-        except:
+        except Exception:
             self.logger.error("Error reading boolean value from buffer")
             raise
 
@@ -713,7 +713,7 @@ class Boolean(Base):
         """
         try:
             ostream.write(pack('!Q', self.value))
-        except:
+        except Exception:
             self.logger.error("Error writing boolean value to buffer")
             raise
 

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -357,11 +357,11 @@ class KMIPProxy(KMIP):
         result['result_status'] = batch_item.result_status.value
         try:
             result['result_reason'] = batch_item.result_reason.value
-        except:
+        except Exception:
             result['result_reason'] = batch_item.result_reason
         try:
             result['result_message'] = batch_item.result_message.value
-        except:
+        except Exception:
             result['result_message'] = batch_item.result_message
 
         return result
@@ -571,11 +571,11 @@ class KMIPProxy(KMIP):
         result['result_status'] = batch_item.result_status.value
         try:
             result['result_reason'] = batch_item.result_reason.value
-        except:
+        except Exception:
             result['result_reason'] = batch_item.result_reason
         try:
             result['result_message'] = batch_item.result_message.value
-        except:
+        except Exception:
             result['result_message'] = batch_item.result_message
 
         return result
@@ -646,11 +646,11 @@ class KMIPProxy(KMIP):
         result['result_status'] = batch_item.result_status.value
         try:
             result['result_reason'] = batch_item.result_reason.value
-        except:
+        except Exception:
             result['result_reason'] = batch_item.result_reason
         try:
             result['result_message'] = batch_item.result_message.value
-        except:
+        except Exception:
             result['result_message'] = batch_item.result_message
 
         return result
@@ -721,11 +721,11 @@ class KMIPProxy(KMIP):
         result['result_status'] = batch_item.result_status.value
         try:
             result['result_reason'] = batch_item.result_reason.value
-        except:
+        except Exception:
             result['result_reason'] = batch_item.result_reason
         try:
             result['result_message'] = batch_item.result_message.value
-        except:
+        except Exception:
             result['result_message'] = batch_item.result_message
 
         return result
@@ -787,11 +787,11 @@ class KMIPProxy(KMIP):
         result['result_status'] = batch_item.result_status.value
         try:
             result['result_reason'] = batch_item.result_reason.value
-        except:
+        except Exception:
             result['result_reason'] = batch_item.result_reason
         try:
             result['result_message'] = batch_item.result_message.value
-        except:
+        except Exception:
             result['result_message'] = batch_item.result_message
 
         return result

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -1208,7 +1208,7 @@ class CryptographyEngine(api.CryptographicEngine):
                 backend=default_backend()
             )
             return private_key
-        except:
+        except Exception:
             private_key = serialization.load_der_private_key(
                 bytes,
                 password=None,
@@ -1271,7 +1271,7 @@ class CryptographyEngine(api.CryptographicEngine):
         if crypto_alg == enums.CryptographicAlgorithm.RSA:
             try:
                 key = self._create_RSA_private_key(signing_key)
-            except:
+            except Exception:
                 raise exceptions.InvalidField('Unable to deserialize key '
                                               'bytes, unknown format.')
         else:

--- a/kmip/tests/unit/services/server/crypto/test_engine.py
+++ b/kmip/tests/unit/services/server/crypto/test_engine.py
@@ -2664,7 +2664,7 @@ def load_private_key(key):
             password=None,
             backend=default_backend()
         )
-    except:
+    except Exception:
         return serialization.load_pem_private_key(
             key,
             password=None,

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -17,7 +17,7 @@ import logging
 
 try:
     import unittest.mock as mock
-except:
+except Exception:
     import mock
 
 import signal


### PR DESCRIPTION
This change fixes violations of E722, the use of except without specifying an exception type. For now the high-level Exception class is used as a generic catchall. In the future these cases will be updated to handle the specific exceptions expected.