### PR TITLE
Fix help text for the CreateKeyPair demo

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -373,11 +373,11 @@ CreateKeyPair
 ~~~~~~~~~~~~~
 The CreateKeyPair operation is used to create asymmetric key pairs.
 
-==========  ==========
+==========  ===============
 Algorithm   Key Sizes
-==========  ==========
-RSA         1024, 2048
-==========  ==========
+==========  ===============
+RSA         512, 1024, 2048
+==========  ===============
 
 All users are allowed to create asymmetric keys. There are no quotas currently
 enforced by the server.

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -112,7 +112,7 @@ def build_cli_parser(operation=None):
             type="str",
             default=None,
             dest="algorithm",
-            help="Encryption algorithm for the secret (e.g., AES)")
+            help="Encryption algorithm for the secret (e.g., RSA)")
         parser.add_option(
             "-l",
             "--length",
@@ -120,7 +120,7 @@ def build_cli_parser(operation=None):
             type="int",
             default=None,
             dest="length",
-            help="Key length in bits (e.g., 128, 256)")
+            help="Key length in bits (e.g., 512, 1024, 2048)")
         parser.add_option(
             "-n",
             "--name",


### PR DESCRIPTION
The help message for the CreateKeyPair demo shows an incorrect algorithm (AES) but for asymmetric keys PyKMIP only supports RSA with a minimum length of 512-bits. This change updates the PyKMIP documentation to correct this.

Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>