### PR TITLE
Update the ProtocolVersion implementation

### DIFF
--- a/kmip/core/messages/messages.py
+++ b/kmip/core/messages/messages.py
@@ -157,9 +157,6 @@ class ResponseHeader(Struct):
         ostream.write(tstream.buffer)
 
     def validate(self):
-        if self.protocol_version is not None:
-            # TODO (peter-hamilton) conduct type check
-            self.protocol_version.validate()
         if self.time_stamp is not None:
             # TODO (peter-hamilton) conduct type check
             self.time_stamp.validate()

--- a/kmip/demos/units/discover_versions.py
+++ b/kmip/demos/units/discover_versions.py
@@ -42,8 +42,7 @@ if __name__ == '__main__':
     if opts.protocol_versions is not None:
         for version in re.split(',| ', opts.protocol_versions):
             mm = re.split('\.', version)
-            protocol_versions.append(ProtocolVersion.create(int(mm[0]),
-                                                            int(mm[1])))
+            protocol_versions.append(ProtocolVersion(int(mm[0]), int(mm[1])))
 
     # Build the client and connect to the server
     client = KMIPProxy(config=config)

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -1341,7 +1341,7 @@ class KMIPProxy(KMIP):
         return credential
 
     def _build_request_message(self, credential, batch_items):
-        protocol_version = ProtocolVersion.create(1, 2)
+        protocol_version = ProtocolVersion(1, 2)
 
         if credential is None:
             credential = self._build_credential()

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -105,9 +105,9 @@ class KmipEngine(object):
         self._id_placeholder = None
 
         self._protocol_versions = [
-            contents.ProtocolVersion.create(1, 2),
-            contents.ProtocolVersion.create(1, 1),
-            contents.ProtocolVersion.create(1, 0)
+            contents.ProtocolVersion(1, 2),
+            contents.ProtocolVersion(1, 1),
+            contents.ProtocolVersion(1, 0)
         ]
 
         self._protocol_version = self._protocol_versions[0]
@@ -2001,11 +2001,11 @@ class KmipEngine(object):
                 contents.Operation(enums.Operation.QUERY)
             ])
 
-            if self._protocol_version >= contents.ProtocolVersion.create(1, 1):
+            if self._protocol_version >= contents.ProtocolVersion(1, 1):
                 operations.extend([
                     contents.Operation(enums.Operation.DISCOVER_VERSIONS)
                 ])
