### PR TITLE
Update the Credential objects

### DIFF
--- a/kmip/core/factories/credentials.py
+++ b/kmip/core/factories/credentials.py
@@ -13,43 +13,41 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core.enums import CredentialType
-
-from kmip.core.objects import Credential
+from kmip.core import enums
+from kmip.core import objects
 
 
 class CredentialFactory(object):
-    def __init__(self):
-        pass
 
-    def _create_credential(self, credential_type, credential_value):
-        credential_type = Credential.CredentialType(credential_type)
-        return Credential(credential_type=credential_type,
-                          credential_value=credential_value)
-
-    def create_credential(self, cred_type, value):
+    def create_credential(self, credential_type, credential_value):
         # Switch on the type of the credential
-        if cred_type is CredentialType.USERNAME_AND_PASSWORD:
-            value = self._create_username_password_credential(value)
-        elif cred_type is CredentialType.DEVICE:
-            value = self._create_device_credential(value)
+        if credential_type is enums.CredentialType.USERNAME_AND_PASSWORD:
+            credential_value = self.create_username_password_credential(
+                credential_value
+            )
+        elif credential_type is enums.CredentialType.DEVICE:
+            credential_value = self.create_device_credential(credential_value)
         else:
             msg = 'Unrecognized credential type: {0}'
-            raise ValueError(msg.format(cred_type))
+            raise ValueError(msg.format(credential_type))
 
-        return self._create_credential(cred_type, value)
+        return objects.Credential(
+            credential_type=credential_type,
+            credential_value=credential_value
+        )
 
-    def _create_username_password_credential(self, value):
+    @staticmethod
+    def create_username_password_credential(value):
         username = value.get('Username')
         password = value.get('Password')
 
-        username = Credential.UsernamePasswordCredential.Username(username)
-        password = Credential.UsernamePasswordCredential.Password(password)
+        return objects.UsernamePasswordCredential(
+            username=username,
+            password=password
+        )
 
-        return Credential.UsernamePasswordCredential(username=username,
-                                                     password=password)
-
-    def _create_device_credential(self, value):
+    @staticmethod
+    def create_device_credential(value):
         dsn = value.get('Device Serial Number')
         password = value.get('Password')
         dev_id = value.get('Device Identifier')
@@ -57,16 +55,11 @@ class CredentialFactory(object):
         mach_id = value.get('Machine Identifier')
         med_id = value.get('Media Identifier')
 
-        dsn = Credential.DeviceCredential.DeviceSerialNumber(dsn)
-        password = Credential.DeviceCredential.Password(password)
-        dev_id = Credential.DeviceCredential.DeviceIdentifier(dev_id)
-        net_id = Credential.DeviceCredential.NetworkIdentifier(net_id)
-        mach_id = Credential.DeviceCredential.MachineIdentifier(mach_id)
-        med_id = Credential.DeviceCredential.MediaIdentifier(med_id)
-
-        return Credential.DeviceCredential(device_serial_number=dsn,
-                                           password=password,
-                                           device_identifier=dev_id,
-                                           network_identifier=net_id,
-                                           machine_identifier=mach_id,
-                                           media_identifier=med_id)
+        return objects.DeviceCredential(
+            device_serial_number=dsn,
+            password=password,
+            device_identifier=dev_id,
+            network_identifier=net_id,
+            machine_identifier=mach_id,
+            media_identifier=med_id
+        )

