### PR TITLE
Update the Travis CI infrastructure to run integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,101 @@
+sudo: true
 language: python
 matrix:
     include:
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=py27
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=py27
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
+          dist: precise
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
+        - python: 2.7
+          os: linux
+          dist: trusty
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
         - python: 3.4
           os: linux
           dist: precise
-          env: TOXENV=py34
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
         - python: 3.4
           os: linux
           dist: trusty
-          env: TOXENV=py34
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
+        - python: 3.4
+          os: linux
+          dist: precise
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
+        - python: 3.4
+          os: linux
+          dist: trusty
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
         - python: 3.5
           os: linux
           dist: precise
-          env: TOXENV=py35
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
         - python: 3.5
           os: linux
           dist: trusty
-          env: TOXENV=py35
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
+        - python: 3.5
+          os: linux
+          dist: precise
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
+        - python: 3.5
+          os: linux
+          dist: trusty
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
         - python: 3.6
           os: linux
           dist: precise
-          env: TOXENV=py36
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
         - python: 3.6
           os: linux
           dist: trusty
-          env: TOXENV=py36
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
+        - python: 3.6
+          os: linux
+          dist: precise
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
+        - python: 3.6
+          os: linux
+          dist: trusty
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=pep8
+          env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=pep8
+          env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=bandit
+          env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=bandit
+          env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: precise
-          env: TOXENV=docs
+          env: TOXENV=docs RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
           dist: trusty
-          env: TOXENV=docs
+          env: TOXENV=docs RUN_INTEGRATION_TESTS=0
 install:
   - pip install tox
   - pip install bandit
   - pip install codecov
+  - python setup.py install
 script:
-  - tox
+  - ./.travis/run.sh
 after_success:
   - codecov

--- a/.travis/pykmip.conf
+++ b/.travis/pykmip.conf
@@ -1,0 +1,12 @@
+[client]
+host=127.0.0.1
+port=5696
+keyfile=/etc/pykmip/certs/key.pem
+certfile=/etc/pykmip/certs/cert.pem
+cert_reqs=CERT_REQUIRED
+ssl_version=PROTOCOL_SSLv23
+ca_certs=/etc/pykmip/certs/cert.pem
+do_handshake_on_connect=True
+suppress_ragged_eofs=True
+username=
+password=

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "${RUN_INTEGRATION_TESTS}" == "1" ]]; then
+    sudo mkdir -p /etc/pykmip/certs
+    cd /etc/pykmip/certs
+    sudo openssl req -x509 -subj "/CN=test" -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
+    cd -
+    sudo cp ./.travis/pykmip.conf /etc/pykmip/pykmip.conf
+    sudo cp ./.travis/server.conf /etc/pykmip/server.conf
+    sudo mkdir /var/log/pykmip
+    sudo chmod 777 /var/log/pykmip
+    python ./bin/run_server.py &
+    tox -e integration -- --config client
+else
+    tox
+fi
+

--- a/.travis/server.conf
+++ b/.travis/server.conf
@@ -1,0 +1,8 @@
+[server]
+hostname=127.0.0.1
+port=5696
+certificate_path=/etc/pykmip/certs/cert.pem
+key_path=/etc/pykmip/certs/key.pem
+ca_path=/etc/pykmip/certs/cert.pem
+auth_suite=Basic
+enable_tls_client_auth=False


### PR DESCRIPTION
This change updates the Travis CI configuration to support running the PyKMIP integation test suite. A custom run.sh script is added which conditionally runs tox based on an environment flag set in .travis.yml. If integration tests are activated, the test VM will be prepped for running the PyKMIP server; this includes creating /etc/pykmip content, like pykmip.conf and server.conf, along with a basic certificate to use for both the client and server.