### PR TITLE
Update the PyKMIP library version to 0.8.dev

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.8 - master
+- This version is under active development and has not been released.
+
 0.7.0 - November 14, 2017
 * Add support for Python 3.6
 * Add support for the InitialDate attribute

--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -25,7 +25,7 @@ from kmip.pie.client import ProxyKmipClient as KmipClient
 version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'version.py')
 with open(version_path, 'r') as version_file:
-    mo = re.search(r"^.*= '(\d\.\d\.\d)'$", version_file.read(), re.MULTILINE)
+    mo = re.search(r"^.*= '(\d\.\d\..*)'$", version_file.read(), re.MULTILINE)
     __version__ = mo.group(1)
 
 

--- a/kmip/version.py
+++ b/kmip/version.py
@@ -13,4 +13,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-__version__ = '0.7.0'
+__version__ = '0.8.dev'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import setuptools
 version_path = os.path.join(os.path.dirname(
     os.path.realpath(__file__)), 'kmip', 'version.py')
 with open(version_path, 'r') as version_file:
-    mo = re.search(r"^.*= '(\d\.\d\.\d)'$", version_file.read(), re.MULTILINE)
+    mo = re.search(r"^.*= '(\d\.\d\..*)'$", version_file.read(), re.MULTILINE)
     __version__ = mo.group(1)
 
 setuptools.setup(


### PR DESCRIPTION
This change updates the library version to the next dev version, tweaking version handling and the changelog to reflect this change.