### PR TITLE
Fixing bug with session logging shared ciphers

### DIFF
--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -158,12 +158,13 @@ class KmipSession(threading.Thread):
         max_size = self._max_response_size
 
         try:
-            shared_ciphers = self._connection.shared_ciphers()
-            self._logger.debug(
-                "Possible session ciphers: {0}".format(len(shared_ciphers))
-            )
-            for cipher in shared_ciphers:
-                self._logger.debug(cipher)
+            if hasattr(self._connection, 'shared_ciphers'):
+                shared_ciphers = self._connection.shared_ciphers()
+                self._logger.debug(
+                    "Possible session ciphers: {0}".format(len(shared_ciphers))
+                )
+                for cipher in shared_ciphers:
+                    self._logger.debug(cipher)
             self._logger.debug(
                 "Session cipher selected: {0}".format(
                     self._connection.cipher()


### PR DESCRIPTION
This change fixes a bug with the KmipSession logging shared ciphers used by the TLS connection. The SSLSocket only supports shared cipher information starting with Python 3.5. Any use of the server with older versions of Python will fail when any connection attempts are made. This fix adds a conditional check that skips logging shared cipher information if the SSLSocket does not support that information.

Fixes #361