-            if self._protocol_version >= contents.ProtocolVersion.create(1, 2):
+            if self._protocol_version >= contents.ProtocolVersion(1, 2):
                 operations.extend([
                     contents.Operation(enums.Operation.ENCRYPT),
                     contents.Operation(enums.Operation.DECRYPT),

--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -157,7 +157,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Name': AttributeRuleSet(
                 False,
@@ -181,7 +181,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Object Type': AttributeRuleSet(
                 True,
@@ -210,7 +210,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Cryptographic Algorithm': AttributeRuleSet(
                 True,
@@ -237,7 +237,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Cryptographic Length': AttributeRuleSet(
                 True,
@@ -264,7 +264,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Cryptographic Parameters': AttributeRuleSet(
                 False,
@@ -286,7 +286,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Cryptographic Domain Parameters': AttributeRuleSet(
                 False,
@@ -304,7 +304,7 @@ class AttributePolicy(object):
                     enums.ObjectType.PRIVATE_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Certificate Type': AttributeRuleSet(
                 True,
@@ -321,7 +321,7 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Certificate Length': AttributeRuleSet(
                 True,
@@ -338,7 +338,7 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'X.509 Certificate Identifier': AttributeRuleSet(
                 True,
@@ -356,7 +356,7 @@ class AttributePolicy(object):
                     # TODO (peterhamilton) Enforce only on X.509 certificates
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'X.509 Certificate Subject': AttributeRuleSet(
                 True,
@@ -374,7 +374,7 @@ class AttributePolicy(object):
                     # TODO (peterhamilton) Enforce only on X.509 certificates
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'X.509 Certificate Issuer': AttributeRuleSet(
                 True,
@@ -392,7 +392,7 @@ class AttributePolicy(object):
                     # TODO (peterhamilton) Enforce only on X.509 certificates
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'Certificate Identifier': AttributeRuleSet(
                 True,
@@ -409,8 +409,8 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 0),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 0),
+                contents.ProtocolVersion(1, 1)
             ),
             'Certificate Subject': AttributeRuleSet(
                 True,
@@ -427,8 +427,8 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 0),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 0),
+                contents.ProtocolVersion(1, 1)
             ),
             'Certificate Issuer': AttributeRuleSet(
                 True,
@@ -445,8 +445,8 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 0),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 0),
+                contents.ProtocolVersion(1, 1)
             ),
             'Digital Signature Algorithm': AttributeRuleSet(
                 True,
@@ -464,7 +464,7 @@ class AttributePolicy(object):
                 (
                     enums.ObjectType.CERTIFICATE,
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'Digest': AttributeRuleSet(
                 True,  # If the server has access to the data
@@ -492,7 +492,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Operation Policy Name': AttributeRuleSet(
                 False,
@@ -521,7 +521,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Cryptographic Usage Mask': AttributeRuleSet(
                 True,
@@ -549,7 +549,7 @@ class AttributePolicy(object):
                     enums.ObjectType.TEMPLATE,
                     enums.ObjectType.SECRET_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Lease Time': AttributeRuleSet(
                 False,
@@ -576,7 +576,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.SECRET_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Usage Limits': AttributeRuleSet(
                 False,
@@ -601,7 +601,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'State': AttributeRuleSet(
                 True,
@@ -631,7 +631,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.SECRET_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Initial Date': AttributeRuleSet(
                 True,
@@ -660,7 +660,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Activation Date': AttributeRuleSet(
                 False,
@@ -689,7 +689,7 @@ class AttributePolicy(object):
                     enums.ObjectType.TEMPLATE,
                     enums.ObjectType.SECRET_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Process Start Date': AttributeRuleSet(
                 False,
@@ -710,7 +710,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Protect Stop Date': AttributeRuleSet(
                 False,
@@ -731,7 +731,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SPLIT_KEY,
                     enums.ObjectType.TEMPLATE
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Deactivation Date': AttributeRuleSet(
                 False,
@@ -760,7 +760,7 @@ class AttributePolicy(object):
                     enums.ObjectType.TEMPLATE,
                     enums.ObjectType.SECRET_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Destroy Date': AttributeRuleSet(
                 False,
@@ -781,7 +781,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Compromise Occurrence Date': AttributeRuleSet(
                 False,
@@ -802,7 +802,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Compromise Date': AttributeRuleSet(
                 False,
@@ -823,7 +823,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Revocation Reason': AttributeRuleSet(
                 False,
@@ -844,7 +844,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Archive Date': AttributeRuleSet(
                 False,
@@ -866,7 +866,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Object Group': AttributeRuleSet(
                 False,
@@ -895,7 +895,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Fresh': AttributeRuleSet(
                 False,
@@ -924,7 +924,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 1)
+                contents.ProtocolVersion(1, 1)
             ),
             'Link': AttributeRuleSet(
                 False,
@@ -951,7 +951,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Application Specific Information': AttributeRuleSet(
                 False,
@@ -975,7 +975,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Contact Information': AttributeRuleSet(
                 False,
@@ -1004,7 +1004,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Last Change Date': AttributeRuleSet(
                 True,
@@ -1042,7 +1042,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
             'Custom Attribute': AttributeRuleSet(
                 False,
@@ -1074,7 +1074,7 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion.create(1, 0)
+                contents.ProtocolVersion(1, 0)
             ),
         }
 

--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -176,7 +176,7 @@ class KmipSession(threading.Thread):
             self._logger.warning("Failure parsing request message.")
             self._logger.exception(e)
             response = self._engine.build_error_response(
-                contents.ProtocolVersion.create(1, 0),
+                contents.ProtocolVersion(1, 0),
                 enums.ResultReason.INVALID_MESSAGE,
                 "Error parsing request message. See server logs for more "
                 "information."

--- a/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
+++ b/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
@@ -30,10 +30,10 @@ class TestDiscoverVersionsRequestPayload(TestCase):
 
         self.protocol_versions_empty = list()
         self.protocol_versions_one = list()
-        self.protocol_versions_one.append(ProtocolVersion.create(1, 0))
+        self.protocol_versions_one.append(ProtocolVersion(1, 0))
         self.protocol_versions_two = list()
-        self.protocol_versions_two.append(ProtocolVersion.create(1, 1))
-        self.protocol_versions_two.append(ProtocolVersion.create(1, 0))
+        self.protocol_versions_two.append(ProtocolVersion(1, 1))
+        self.protocol_versions_two.append(ProtocolVersion(1, 0))
 
         self.encoding_empty = utils.BytearrayStream((
             b'\x42\x00\x79\x01\x00\x00\x00\x00'))
@@ -157,10 +157,10 @@ class TestDiscoverVersionsResponsePayload(TestCase):
 
         self.protocol_versions_empty = list()
         self.protocol_versions_one = list()
-        self.protocol_versions_one.append(ProtocolVersion.create(1, 0))
+        self.protocol_versions_one.append(ProtocolVersion(1, 0))
         self.protocol_versions_two = list()
-        self.protocol_versions_two.append(ProtocolVersion.create(1, 1))
-        self.protocol_versions_two.append(ProtocolVersion.create(1, 0))
+        self.protocol_versions_two.append(ProtocolVersion(1, 1))
+        self.protocol_versions_two.append(ProtocolVersion(1, 0))
 
         self.encoding_empty = utils.BytearrayStream((
             b'\x42\x00\x7C\x01\x00\x00\x00\x00'))

--- a/kmip/tests/unit/core/messages/test_messages.py
+++ b/kmip/tests/unit/core/messages/test_messages.py
@@ -183,25 +183,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -352,7 +352,7 @@ class TestRequestMessage(TestCase):
                                           exp_value, attribute_value.value))
 
     def test_create_request_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         batch_count = contents.BatchCount(1)
         request_header = messages.RequestHeader(protocol_version=prot_ver,
@@ -414,25 +414,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -486,7 +486,7 @@ class TestRequestMessage(TestCase):
         )
 
     def test_get_request_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         batch_count = contents.BatchCount(1)
         req_header = messages.RequestHeader(protocol_version=prot_ver,
@@ -532,25 +532,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -605,7 +605,7 @@ class TestRequestMessage(TestCase):
                          msg.format(exp_value, rcv_value))
 
     def test_destroy_request_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         batch_count = contents.BatchCount(1)
         req_header = messages.RequestHeader(protocol_version=prot_ver,
@@ -651,25 +651,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -775,7 +775,7 @@ class TestRequestMessage(TestCase):
                              msg.format(exp_length, rcv_length))
 
     def test_register_request_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         batch_count = contents.BatchCount(1)
         req_header = messages.RequestHeader(protocol_version=prot_ver,
@@ -867,25 +867,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -1012,25 +1012,25 @@ class TestRequestMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(2, protocol_version_minor.value,
-                         msg.format(2, protocol_version_minor.value))
+        self.assertEqual(2, protocol_version_minor,
+                         msg.format(2, protocol_version_minor))
 
         batch_count = request_header.batch_count
         msg = "Bad batch count type: expected {0}, received {1}"
@@ -1114,7 +1114,7 @@ class TestRequestMessage(TestCase):
         )
 
     def test_mac_request_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 2)
