### PR TITLE
Drop Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,6 @@ matrix:
           os: linux
           dist: trusty
           env: TOXENV=py27
-        - python: 3.3
-          os: linux
-          dist: precise
-          env: TOXENV=py33
-        - python: 3.3
-          os: linux
-          dist: trusty
-          env: TOXENV=py33
         - python: 3.4
           os: linux
           dist: precise

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,7 +8,7 @@ You can install PyKMIP via ``pip``:
 
 Supported platforms
 -------------------
-PyKMIP is tested on Python 2.7, 3.3, 3.4, 3.5, and 3.6 on the following
+PyKMIP is tested on Python 2.7, 3.4, 3.5, and 3.6 on the following
 operating systems:
 
 * Ubuntu 12.04, 14.04, and 16.04

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 coverage
-pytest<3.3  # TODO (peter-hamilton): Unpin this after Python 3.3 is dropped
+pytest
 flake8
 testtools
 fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py27,py33,py34,py35,py36,bandit,docs
+envlist = pep8,py27,py34,py35,py36,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This change drops Python 3.3 support for PyKMIP. Python 3.3 was released over 5 years ago and has reached end-of-life as of September 19, 2017 with the 3.3.7 release. Library dependencies have begun to drop Python 3.3 support as well.