### PR TITLE
Update the Travis CI config to test doc building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ matrix:
           os: linux
           dist: trusty
           env: TOXENV=bandit
+        - python: 2.7
+          os: linux
+          dist: precise
+          env: TOXENV=docs
+        - python: 2.7
+          os: linux
+          dist: trusty
+          env: TOXENV=docs
 install:
   - pip install tox
   - pip install bandit


### PR DESCRIPTION
This change updates the .travis.yml configuration to include building the Sphinx documentation whenever the Travis CI build is triggered.