+        prot_ver = contents.ProtocolVersion(1, 2)
 
         batch_count = contents.BatchCount(1)
         req_header = messages.RequestHeader(protocol_version=prot_ver,
@@ -1284,26 +1284,26 @@ class TestResponseMessage(TestCase):
                                               contents.ProtocolVersion,
                                               type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        protocol_version_major = protocol_version.major
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               self.msg.format('protocol version major',
                                               'type', exp_type, rcv_type))
-        self.assertEqual(1, protocol_version_major.value,
+        self.assertEqual(1, protocol_version_major,
                          self.msg.format('protocol version major', 'value',
-                                         1, protocol_version_major.value))
+                                         1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        protocol_version_minor = protocol_version.minor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor,
-                              contents.ProtocolVersion.ProtocolVersionMinor,
+                              int,
                               self.msg.format('protocol version minor',
                                               'type', exp_type, rcv_type))
-        self.assertEqual(1, protocol_version_minor.value,
+        self.assertEqual(1, protocol_version_minor,
                          self.msg.format('protocol version minor', 'value',
-                                         1, protocol_version_minor.value))
+                                         1, protocol_version_minor))
 
         time_stamp = response_header.time_stamp
         value = 0x4f9a54e5  # Fri Apr 27 10:12:21 CEST 2012
