### PR TITLE
Add payloads for the GetUsageAllocation operation

### DIFF
--- a/kmip/core/messages/payloads/__init__.py
+++ b/kmip/core/messages/payloads/__init__.py
@@ -65,6 +65,10 @@ from kmip.core.messages.payloads.get_attributes import (
     GetAttributesRequestPayload,
     GetAttributesResponsePayload
 )
+from kmip.core.messages.payloads.get_usage_allocation import (
+    GetUsageAllocationRequestPayload,
+    GetUsageAllocationResponsePayload
+)
 from kmip.core.messages.payloads.locate import (
     LocateRequestPayload,
     LocateResponsePayload
@@ -126,6 +130,8 @@ __all__ = [
     "GetAttributeListResponsePayload",
     "GetAttributesRequestPayload",
     "GetAttributesResponsePayload",
+    "GetUsageAllocationRequestPayload",
+    "GetUsageAllocationResponsePayload",
     "LocateRequestPayload",
     "LocateResponsePayload",
     "MACRequestPayload",

--- a/kmip/core/messages/payloads/get_usage_allocation.py
+++ b/kmip/core/messages/payloads/get_usage_allocation.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2017 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import six
+
+from kmip import enums
+from kmip.core import primitives
+from kmip.core import utils
+
+
+class GetUsageAllocationRequestPayload(primitives.Struct):
+    """
+    A request payload for the GetUsageAllocation operation.
+
+    Attributes:
+        unique_identifier: The unique ID of the object for which to obtain a
+            usage allocation.
+        usage_limits_count: The number of usage limits units that should be
+            reserved for the object.
+    """
+
+    def __init__(self, unique_identifier=None, usage_limits_count=None):
+        """
+        Construct a GetUsageAllocation request payload struct.
+
+        Args:
+            unique_identifier (string): The ID of the managed object (e.g.,
+                a public key) to obtain a usage allocation for. Optional,
+                defaults to None.
+            usage_limits_count (int): The number of usage limits units that
+                should be reserved for the object. Optional, defaults to None.
+        """
+        super(GetUsageAllocationRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD
+        )
+
+        self._unique_identifier = None
+        self._usage_limits_count = None
+
+        self.unique_identifier = unique_identifier
+        self.usage_limits_count = usage_limits_count
+
+    @property
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
+        else:
+            return None
+
+    @unique_identifier.setter
+    def unique_identifier(self, value):
+        if value is None:
+            self._unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Unique identifier must be a string.")
+
+    @property
+    def usage_limits_count(self):
+        if self._usage_limits_count:
+            return self._usage_limits_count.value
+        else:
+            return None
+
+    @usage_limits_count.setter
+    def usage_limits_count(self, value):
+        if value is None:
+            self._usage_limits_count = None
+        elif isinstance(value, six.integer_types):
+            self._usage_limits_count = primitives.LongInteger(
+                value=value,
+                tag=enums.Tags.USAGE_LIMITS_COUNT
+            )
+        else:
+            raise TypeError("Usage limits count must be an integer.")
+
+    def read(self, input_stream):
+        """
+        Read the data encoding the GetUsageAllocation request payload and
+        decode it into its constituent parts.
+
+        Args:
+            input_stream (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
+
+        Raises:
+            ValueError: Raised if the data attribute is missing from the
+                encoded payload.
+        """
+        super(GetUsageAllocationRequestPayload, self).read(input_stream)
+        local_stream = utils.BytearrayStream(input_stream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
+            self._unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            self._unique_identifier.read(local_stream)
+        if self.is_tag_next(enums.Tags.USAGE_LIMITS_COUNT, local_stream):
+            self._usage_limits_count = primitives.LongInteger(
+                tag=enums.Tags.USAGE_LIMITS_COUNT
+            )
+            self._usage_limits_count.read(local_stream)
+
+        self.is_oversized(local_stream)
+
+    def write(self, output_stream):
+        """
+        Write the data encoding the GetUsageAllocation request payload to a
+        stream.
+
+        Args:
+            output_stream (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
+
+        Raises:
+            ValueError: Raised if the data attribute is not defined.
+        """
+        local_stream = utils.BytearrayStream()
+
+        if self._unique_identifier:
+            self._unique_identifier.write(local_stream)
+        if self._usage_limits_count:
+            self._usage_limits_count.write(local_stream)
+
+        self.length = local_stream.length()
+        super(GetUsageAllocationRequestPayload, self).write(output_stream)
+        output_stream.write(local_stream.buffer)
+
+    def __eq__(self, other):
+        if isinstance(other, GetUsageAllocationRequestPayload):
+            if self.unique_identifier != other.unique_identifier:
+                return False
+            elif self.usage_limits_count != other.usage_limits_count:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, GetUsageAllocationRequestPayload):
+            return not (self == other)
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        args = ", ".join([
+            "unique_identifier='{0}'".format(self.unique_identifier),
+            "usage_limits_count={0}".format(self.usage_limits_count)
+        ])
+        return "GetUsageAllocationRequestPayload({0})".format(args)
+
+    def __str__(self):
+        return str({
+            'unique_identifier': self.unique_identifier,
+            'usage_limits_count': self.usage_limits_count
+        })
+
+
+class GetUsageAllocationResponsePayload(primitives.Struct):
+    """
+    A response payload for the GetUsageAllocation operation.
+
+    Attributes:
+        unique_identifier: The unique ID of the object that was allocated.
+    """
+
+    def __init__(self, unique_identifier=None):
+        """
+        Construct a GetUsageAllocation response payload struct.
+
+        Args:
+            unique_identifier (string): The ID of the managed object (e.g.,
+                a public key) that was allocated. Optional, defaults to None.
+        """
+        super(GetUsageAllocationResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD
+        )
+
+        self._unique_identifier = None
+        self.unique_identifier = unique_identifier
+
+    @property
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
+        else:
+            return None
+
+    @unique_identifier.setter
+    def unique_identifier(self, value):
+        if value is None:
+            self._unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Unique identifier must be a string.")
+
+    def read(self, input_stream):
+        """
+        Read the data encoding the GetUsageAllocation response payload and
+        decode it into its constituent parts.
+
+        Args:
+            input_stream (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
+
+        Raises:
+            ValueError: Raised if the data attribute is missing from the
+                encoded payload.
+        """
+        super(GetUsageAllocationResponsePayload, self).read(input_stream)
+        local_stream = utils.BytearrayStream(input_stream.read(self.length))
+
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
+            self._unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            self._unique_identifier.read(local_stream)
+
+        self.is_oversized(local_stream)
+
+    def write(self, output_stream):
+        """
+        Write the data encoding the GetUsageAllocation response payload to a
+        stream.
+
+        Args:
+            output_stream (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
+
+        Raises:
+            ValueError: Raised if the data attribute is not defined.
+        """
+        local_stream = utils.BytearrayStream()
+
+        if self._unique_identifier:
+            self._unique_identifier.write(local_stream)
+
+        self.length = local_stream.length()
+        super(GetUsageAllocationResponsePayload, self).write(output_stream)
+        output_stream.write(local_stream.buffer)
+
+    def __eq__(self, other):
+        if isinstance(other, GetUsageAllocationResponsePayload):
+            if self.unique_identifier != other.unique_identifier:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, GetUsageAllocationResponsePayload):
+            return not (self == other)
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        args = "unique_identifier='{0}'".format(self.unique_identifier)
+        return "GetUsageAllocationResponsePayload({0})".format(args)
+
+    def __str__(self):
+        return str({
+            'unique_identifier': self.unique_identifier,
+        })

--- a/kmip/tests/unit/core/messages/payloads/test_get_usage_allocation.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_usage_allocation.py
@@ -1,0 +1,634 @@
+# Copyright (c) 2017 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from kmip.core import utils
+from kmip.core.messages import payloads
+
+
+class TestGetUsageAllocationRequestPayload(testtools.TestCase):
+    """
+    Test suite for the GetUsageAllocation request payload.
+    """
+
+    def setUp(self):
+        super(TestGetUsageAllocationRequestPayload, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 5.1.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Unique Identifier - 2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6
+        #     Usage Limits Count - 500
+
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x00\x40'
+            b'\x42\x00\x94\x07\x00\x00\x00\x24'
+            b'\x32\x63\x32\x33\x32\x31\x37\x65\x2D\x66\x35\x33\x63\x2D\x34\x62'
+            b'\x64\x66\x2D\x61\x64\x30\x61\x2D\x35\x38\x61\x33\x31\x66\x64\x33'
+            b'\x64\x34\x62\x36\x00\x00\x00\x00'
+            b'\x42\x00\x96\x03\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x01\xF4'
+        )
+
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Usage Limits Count - 500
+        self.partial_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x00\x10'
+            b'\x42\x00\x96\x03\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x01\xF4'
+        )
+
+        self.empty_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestGetUsageAllocationRequestPayload, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a GetUsageAllocation request payload can be constructed with
+        no arguments.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.usage_limits_count)
+
+    def test_init_with_args(self):
+        """
+        Test that a GetUsageAllocation request payload can be constructed with
+        valid values.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='00000000-1111-2222-3333-444444444444',
+            usage_limits_count=10
+        )
+
+        self.assertEqual(
+            '00000000-1111-2222-3333-444444444444',
+            payload.unique_identifier
+        )
+        self.assertEqual(10, payload.usage_limits_count)
+
+    def test_invalid_unique_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the unique identifier of a GetUsageAllocation request payload.
+        """
+        kwargs = {'unique_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Unique identifier must be a string.",
+            payloads.GetUsageAllocationRequestPayload,
+            **kwargs
+        )
+
+        payload = payloads.GetUsageAllocationRequestPayload()
+        args = (payload, 'unique_identifier', 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Unique identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_usage_limits_count(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the usage limits count of a GetUsageAllocation request payload.
+        """
+        kwargs = {'usage_limits_count': 'invalid'}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Usage limits count must be an integer.",
+            payloads.GetUsageAllocationRequestPayload,
+            **kwargs
+        )
+
+        payload = payloads.GetUsageAllocationRequestPayload()
+        args = (payload, 'usage_limits_count', 'invalid')
+        self.assertRaisesRegexp(
+            TypeError,
+            "Usage limits count must be an integer.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a GetUsageAllocation request payload can be read from a data
+        stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.usage_limits_count)
+
+        payload.read(self.full_encoding)
+
+        self.assertEqual(
+            '2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6',
+            payload.unique_identifier
+        )
+        self.assertEqual(500, payload.usage_limits_count)
+
+    def test_read_partial(self):
+        """
+        Test that a GetUsageAllocation request payload can be read from a
+        partial data stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.usage_limits_count)
+
+        payload.read(self.partial_encoding)
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(500, payload.usage_limits_count)
+
+    def test_read_empty(self):
+        """
+        Test that a GetUsageAllocation request payload can be read from an
+        empty data stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.usage_limits_count)
+
+        payload.read(self.empty_encoding)
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.usage_limits_count)
+
+    def test_write(self):
+        """
+        Test that a GetUsageAllocation request payload can be written to a
+        data stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6',
+            usage_limits_count=500
+        )
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_partial(self):
+        """
+        Test that a partial GetUsageAllocation request payload can be written
+        to a data stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload(
+            usage_limits_count=500
+        )
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.partial_encoding), len(stream))
+        self.assertEqual(str(self.partial_encoding), str(stream))
+
+    def test_write_empty(self):
+        """
+        Test that an empty GetUsageAllocation request payload can be written
+        to a data stream.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload()
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.empty_encoding), len(stream))
+        self.assertEqual(str(self.empty_encoding), str(stream))
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        GetUsageAllocation request payloads with the same data.
+        """
+        a = payloads.GetUsageAllocationRequestPayload()
+        b = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=200
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=200
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        GetUsageAllocation request payloads with different unique identifiers.
+        """
+        a = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='a'
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='b'
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_usage_limits_count(self):
+        """
+        Test that the equality operator returns False when comparing two
+        GetUsageAllocation request payloads with different usage limits counts.
+        """
+        a = payloads.GetUsageAllocationRequestPayload(
+            usage_limits_count=0
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            usage_limits_count=1
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        GetUsageAllocation request payloads with different types.
+        """
+        a = payloads.GetUsageAllocationRequestPayload()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        GetUsageAllocation request payloads with the same data.
+        """
+        a = payloads.GetUsageAllocationRequestPayload()
+        b = payloads.GetUsageAllocationRequestPayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=200
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=200
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        GetUsageAllocation request payloads with different unique identifiers.
+        """
+        a = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='a'
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='b'
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_usage_limits_count(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        GetUsageAllocation request payloads with different usage limits counts.
+        """
+        a = payloads.GetUsageAllocationRequestPayload(
+            usage_limits_count=0
+        )
+        b = payloads.GetUsageAllocationRequestPayload(
+            usage_limits_count=1
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        GetUsageAllocation request payloads with different types.
+        """
+        a = payloads.GetUsageAllocationRequestPayload()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a GetUsageAllocation request payload.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=1000
+        )
+        expected = (
+            "GetUsageAllocationRequestPayload("
+            "unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038', "
+            "usage_limits_count=1000)"
+        )
+        observed = repr(payload)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a GetUsageAllocation request payload.
+        """
+        payload = payloads.GetUsageAllocationRequestPayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            usage_limits_count=1000
+        )
+
+        expected = str({
+            'unique_identifier': '49a1ca88-6bea-4fb2-b450-7e58802c3038',
+            'usage_limits_count': 1000
+        })
+        observed = str(payload)
+
+        self.assertEqual(expected, observed)
+
+
+class TestGetUsageAllocationResponsePayload(testtools.TestCase):
+    """
+    Test suite for the GetUsageAllocation response payload.
+    """
+
+    def setUp(self):
+        super(TestGetUsageAllocationResponsePayload, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 5.1.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Unique Identifier - 2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6
+
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x30'
+            b'\x42\x00\x94\x07\x00\x00\x00\x24'
+            b'\x32\x63\x32\x33\x32\x31\x37\x65\x2D\x66\x35\x33\x63\x2D\x34\x62'
+            b'\x64\x66\x2D\x61\x64\x30\x61\x2D\x35\x38\x61\x33\x31\x66\x64\x33'
+            b'\x64\x34\x62\x36\x00\x00\x00\x00'
+        )
+
+        self.empty_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestGetUsageAllocationResponsePayload, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a GetUsageAllocation response payload can be constructed
+        with no arguments.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+
+    def test_init_with_args(self):
+        """
+        Test that a GetUsageAllocation response payload can be constructed
+        with valid values.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='00000000-1111-2222-3333-444444444444'
+        )
+
+        self.assertEqual(
+            '00000000-1111-2222-3333-444444444444',
+            payload.unique_identifier
+        )
+
+    def test_invalid_unique_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the unique identifier of a GetUsageAllocation response payload.
+        """
+        kwargs = {'unique_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Unique identifier must be a string.",
+            payloads.GetUsageAllocationResponsePayload,
+            **kwargs
+        )
+
+        payload = payloads.GetUsageAllocationResponsePayload()
+        args = (payload, 'unique_identifier', 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Unique identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a GetUsageAllocation response payload can be read from a
+        data stream.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+
+        payload.read(self.full_encoding)
+
+        self.assertEqual(
+            '2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6',
+            payload.unique_identifier
+        )
+
+    def test_read_empty(self):
+        """
+        Test that a GetUsageAllocation response payload can be read from an
+        empty data stream.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+
+        payload.read(self.empty_encoding)
+
+        self.assertEqual(None, payload.unique_identifier)
+
+    def test_write(self):
+        """
+        Test that a GetUsageAllocation response payload can be written to a
+        data stream.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='2c23217e-f53c-4bdf-ad0a-58a31fd3d4b6'
+        )
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_empty(self):
+        """
+        Test that an empty GetUsageAllocation response payload can be written
+        to a data stream.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload()
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.empty_encoding), len(stream))
+        self.assertEqual(str(self.empty_encoding), str(stream))
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        GetUsageAllocation response payloads with the same data.
+        """
+        a = payloads.GetUsageAllocationResponsePayload()
+        b = payloads.GetUsageAllocationResponsePayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+        b = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        GetUsageAllocation response payloads with different unique identifiers.
+        """
+        a = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='a'
+        )
+        b = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='b'
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        GetUsageAllocation response payloads with different types.
+        """
+        a = payloads.GetUsageAllocationResponsePayload()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        GetUsageAllocation response payloads with the same data.
+        """
+        a = payloads.GetUsageAllocationResponsePayload()
+        b = payloads.GetUsageAllocationResponsePayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+        b = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        GetUsageAllocation response payloads with different unique identifiers.
+        """
+        a = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='a'
+        )
+        b = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='b'
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        GetUsageAllocation response payloads with different types.
+        """
+        a = payloads.GetUsageAllocationResponsePayload()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a GetUsageAllocation response payload.
+        """
+        payload = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+        expected = (
+            "GetUsageAllocationResponsePayload("
+            "unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038')"
+        )
+        observed = repr(payload)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a GetUsageAllocation response payload
+        """
+        payload = payloads.GetUsageAllocationResponsePayload(
+            unique_identifier='49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        )
+
+        expected = str({
+            'unique_identifier': '49a1ca88-6bea-4fb2-b450-7e58802c3038'
+        })
+        observed = str(payload)
+
+        self.assertEqual(expected, observed)


### PR DESCRIPTION
This change adds request and response payloads for the GetUsageAllocation operation. Unit test suites are included for both payloads and both payloads can be imported directly from the payloads package.