### PR TITLE
Update ProxyKmipClient register to support name attributes

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -353,6 +353,14 @@ class ProxyKmipClient(object):
                     managed_object.operation_policy_name
                 )
                 object_attributes.append(opn_attribute)
+        if hasattr(managed_object, 'names'):
+            if managed_object.names:
+                for name in managed_object.names:
+                    name_attribute = self.attribute_factory.create_attribute(
+                        enums.AttributeType.NAME,
+                        name
+                    )
+                    object_attributes.append(name_attribute)
 
         template = cobjects.TemplateAttribute(attributes=object_attributes)
         object_type = managed_object.object_type

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -111,7 +111,9 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
             enums.CryptographicAlgorithm.AES,
             128,
             (b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E'
-             b'\x0F'))
+             b'\x0F'),
+            name="Test Symmetric Key"
+        )
 
         uid = self.client.register(key)
         self.assertIsInstance(uid, six.string_types)


### PR DESCRIPTION
This change updates the ProxyKmipClient support for the Register operation, adding the ability to register Name attributes with the managed object being registered. This matches the functionality available when using the Create operation.

Fixes #400