@@ -1383,7 +1383,7 @@ class TestResponseMessage(TestCase):
                                              unique_identifier.value, value))
 
     def test_create_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Fri Apr 27 10:12:21 CEST 2012
         time_stamp = contents.TimeStamp(0x4f9a54e5)
@@ -1436,25 +1436,25 @@ class TestResponseMessage(TestCase):
                                               contents.ProtocolVersion,
                                               type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        protocol_version_major = protocol_version.major
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               self.msg.format('protocol version major', 'type',
                                               exp_type, rcv_type))
-        self.assertEqual(1, protocol_version_major.value,
+        self.assertEqual(1, protocol_version_major,
                          self.msg.format('protocol version major', 'value',
-                                         1, protocol_version_major.value))
+                                         1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        protocol_version_minor = protocol_version.minor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               self.msg.format('protocol version minor', 'type',
                                               exp_type, rcv_type))
-        self.assertEqual(1, protocol_version_minor.value,
+        self.assertEqual(1, protocol_version_minor,
                          self.msg.format('protocol version minor', 'value',
-                                         1, protocol_version_minor.value))
+                                         1, protocol_version_minor))
 
         time_stamp = response_header.time_stamp
         value = 0x4f9a54e7  # Fri Apr 27 10:12:23 CEST 2012
@@ -1584,7 +1584,7 @@ class TestResponseMessage(TestCase):
                                                        'value', exp, obs))
 
     def test_get_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Fri Apr 27 10:12:23 CEST 2012
         time_stamp = contents.TimeStamp(0x4f9a54e7)
@@ -1665,25 +1665,25 @@ class TestResponseMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         time_stamp = response_header.time_stamp
         value = 0x4f9a54e5  # Fri Apr 27 10:12:21 CEST 2012
@@ -1758,7 +1758,7 @@ class TestResponseMessage(TestCase):
                              msg.format(exp_value, rcv_value))
 
     def test_destroy_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Fri Apr 27 10:12:21 CEST 2012
         time_stamp = contents.TimeStamp(0x4f9a54e5)
@@ -1808,25 +1808,25 @@ class TestResponseMessage(TestCase):
                               msg.format(contents.ProtocolVersion,
                                          type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
+        protocol_version_major = protocol_version.major
         msg = "Bad protocol version major type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version major value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_major.value,
-                         msg.format(1, protocol_version_major.value))
+        self.assertEqual(1, protocol_version_major,
+                         msg.format(1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
+        protocol_version_minor = protocol_version.minor
         msg = "Bad protocol version minor type: expected {0}, received {1}"
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               msg.format(exp_type, rcv_type))
         msg = "Bad protocol version minor value: expected {0}, received {1}"
-        self.assertEqual(1, protocol_version_minor.value,
-                         msg.format(1, protocol_version_minor.value))
+        self.assertEqual(1, protocol_version_minor,
+                         msg.format(1, protocol_version_minor))
 
         time_stamp = response_header.time_stamp
         value = 0x4f9a54e5  # Fri Apr 27 10:12:21 CEST 2012
@@ -1901,7 +1901,7 @@ class TestResponseMessage(TestCase):
                              msg.format(exp_value, rcv_value))
 
     def test_register_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Fri Apr 27 10:12:21 CEST 2012
         time_stamp = contents.TimeStamp(0x4f9a54e5)