--- a/kmip/tests/unit/core/objects/test_credentials.py
+++ b/kmip/tests/unit/core/objects/test_credentials.py
@@ -1,0 +1,1991 @@
+# Copyright (c) 2018 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from kmip import enums
+from kmip.core import objects
+from kmip.core import utils
+
+
+class TestUsernamePasswordCredential(testtools.TestCase):
+    """
+    Test suite for the UsernamePasswordCredential struct.
+    """
+
+    def setUp(self):
+        super(TestUsernamePasswordCredential, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 11.1.
+        #
+        # This encoding matches the following set of values:
+        # UsernamePasswordCredential
+        #     Username - Fred
+        #     Password - password1
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x28'
+            b'\x42\x00\x99\x07\x00\x00\x00\x04'
+            b'\x46\x72\x65\x64\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x09'
+            b'\x70\x61\x73\x73\x77\x6F\x72\x64\x31\x00\x00\x00\x00\x00\x00\x00'
+        )
+
+        self.encoding_missing_username = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x18'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x09'
+            b'\x70\x61\x73\x73\x77\x6F\x72\x64\x31\x00\x00\x00\x00\x00\x00\x00'
+        )
+
+        self.encoding_missing_password = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x10'
+            b'\x42\x00\x99\x07\x00\x00\x00\x04'
+            b'\x46\x72\x65\x64\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestUsernamePasswordCredential, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a UsernamePasswordCredential struct can be constructed
+        without arguments.
+        """
+        credential = objects.UsernamePasswordCredential()
+
+        self.assertEqual(None, credential.username)
+        self.assertEqual(None, credential.password)
+
+    def test_init_with_args(self):
+        """
+        Test that a UsernamePasswordCredential struct can be constructed with
+        arguments.
+        """
+        credential = objects.UsernamePasswordCredential(
+            username="John",
+            password="abc123"
+        )
+
+        self.assertEqual("John", credential.username)
+        self.assertEqual("abc123", credential.password)
+
+    def test_invalid_username(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the username of a UsernamePasswordCredential struct.
+        """
+        kwargs = {'username': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Username must be a string.",
+            objects.UsernamePasswordCredential,
+            **kwargs
+        )
+
+        credential = objects.UsernamePasswordCredential()
+        args = (credential, "username", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Username must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_password(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the password of a UsernamePasswordCredential struct.
+        """
+        kwargs = {'password': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Password must be a string.",
+            objects.UsernamePasswordCredential,
+            **kwargs
+        )
+
+        credential = objects.UsernamePasswordCredential()
+        args = (credential, "password", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Password must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a UsernamePasswordCredential struct can be read from a data
+        stream.
+        """
+        credential = objects.UsernamePasswordCredential()
+
+        self.assertEqual(None, credential.username)
+        self.assertEqual(None, credential.password)
+
+        credential.read(self.full_encoding)
+
+        self.assertEqual("Fred", credential.username)
+        self.assertEqual("password1", credential.password)
+
+    def test_read_missing_username(self):
+        """
+        Test that a ValueError gets raised when attempting to read a
+        UsernamePasswordCredential struct from a data stream missing the
+        username data.
+        """
+        credential = objects.UsernamePasswordCredential()
+
+        self.assertEqual(None, credential.username)
+        self.assertEqual(None, credential.password)
+
+        args = (self.encoding_missing_username, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Username/password credential encoding missing the username.",
+            credential.read,
+            *args
+        )
+
+    def test_read_missing_password(self):
+        """
+        Test that a UsernamePasswordCredential struct can be read from a data
+        stream missing the password data.
+        """
+        credential = objects.UsernamePasswordCredential()
+
+        self.assertEqual(None, credential.username)
+        self.assertEqual(None, credential.password)
+
+        credential.read(self.encoding_missing_password)
+
+        self.assertEqual("Fred", credential.username)
+        self.assertEqual(None, credential.password)
+
+    def test_write(self):
+        """
+        Test that a UsernamePasswordCredential struct can be written to a
+        data stream.
+        """
+        credential = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_missing_username(self):
+        """
+        Test that a ValueError gets raised when attempting to write a
+        UsernamePasswordCredential struct missing username data to a data
+        stream.
+        """
+        credential = objects.UsernamePasswordCredential(
+            password="password1"
+        )
+        stream = utils.BytearrayStream()
+
+        args = (stream, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Username/password credential struct missing the username.",
+            credential.write,
+            *args
+        )
+
+    def test_write_missing_password(self):
+        """
+        Test that a UsernamePasswordCredential struct missing password data
+        can be written to a data stream.
+        """
+        credential = objects.UsernamePasswordCredential(
+            username="Fred"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.encoding_missing_password), len(stream))
+        self.assertEqual(str(self.encoding_missing_password), str(stream))
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        UsernamePasswordCredential structs with the same data.
+        """
+        a = objects.UsernamePasswordCredential()
+        b = objects.UsernamePasswordCredential()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_username(self):
+        """
+        Test that the equality operator returns False when comparing two
+        UsernamePasswordCredential structs with different usernames.
+        """
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Wilma",
+            password="password1"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_password(self):
+        """
+        Test that the equality operator returns False when comparing two
+        UsernamePasswordCredential structs with different passwords.
+        """
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="1password"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        UsernamePasswordCredential structs with different types.
+        """
+        a = objects.UsernamePasswordCredential()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        UsernamePasswordCredential structs with the same data.
+        """
+        a = objects.UsernamePasswordCredential()
+        b = objects.UsernamePasswordCredential()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_username(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        UsernamePasswordCredential structs with different usernames.
+        """
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Wilma",
+            password="password1"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_password(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        UsernamePasswordCredential structs with different passwords.
+        """
+        a = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        b = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="1password"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        UsernamePasswordCredential structs with different types.
+        """
+        a = objects.UsernamePasswordCredential()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a UsernamePasswordCredential struct.
+        """
+        credential = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        expected = (
+            "UsernamePasswordCredential("
+            "username='Fred', "
+            "password='password1')"
+        )
+        observed = repr(credential)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a UsernamePasswordCredential struct.
+        """
+        credential = objects.UsernamePasswordCredential(
+            username="Fred",
+            password="password1"
+        )
+        expected = str({"username": "Fred", "password": "password1"})
+        observed = str(credential)
+
+        self.assertEqual(expected, observed)
+
+
+class TestDeviceCredential(testtools.TestCase):
+    """
+    Test suite for the DeviceCredential struct.
+    """
+
+    def setUp(self):
+        super(TestDeviceCredential, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 11.2.
+        #
+        # This encoding matches the following set of values:
+        # DeviceCredential
+        #     Device Serial Number - serNum123456
+        #     Password - secret
+        #     Device Identifier - devID2233
+        #     Network Identifier - netID9000
+        #     Machine Identifier - machineID1
+        #     Media Identifier - mediaID313
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x88'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_device_serial_number = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x70'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_password = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x78'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_device_identifier = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x70'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_network_identifier = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x70'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_machine_identifier = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x70'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_media_identifier = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x70'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+        )
+        self.empty_encoding = utils.BytearrayStream(
+            b'\x42\x00\x25\x01\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestDeviceCredential, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a DeviceCredential struct can be constructed without
+        arguments.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+    def test_init_with_args(self):
+        """
+        Test that a DeviceCredential struct can be constructed with arguments.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_invalid_device_serial_number(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the device serial number of a DeviceCredential struct.
+        """
+        kwargs = {'device_serial_number': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Device serial number must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "device_serial_number", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Device serial number must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_password(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the password of a DeviceCredential struct.
+        """
+        kwargs = {'password': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Password must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "password", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Password must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_device_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the device identifier of a DeviceCredential struct.
+        """
+        kwargs = {'device_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Device identifier must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "device_identifier", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Device identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_network_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the network identifier of a DeviceCredential struct.
+        """
+        kwargs = {'network_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Network identifier must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "network_identifier", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Network identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_machine_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the machine identifier of a DeviceCredential struct.
+        """
+        kwargs = {'machine_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Machine identifier must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "machine_identifier", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Machine identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_media_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the media identifier of a DeviceCredential struct.
+        """
+        kwargs = {'media_identifier': 0}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Media identifier must be a string.",
+            objects.DeviceCredential,
+            **kwargs
+        )
+
+        credential = objects.DeviceCredential()
+        args = (credential, "media_identifier", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Media identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.full_encoding)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_device_serial_number(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the device serial number data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_device_serial_number)
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_password(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the password data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_password)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_device_identifier(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the device identifier data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_device_identifier)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_network_identifier(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the network identifier data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_network_identifier)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_machine_identifier(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the machine identifier data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_machine_identifier)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual("mediaID313", credential.media_identifier)
+
+    def test_read_missing_media_identifier(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing the media identifier data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.encoding_missing_media_identifier)
+
+        self.assertEqual("serNum123456", credential.device_serial_number)
+        self.assertEqual("secret", credential.password)
+        self.assertEqual("devID2233", credential.device_identifier)
+        self.assertEqual("netID9000", credential.network_identifier)
+        self.assertEqual("machineID1", credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+    def test_read_missing_everything(self):
+        """
+        Test that a DeviceCredential struct can be read from a data stream
+        missing all data.
+        """
+        credential = objects.DeviceCredential()
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+        credential.read(self.empty_encoding)
+
+        self.assertEqual(None, credential.device_serial_number)
+        self.assertEqual(None, credential.password)
+        self.assertEqual(None, credential.device_identifier)
+        self.assertEqual(None, credential.network_identifier)
+        self.assertEqual(None, credential.machine_identifier)
+        self.assertEqual(None, credential.media_identifier)
+
+    def test_write(self):
+        """
+        Test that a DeviceCredential struct can be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_missing_device_serial_number(self):
+        """
+        Test that a DeviceCredential struct missing device serial number data
+        can be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(
+            len(self.encoding_missing_device_serial_number),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_missing_device_serial_number),
+            str(stream)
+        )
+
+    def test_write_missing_password(self):
+        """
+        Test that a DeviceCredential struct missing password data can be
+        written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.encoding_missing_password), len(stream))
+        self.assertEqual(str(self.encoding_missing_password), str(stream))
+
+    def test_write_missing_device_identifier(self):
+        """
+        Test that a DeviceCredential struct missing device identifier data can
+        be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(
+            len(self.encoding_missing_device_identifier),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_missing_device_identifier),
+            str(stream)
+        )
+
+    def test_write_missing_network_identifier(self):
+        """
+        Test that a DeviceCredential struct missing network identifier data
+        can be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(
+            len(self.encoding_missing_network_identifier),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_missing_network_identifier),
+            str(stream)
+        )
+
+    def test_write_missing_machine_identifier(self):
+        """
+        Test that a DeviceCredential struct missing machine identifier data
+        can be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            media_identifier="mediaID313"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(
+            len(self.encoding_missing_machine_identifier),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_missing_machine_identifier),
+            str(stream)
+        )
+
+    def test_write_missing_media_identifier(self):
+        """
+        Test that a DeviceCredential struct missing media identifier data can
+        be written to a data stream.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1"
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(
+            len(self.encoding_missing_media_identifier),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.encoding_missing_media_identifier),
+            str(stream)
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        DeviceCredential structs with the same data.
+        """
+        a = objects.DeviceCredential()
+        b = objects.DeviceCredential()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        b = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_device_serial_number(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different device serial numbers.
+        """
+        a = objects.DeviceCredential(
+            device_serial_number="serNum123456"
+        )
+        b = objects.DeviceCredential(
+            device_serial_number="serNum654321"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_password(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different passwords.
+        """
+        a = objects.DeviceCredential(
+            password="secret"
+        )
+        b = objects.DeviceCredential(
+            password="public"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_device_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different device identifiers.
+        """
+        a = objects.DeviceCredential(
+            device_identifier="devID2233"
+        )
+        b = objects.DeviceCredential(
+            device_identifier="devID0011"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_network_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different network identifiers.
+        """
+        a = objects.DeviceCredential(
+            network_identifier="netID9000"
+        )
+        b = objects.DeviceCredential(
+            network_identifier="netID0999"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_machine_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different machine identifiers.
+        """
+        a = objects.DeviceCredential(
+            machine_identifier="machineID1"
+        )
+        b = objects.DeviceCredential(
+            machine_identifier="machineID2"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_media_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different media identifiers.
+        """
+        a = objects.DeviceCredential(
+            media_identifier="mediaID313"
+        )
+        b = objects.DeviceCredential(
+            media_identifier="mediaID828"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        DeviceCredential structs with different types.
+        """
+        a = objects.DeviceCredential()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        DeviceCredential structs with the same data.
+        """
+        a = objects.DeviceCredential()
+        b = objects.DeviceCredential()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        b = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_device_serial_number(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different device serial numbers.
+        """
+        a = objects.DeviceCredential(
+            device_serial_number="serNum123456"
+        )
+        b = objects.DeviceCredential(
+            device_serial_number="serNum654321"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_password(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different passwords.
+        """
+        a = objects.DeviceCredential(
+            password="secret"
+        )
+        b = objects.DeviceCredential(
+            password="public"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_device_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different device identifiers.
+        """
+        a = objects.DeviceCredential(
+            device_identifier="devID2233"
+        )
+        b = objects.DeviceCredential(
+            device_identifier="devID0011"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_network_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different network identifiers.
+        """
+        a = objects.DeviceCredential(
+            network_identifier="netID9000"
+        )
+        b = objects.DeviceCredential(
+            network_identifier="netID0999"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_machine_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different machine identifiers.
+        """
+        a = objects.DeviceCredential(
+            machine_identifier="machineID1"
+        )
+        b = objects.DeviceCredential(
+            machine_identifier="machineID2"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_media_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different media identifiers.
+        """
+        a = objects.DeviceCredential(
+            media_identifier="mediaID313"
+        )
+        b = objects.DeviceCredential(
+            media_identifier="mediaID828"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        DeviceCredential structs with different types.
+        """
+        a = objects.DeviceCredential()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a DeviceCredential struct.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        expected = (
+            "DeviceCredential("
+            "device_serial_number='serNum123456', "
+            "password='secret', "
+            "device_identifier='devID2233', "
+            "network_identifier='netID9000', "
+            "machine_identifier='machineID1', "
+            "media_identifier='mediaID313')"
+        )
+        observed = repr(credential)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a DeviceCredential struct.
+        """
+        credential = objects.DeviceCredential(
+            device_serial_number="serNum123456",
+            password="secret",
+            device_identifier="devID2233",
+            network_identifier="netID9000",
+            machine_identifier="machineID1",
+            media_identifier="mediaID313"
+        )
+        expected = str(
+            {
+                "device_serial_number": "serNum123456",
+                "password": "secret",
+                "device_identifier": "devID2233",
+                "network_identifier": "netID9000",
+                "machine_identifier": "machineID1",
+                "media_identifier": "mediaID313"
+            }
+        )
+        observed = str(credential)
+
+        self.assertEqual(expected, observed)
+
+
+class TestCredential(testtools.TestCase):
+    """
+    Test suite for the Credential struct.
+    """
+
+    def setUp(self):
+        super(TestCredential, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 11.1.
+        #
+        # This encoding matches the following set of values:
+        # Credential
+        #     CredentialType - Username and Password
+        #     CredentialValue
+        #         Username - Fred
+        #         Password - password1
+        self.username_password_encoding = utils.BytearrayStream(
+            b'\x42\x00\x23\x01\x00\x00\x00\x40'
+            b'\x42\x00\x24\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x25\x01\x00\x00\x00\x28'
+            b'\x42\x00\x99\x07\x00\x00\x00\x04'
+            b'\x46\x72\x65\x64\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x09'
+            b'\x70\x61\x73\x73\x77\x6F\x72\x64\x31\x00\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_credential_type = utils.BytearrayStream(
+            b'\x42\x00\x23\x01\x00\x00\x00\x30'
+            b'\x42\x00\x25\x01\x00\x00\x00\x28'
+            b'\x42\x00\x99\x07\x00\x00\x00\x04'
+            b'\x46\x72\x65\x64\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x09'
+            b'\x70\x61\x73\x73\x77\x6F\x72\x64\x31\x00\x00\x00\x00\x00\x00\x00'
+        )
+        self.encoding_missing_credential_value = utils.BytearrayStream(
+            b'\x42\x00\x23\x01\x00\x00\x00\x10'
+            b'\x42\x00\x24\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+        self.encoding_unknown_credential_type = utils.BytearrayStream(
+            b'\x42\x00\x23\x01\x00\x00\x00\x40'
+            b'\x42\x00\x24\x05\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\x25\x01\x00\x00\x00\x28'
+            b'\x42\x00\x99\x07\x00\x00\x00\x04'
+            b'\x46\x72\x65\x64\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x09'
+            b'\x70\x61\x73\x73\x77\x6F\x72\x64\x31\x00\x00\x00\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 11.2.
+        #
+        # This encoding matches the following set of values:
+        # Credential
+        #     CredentialType - Device
+        #     CredentialValue
+        #         Device Serial Number - serNum123456
+        #         Password - secret
+        #         Device Identifier - devID2233
+        #         Network Identifier - netID9000
+        #         Machine Identifier - machineID1
+        #         Media Identifier - mediaID313
+        self.device_encoding = utils.BytearrayStream(
+            b'\x42\x00\x23\x01\x00\x00\x00\xA0'
+            b'\x42\x00\x24\x05\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x00'
+            b'\x42\x00\x25\x01\x00\x00\x00\x88'
+            b'\x42\x00\xB0\x07\x00\x00\x00\x0C'
+            b'\x73\x65\x72\x4E\x75\x6D\x31\x32\x33\x34\x35\x36\x00\x00\x00\x00'
+            b'\x42\x00\xA1\x07\x00\x00\x00\x06'
+            b'\x73\x65\x63\x72\x65\x74\x00\x00'
+            b'\x42\x00\xA2\x07\x00\x00\x00\x09'
+            b'\x64\x65\x76\x49\x44\x32\x32\x33\x33\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAB\x07\x00\x00\x00\x09'
+            b'\x6E\x65\x74\x49\x44\x39\x30\x30\x30\x00\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xA9\x07\x00\x00\x00\x0A'
+            b'\x6D\x61\x63\x68\x69\x6E\x65\x49\x44\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\xAA\x07\x00\x00\x00\x0A'
+            b'\x6D\x65\x64\x69\x61\x49\x44\x33\x31\x33\x00\x00\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestCredential, self).tearDown()
+
+    def test_init(self):
+        """
+        Test that a Credential struct can be constructed without arguments.
+        """
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+    def test_init_with_args(self):
+        """
+        Test that a Credential struct can be constructed with arguments.
+        """
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="John",
+                password="abc123"
+            )
+        )
+
+        self.assertEqual(
+            enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential.credential_type
+        )
+        self.assertEqual(
+            objects.UsernamePasswordCredential(
+                username="John",
+                password="abc123"
+            ),
+            credential.credential_value
+        )
+
+    def test_invalid_credential_type(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the credential type of a Credential struct.
+        """
+        kwargs = {"credential_type": "invalid"}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Credential type must be a CredentialType enumeration.",
+            objects.Credential,
+            **kwargs
+        )
+
+        credential = objects.Credential()
+        args = (credential, "credential_type", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Credential type must be a CredentialType enumeration.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_credential_value(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the credential value of a Credential struct.
+        """
+        kwargs = {"credential_value": "invalid"}
+        self.assertRaisesRegexp(
+            TypeError,
+            "Credential value must be a CredentialValue struct.",
+            objects.Credential,
+            **kwargs
+        )
+
+        credential = objects.Credential()
+        args = (credential, "credential_value", 0)
+        self.assertRaisesRegexp(
+            TypeError,
+            "Credential value must be a CredentialValue struct.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a Credential struct can be read from a data stream.
+        """
+        # Test with a UsernamePasswordCredential.
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+        credential.read(self.username_password_encoding)
+
+        self.assertEqual(
+            enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential.credential_type
+        )
+        self.assertEqual(
+            objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            ),
+            credential.credential_value
+        )
+
+        # Test with a DeviceCredential
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+        credential.read(self.device_encoding)
+
+        self.assertEqual(
+            enums.CredentialType.DEVICE,
+            credential.credential_type
+        )
+        self.assertEqual(
+            objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            ),
+            credential.credential_value
+        )
+
+    def test_read_missing_credential_type(self):
+        """
+        Test that a ValueError gets raised when attempting to read a
+        Credential struct from a data stream missing the credential type data.
+        """
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+        args = (self.encoding_missing_credential_type, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Credential encoding missing the credential type.",
+            credential.read,
+            *args
+        )
+
+    def test_read_unknown_credential_type(self):
+        """
+        Test that a ValueError gets raised when attempting to read a
+        Credential struct from a data stream with an unknown credential
+        type.
+        """
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+        args = (self.encoding_unknown_credential_type, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Credential encoding includes unrecognized credential type.",
+            credential.read,
+            *args
+        )
+
+    def test_read_missing_credential_value(self):
+        """
+        Test that a ValueError gets raised when attempting to read a
+        Credential struct from a data stream missing the credential value
+        data.
+        """
+        credential = objects.Credential()
+
+        self.assertEqual(None, credential.credential_type)
+        self.assertEqual(None, credential.credential_value)
+
+        args = (self.encoding_missing_credential_value, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Credential encoding missing the credential value.",
+            credential.read,
+            *args
+        )
+
+    def test_write(self):
+        """
+        Test that a Credential struct can be written to a data stream.
+        """
+        # Test with a UsernamePasswordCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.username_password_encoding), len(stream))
+        self.assertEqual(str(self.username_password_encoding), str(stream))
+
+        # Test with a DeviceCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+        stream = utils.BytearrayStream()
+
+        credential.write(stream)
+
+        self.assertEqual(len(self.device_encoding), len(stream))
+        self.assertEqual(str(self.device_encoding), str(stream))
+
+    def test_write_missing_credential_type(self):
+        """
+        Test that a ValueError gets raised when attempting to write a
+        Credential struct missing credential type data to a data stream.
+        """
+        credential = objects.Credential(
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        stream = utils.BytearrayStream()
+
+        args = (stream, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Credential struct missing the credential type.",
+            credential.write,
+            *args
+        )
+
+    def test_write_missing_credential_value(self):
+        """
+        Test that a ValueError gets raised when attempting to write a
+        Credential struct missing credential value data to a data stream.
+        """
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE
+        )
+        stream = utils.BytearrayStream()
+
+        args = (stream, )
+        self.assertRaisesRegexp(
+            ValueError,
+            "Credential struct missing the credential value.",
+            credential.write,
+            *args
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        Credential structs with the same data.
+        """
+        a = objects.Credential()
+        b = objects.Credential()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        # Test with a UsernamePasswordCredential.
+        a = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        # Test with a DeviceCredential.
+        a = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_credential_type(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Credential structs with different credential types.
+        """
+        a = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_credential_value(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Credential structs with different credential values.
+        """
+        a = objects.Credential(
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        b = objects.Credential(
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Credential structs with different types.
+        """
+        a = objects.Credential()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        Credential structs with the same data.
+        """
+        a = objects.Credential()
+        b = objects.Credential()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        # Test with a UsernamePasswordCredential.
+        a = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        # Test with a DeviceCredential.
+        a = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_credential_type(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Credential structs with different credential types.
+        """
+        a = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD
+        )
+        b = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_credential_value(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Credential structs with different credential values.
+        """
+        a = objects.Credential(
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        b = objects.Credential(
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Credential structs with different types.
+        """
+        a = objects.Credential()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a Credential struct.
+        """
+        # Test with a UsernamePasswordCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        expected = (
+            "Credential("
+            "credential_type=CredentialType.USERNAME_AND_PASSWORD, "
+            "credential_value=UsernamePasswordCredential("
+            "username='Fred', "
+            "password='password1'))"
+        )
+        observed = repr(credential)
+
+        self.assertEqual(expected, observed)
+
+        # Test with a DeviceCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+        expected = (
+            "Credential("
+            "credential_type=CredentialType.DEVICE, "
+            "credential_value=DeviceCredential("
+            "device_serial_number='serNum123456', "
+            "password='secret', "
+            "device_identifier='devID2233', "
+            "network_identifier='netID9000', "
+            "machine_identifier='machineID1', "
+            "media_identifier='mediaID313'))"
+        )
+        observed = repr(credential)
+
+        self.assertEqual(expected, observed)
+
+    def test_str(self):
+        """
+        Test that str can be applied to a Credential struct.
+        """
+        # Test with a UsernamePasswordCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.USERNAME_AND_PASSWORD,
+            credential_value=objects.UsernamePasswordCredential(
+                username="Fred",
+                password="password1"
+            )
+        )
+        expected = str({
+            "credential_type": enums.CredentialType.USERNAME_AND_PASSWORD,
+            "credential_value": str({
+                "username": "Fred",
+                "password": "password1"
+            })
+        })
+        observed = str(credential)
+
+        self.assertEqual(expected, observed)
+
+        # Test with a DeviceCredential.
+        credential = objects.Credential(
+            credential_type=enums.CredentialType.DEVICE,
+            credential_value=objects.DeviceCredential(
+                device_serial_number="serNum123456",
+                password="secret",
+                device_identifier="devID2233",
+                network_identifier="netID9000",
+                machine_identifier="machineID1",
+                media_identifier="mediaID313"
+            )
+        )
+        expected = str({
+            "credential_type": enums.CredentialType.DEVICE,
+            "credential_value": str({
+                "device_serial_number": "serNum123456",
+                "password": "secret",
+                "device_identifier": "devID2233",
+                "network_identifier": "netID9000",
+                "machine_identifier": "machineID1",
+                "media_identifier": "mediaID313"
+            })
+        })
+        observed = str(credential)
+
+        self.assertEqual(expected, observed)

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -64,8 +64,6 @@ from kmip.services.results import OperationResult
 from kmip.services.results import QueryResult
 from kmip.services.results import RekeyKeyPairResult
 
-import kmip.core.utils as utils
-
 import mock
 import os
 import socket
@@ -144,31 +142,17 @@ class TestKMIPClient(TestCase):
     def test_build_credential(self):
         username = 'username'
         password = 'password'
-        cred_type = CredentialType.USERNAME_AND_PASSWORD
         self.client.username = username
         self.client.password = password
 
         credential = self.client._build_credential()
 
-        message = utils.build_er_error(credential.__class__, 'type',
-                                       cred_type,
-                                       credential.credential_type.value,
-                                       'value')
-        self.assertEqual(CredentialType.USERNAME_AND_PASSWORD,
-                         credential.credential_type.value,
-                         message)
-
-        message = utils.build_er_error(
-            credential.__class__, 'type', username,
-            credential.credential_value.username.value, 'value')
-        self.assertEqual(username, credential.credential_value.username.value,
-                         message)
-
-        message = utils.build_er_error(
-            credential.__class__, 'type', password,
-            credential.credential_value.password.value, 'value')
-        self.assertEqual(password, credential.credential_value.password.value,
-                         message)
+        self.assertEqual(
+            CredentialType.USERNAME_AND_PASSWORD,
+            credential.credential_type
+        )
+        self.assertEqual(username, credential.credential_value.username)
+        self.assertEqual(password, credential.credential_value.password)
 
     def test_build_credential_no_username(self):
         username = None


### PR DESCRIPTION
This change updates the implementation of the Credential objects. The UsernamePassword and Device credentials are now first-class objects and, along with the base Credential, have been restructured to match the current struct style. Comprehensive unit test suites for each class have been added. Additionally, the credential factory code and its usage in the KMIPProxy class and associated test suites have been updated to reflect this change.