### PR TITLE
Temporarily pin pytest to <3.3

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
-# TODO: add any test requirements here
 coverage
-pytest
+pytest<3.3  # TODO (peter-hamilton): Unpin this after Python 3.3 is dropped
 flake8
 testtools
 fixtures


### PR DESCRIPTION
This change pins the pytest requirement to <3.3 to allow for continuing Python 3.3 support. This change will be reverted once official support for Python 3.3 is dropped from PyKMIP.