@@ -1934,7 +1934,7 @@ class TestResponseMessage(TestCase):
         self.assertEqual(self.register, result, msg)
 
     def test_locate_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Fri Apr 27 10:12:22 CEST 2012
         time_stamp = contents.TimeStamp(0x4f9a54e6)
@@ -1985,25 +1985,25 @@ class TestResponseMessage(TestCase):
                                               contents.ProtocolVersion,
                                               type(protocol_version)))
 
-        protocol_version_major = protocol_version.protocol_version_major
-        exp_type = contents.ProtocolVersion.ProtocolVersionMajor
+        protocol_version_major = protocol_version.major
+        exp_type = int
         rcv_type = type(protocol_version_major)
         self.assertIsInstance(protocol_version_major, exp_type,
                               self.msg.format('protocol version major', 'type',
                                               exp_type, rcv_type))
-        self.assertEqual(1, protocol_version_major.value,
+        self.assertEqual(1, protocol_version_major,
                          self.msg.format('protocol version major', 'value',
-                                         1, protocol_version_major.value))
+                                         1, protocol_version_major))
 
-        protocol_version_minor = protocol_version.protocol_version_minor
-        exp_type = contents.ProtocolVersion.ProtocolVersionMinor
+        protocol_version_minor = protocol_version.minor
+        exp_type = int
         rcv_type = type(protocol_version_minor)
         self.assertIsInstance(protocol_version_minor, exp_type,
                               self.msg.format('protocol version minor', 'type',
                                               exp_type, rcv_type))
-        self.assertEqual(2, protocol_version_minor.value,
+        self.assertEqual(2, protocol_version_minor,
                          self.msg.format('protocol version minor', 'value',
-                                         2, protocol_version_minor.value))
+                                         2, protocol_version_minor))
 
         time_stamp = response_header.time_stamp
         value = 0x588a3f23
@@ -2092,7 +2092,7 @@ class TestResponseMessage(TestCase):
                                              binascii.hexlify(value)))
 
     def test_mac_response_write(self):
-        prot_ver = contents.ProtocolVersion.create(1, 2)
+        prot_ver = contents.ProtocolVersion(1, 2)
 
         # Fri Apr 27 10:12:23 CEST 2012
         time_stamp = contents.TimeStamp(0x588a3f23)
@@ -2142,7 +2142,7 @@ class TestResponseMessage(TestCase):
     def test_message_invalid_response_write(self):
         # Batch item of 'INVALID MESSAGE' response
         # has no 'operation' attribute
-        prot_ver = contents.ProtocolVersion.create(1, 1)
+        prot_ver = contents.ProtocolVersion(1, 1)
 
         # Time stamp Tue Mar 29 10:58:37 2016
         time_stamp = contents.TimeStamp(0x56fa43bd)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -89,7 +89,7 @@ class TestKmipEngine(testtools.TestCase):
             )
         ]
 
-        protocol = contents.ProtocolVersion.create(1, 0)
+        protocol = contents.ProtocolVersion(1, 0)
         max_size = contents.MaximumResponseSize(2 ** 20)
         asynch = contents.AsynchronousIndicator(False)
 
