### PR TITLE
PyKMIP - Release 0.7.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,30 @@
+0.7.0 - November 14, 2017
+* Add support for Python 3.6
+* Add support for the InitialDate attribute
+* Add server support for the GetAttributeList operation
+* Add server support for the Locate operation
+* Add client and server support for the MAC operation
+* Add client and server support for the Revoke operation
+* Add client and server support for the Encrypt operation
+* Add client and server support for the Decrypt operation
+* Add client and server support for the DeriveKey operation
+* Add client and server support for the Sign operation
+* Add client and server support for the SignatureVerify operation
+* Add client and server support for retrieving wrapped keys
+* Add client and server support for storing wrapped keys
+* Add KMIP 1.4 enumerations
+* Add server config option enabling certificate extension checks
+* Add server config option defining set of usable TLS ciphers
+* Add server config option setting the server log level
+* Update the server to enforce checking object state and usage masks
+* Update server Locate support to allow object name filtering
+* Remove support for Python 2.6
+* Fix bug with multithreading support with the SQLite backend
+* Fix bug with how open() is mocked in the server test suite
+* Fix bug with mismapped polymorphic identity for certificate objects
+* Fix bug with socket interrupt handling under Python 3.5
+* Fix bug with detached instance errors in the server test suite
+
 0.6.0 - December 14, 2016
 * Add support for Python 3.5
 * Add support for the State and OperationPolicyName attributes

--- a/kmip/version.py
+++ b/kmip/version.py
@@ -13,4 +13,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'


### PR DESCRIPTION
This update includes new operations and features for the client and server, in addition to other minor updates and bug fixes:

* Add support for Python 3.6
* Add support for the InitialDate attribute
* Add server support for the GetAttributeList operation
* Add server support for the Locate operation
* Add client and server support for the MAC operation
* Add client and server support for the Revoke operation
* Add client and server support for the Encrypt operation
* Add client and server support for the Decrypt operation
* Add client and server support for the DeriveKey operation
* Add client and server support for the Sign operation
* Add client and server support for the SignatureVerify operation
* Add client and server support for retrieving wrapped keys
* Add client and server support for storing wrapped keys
* Add KMIP 1.4 enumerations
* Add server config option enabling certificate extension checks
* Add server config option defining set of usable TLS ciphers
* Add server config option setting the server log level
* Update server to enforce checking object state and usage masks
* Update server Locate support to allow object name filtering
* Remove support for Python 2.6
* Fix bug with multithreading support with the SQLite backend
* Fix bug with how open() is mocked in the server test suite
* Fix bug with mismapped polymorphic identity for certificates
* Fix bug with socket interrupt handling under Python 3.5
* Fix bug with detached instance errors in the server test suite