@@ -339,7 +339,7 @@ class TestKmipEngine(testtools.TestCase):
         """
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 0)
+        e._protocol_version = contents.ProtocolVersion(1, 0)
 
         args = (None, )
         regex = "DiscoverVersions is not supported by KMIP {0}".format(
@@ -360,7 +360,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 1)
+        protocol = contents.ProtocolVersion(1, 1)
         header = messages.RequestHeader(
             protocol_version=protocol,
             maximum_response_size=contents.MaximumResponseSize(2 ** 20),
@@ -402,7 +402,7 @@ class TestKmipEngine(testtools.TestCase):
 
         self.assertIsNotNone(header)
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 1),
+            contents.ProtocolVersion(1, 1),
             header.protocol_version
         )
         self.assertIsInstance(header.time_stamp, contents.TimeStamp)
@@ -442,7 +442,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(0, 1)
+        protocol = contents.ProtocolVersion(0, 1)
         header = messages.RequestHeader(
             protocol_version=protocol
         )
@@ -470,7 +470,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 0)
+        protocol = contents.ProtocolVersion(1, 0)
         header = messages.RequestHeader(
             protocol_version=protocol,
             time_stamp=contents.TimeStamp(0)
@@ -503,7 +503,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 0)
+        protocol = contents.ProtocolVersion(1, 0)
         header = messages.RequestHeader(
             protocol_version=protocol,
             time_stamp=contents.TimeStamp(10 ** 10)
@@ -536,7 +536,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 1)
+        protocol = contents.ProtocolVersion(1, 1)
         header = messages.RequestHeader(
             protocol_version=protocol,
             asynchronous_indicator=contents.AsynchronousIndicator(True)
@@ -563,7 +563,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 1)
+        protocol = contents.ProtocolVersion(1, 1)
         header = messages.RequestHeader(
             protocol_version=protocol,
             authentication=contents.Authentication(),
@@ -593,7 +593,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
 
-        protocol = contents.ProtocolVersion.create(1, 1)
+        protocol = contents.ProtocolVersion(1, 1)
         header = messages.RequestHeader(
             protocol_version=protocol,
             authentication=None,
@@ -629,7 +629,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
 
         response = e.build_error_response(
-            contents.ProtocolVersion.create(1, 1),
+            contents.ProtocolVersion(1, 1),
             enums.ResultReason.GENERAL_FAILURE,
             "A general test failure occurred."
         )
@@ -639,7 +639,7 @@ class TestKmipEngine(testtools.TestCase):
         header = response.response_header
 
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 1),
+            contents.ProtocolVersion(1, 1),
             header.protocol_version
         )
         self.assertIsNotNone(header.time_stamp)
@@ -760,7 +760,7 @@ class TestKmipEngine(testtools.TestCase):
         """
         e = engine.KmipEngine()
         e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 0)
+        e._protocol_version = contents.ProtocolVersion(1, 0)
 
         batch = list([
             messages.RequestBatchItem(
@@ -6515,7 +6515,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
 
         e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 0)
+        e._protocol_version = contents.ProtocolVersion(1, 0)
 
         payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
@@ -6601,7 +6601,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
 
         e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 1)
+        e._protocol_version = contents.ProtocolVersion(1, 1)
 
         payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
@@ -6691,7 +6691,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
 
         e._logger = mock.MagicMock()
-        e._protocol_version = contents.ProtocolVersion.create(1, 2)
+        e._protocol_version = contents.ProtocolVersion(1, 2)
 
         payload = payloads.QueryRequestPayload([
             misc.QueryFunction(enums.QueryFunction.QUERY_OPERATIONS),
@@ -6817,22 +6817,22 @@ class TestKmipEngine(testtools.TestCase):
         self.assertIsNotNone(result.protocol_versions)
         self.assertEqual(3, len(result.protocol_versions))
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 2),
+            contents.ProtocolVersion(1, 2),
             result.protocol_versions[0]
         )
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 1),
+            contents.ProtocolVersion(1, 1),
             result.protocol_versions[1]
         )
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 0),
+            contents.ProtocolVersion(1, 0),
             result.protocol_versions[2]
         )
 
         # Test detailed request.
         e._logger = mock.MagicMock()
         payload = payloads.DiscoverVersionsRequestPayload([
-            contents.ProtocolVersion.create(1, 0)
+            contents.ProtocolVersion(1, 0)
         ])
 
         result = e._process_discover_versions(payload)
@@ -6843,14 +6843,14 @@ class TestKmipEngine(testtools.TestCase):
         self.assertIsNotNone(result.protocol_versions)
         self.assertEqual(1, len(result.protocol_versions))
         self.assertEqual(
-            contents.ProtocolVersion.create(1, 0),
+            contents.ProtocolVersion(1, 0),
             result.protocol_versions[0]
         )
 
         # Test disjoint request.
         e._logger = mock.MagicMock()
         payload = payloads.DiscoverVersionsRequestPayload([
-            contents.ProtocolVersion.create(0, 1)
+            contents.ProtocolVersion(0, 1)
         ])
 
         result = e._process_discover_versions(payload)

--- a/kmip/tests/unit/services/server/test_policy.py
+++ b/kmip/tests/unit/services/server/test_policy.py
@@ -35,14 +35,14 @@ class TestAttributePolicy(testtools.TestCase):
         """
         Test that an AttributePolicy can be built without any errors.
         """
-        policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        policy.AttributePolicy(contents.ProtocolVersion(1, 0))
 
     def test_is_attribute_supported(self):
         """
         Test that is_attribute_supported returns the expected results in all
         cases.
         """
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
         attribute_a = 'Unique Identifier'
         attribute_b = 'Certificate Length'
         attribute_c = 'invalid'
@@ -61,7 +61,7 @@ class TestAttributePolicy(testtools.TestCase):
         Test that is_attribute_deprecated returns the expected results in all
         cases.
         """
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
         attribute_a = 'Name'
         attribute_b = 'Certificate Subject'
 
@@ -71,7 +71,7 @@ class TestAttributePolicy(testtools.TestCase):
         result = rules.is_attribute_deprecated(attribute_b)
         self.assertFalse(result)
 
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 1))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 1))
 
         result = rules.is_attribute_deprecated(attribute_b)
         self.assertTrue(result)
@@ -81,7 +81,7 @@ class TestAttributePolicy(testtools.TestCase):
         Test that is_attribute_applicable_to_object_type returns the
         expected results in all cases.
         """
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
         attribute = 'Cryptographic Algorithm'
         object_type_a = enums.ObjectType.SYMMETRIC_KEY
         object_type_b = enums.ObjectType.OPAQUE_DATA
@@ -103,7 +103,7 @@ class TestAttributePolicy(testtools.TestCase):
         Test that is_attribute_multivalued returns the expected results in
         all cases.
         """
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
         attribute_a = 'Object Type'
         attribute_b = 'Link'
 
@@ -118,7 +118,7 @@ class TestAttributePolicy(testtools.TestCase):
         Test that get_all_attribute_names returns a complete list of the
         names of all spec-defined attributes.
         """
-        rules = policy.AttributePolicy(contents.ProtocolVersion.create(1, 0))
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
         attribute_names = [
             'Unique Identifier',
             'Name',

--- a/kmip/tests/unit/services/server/test_session.py
+++ b/kmip/tests/unit/services/server/test_session.py
@@ -345,7 +345,7 @@ class TestKmipSession(testtools.TestCase):
         )
         batch_items = [batch_item]
         header = messages.ResponseHeader(
-            protocol_version=contents.ProtocolVersion.create(1, 0),
+            protocol_version=contents.ProtocolVersion(1, 0),
             time_stamp=contents.TimeStamp(int(time.time())),
             batch_count=contents.BatchCount(len(batch_items))
         )

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -385,7 +385,7 @@ class TestKMIPClient(TestCase):
         self.assertEqual(protocol_versions, observed, msg)
 
     def test_build_discover_versions_batch_item_with_input(self):
-        protocol_versions = [ProtocolVersion.create(1, 0)]
+        protocol_versions = [ProtocolVersion(1, 0)]
         self._test_build_discover_versions_batch_item(protocol_versions)
 
     def test_build_discover_versions_batch_item_no_input(self):
@@ -612,7 +612,7 @@ class TestKMIPClient(TestCase):
         self.assertEqual(protocol_versions, result.protocol_versions, msg)
 
     def test_process_discover_versions_batch_item_with_results(self):
-        protocol_versions = [ProtocolVersion.create(1, 0)]
+        protocol_versions = [ProtocolVersion(1, 0)]
         self._test_process_discover_versions_batch_item(protocol_versions)
 
     def test_process_discover_versions_batch_item_no_results(self):


### PR DESCRIPTION
This change updates the implementation of the ProtocolVersion struct, bringing it inline with the current struct style. All uses of the struct have been updated to reflect these changes, as have the struct unit tests.