### PR TITLE
Add operation policy name to demo scripts

### DIFF
--- a/kmip/demos/pie/create.py
+++ b/kmip/demos/pie/create.py
@@ -46,7 +46,11 @@ if __name__ == '__main__':
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:
         try:
-            uid = client.create(algorithm, length)
+            uid = client.create(
+                algorithm,
+                length,
+                operation_policy_name=opts.operation_policy_name
+            )
             logger.info("Successfully created symmetric key with ID: "
                         "{0}".format(uid))
         except Exception as e:

--- a/kmip/demos/pie/create_key_pair.py
+++ b/kmip/demos/pie/create_key_pair.py
@@ -45,7 +45,11 @@ if __name__ == '__main__':
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:
         try:
-            public_uid, private_uid = client.create_key_pair(algorithm, length)
+            public_uid, private_uid = client.create_key_pair(
+                algorithm,
+                length,
+                operation_policy_name=opts.operation_policy_name
+            )
             logger.info("Successfully created public key with ID: {0}".format(
                 public_uid))
             logger.info("Successfully created private key with ID: {0}".format(

--- a/kmip/demos/pie/register_certificate.py
+++ b/kmip/demos/pie/register_certificate.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
     name = 'Demo X.509 Certificate'
 
     cert = objects.X509Certificate(value, usage_mask, name)
+    cert.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/pie/register_opaque_object.py
+++ b/kmip/demos/pie/register_opaque_object.py
@@ -36,6 +36,7 @@ if __name__ == '__main__':
     name = 'Demo Opaque Object'
 
     obj = objects.OpaqueObject(value, opaque_type, name)
+    obj.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/pie/register_private_key.py
+++ b/kmip/demos/pie/register_private_key.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
 
     key = objects.PrivateKey(
         algorithm, length, value, format_type, usage_mask, name)
+    key.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/pie/register_public_key.py
+++ b/kmip/demos/pie/register_public_key.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
 
     key = objects.PublicKey(
         algorithm, length, value, format_type, usage_mask, name)
+    key.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/pie/register_secret_data.py
+++ b/kmip/demos/pie/register_secret_data.py
@@ -38,6 +38,7 @@ if __name__ == '__main__':
     name = 'Demo Secret Data'
 
     secret = objects.SecretData(value, data_type, usage_mask, name)
+    secret.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/pie/register_symmetric_key.py
+++ b/kmip/demos/pie/register_symmetric_key.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     name = 'Demo Symmetric Key'
 
     key = objects.SymmetricKey(algorithm, length, value, usage_mask, name)
+    key.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(config=config) as client:

--- a/kmip/demos/units/create.py
+++ b/kmip/demos/units/create.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import AttributeType
 from kmip.core.enums import CredentialType
 from kmip.core.enums import CryptographicAlgorithm
@@ -108,6 +109,14 @@ if __name__ == '__main__':
     name = Attribute(attribute_name=name, attribute_value=value)
 
     attributes = [algorithm_obj, usage_mask, length_obj, name]
+
+    if opts.operation_policy_name is not None:
+        opn = attribute_factory.create_attribute(
+            enums.AttributeType.OPERATION_POLICY_NAME,
+            opts.operation_policy_name
+        )
+        attributes.append(opn)
+
     template_attribute = TemplateAttribute(attributes=attributes)
 
     # Create the SYMMETRIC_KEY object

--- a/kmip/demos/units/create_key_pair.py
+++ b/kmip/demos/units/create_key_pair.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import AttributeType
 from kmip.core.enums import CredentialType
 from kmip.core.enums import CryptographicAlgorithm
@@ -108,6 +109,14 @@ if __name__ == '__main__':
                                                     length)
 
     attributes = [algorithm_obj, length_obj, name, usage_mask]
+
+    if opts.operation_policy_name is not None:
+        opn = attribute_factory.create_attribute(
+            enums.AttributeType.OPERATION_POLICY_NAME,
+            opts.operation_policy_name
+        )
+        attributes.append(opn)
+
     common = CommonTemplateAttribute(attributes=attributes)
     private = PrivateKeyTemplateAttribute(attributes=attributes)
     public = PublicKeyTemplateAttribute(attributes=attributes)

--- a/kmip/demos/units/register.py
+++ b/kmip/demos/units/register.py
@@ -13,11 +13,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import KeyFormatType
 from kmip.core.enums import ObjectType
 from kmip.core.enums import Operation
 from kmip.core.enums import ResultStatus
 
+from kmip.core.factories.attributes import AttributeFactory
 from kmip.core.objects import TemplateAttribute
 
 from kmip.demos import utils
@@ -51,9 +53,19 @@ if __name__ == '__main__':
         logger.error(
             "Invalid key format type specified; exiting early from demo")
 
+    attribute_factory = AttributeFactory()
+
     # Create the template attribute for the secret and then build the secret
     usage_mask = utils.build_cryptographic_usage_mask(logger, object_type)
     attributes = [usage_mask]
+
+    if opts.operation_policy_name is not None:
+        opn = attribute_factory.create_attribute(
+            enums.AttributeType.OPERATION_POLICY_NAME,
+            opts.operation_policy_name
+        )
+        attributes.append(opn)
+
     template_attribute = TemplateAttribute(attributes=attributes)
 
     secret = utils.build_object(logger, object_type, key_format_type)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -104,6 +104,15 @@ def build_cli_parser(operation=None):
             default=None,
             dest="length",
             help="Key length in bits (e.g., 128, 256)")
+        parser.add_option(
+            "-o",
+            "--operation-policy-name",
+            action="store",
+            type="str",
+            default=None,
+            dest="operation_policy_name",
+            help="Operation policy name for the secret (e.g., 'default')"
+        )
     elif operation is Operation.CREATE_KEY_PAIR:
         parser.add_option(
             "-a",
@@ -129,6 +138,16 @@ def build_cli_parser(operation=None):
             default=None,
             dest="name",
             help="Name of key pair to create")
+        parser.add_option(
+            "-o",
+            "--operation-policy-name",
+            action="store",
+            type="str",
+            default=None,
+            dest="operation_policy_name",
+            help="Operation policy name for the secrets (e.g., 'default')"
+        )
+
     elif operation is Operation.DESTROY:
         parser.add_option(
             "-i",
@@ -212,6 +231,15 @@ def build_cli_parser(operation=None):
             help=("Type of the object to register. Supported types include: "
                   "CERTIFICATE, PRIVATE_KEY, PUBLIC_KEY, SYMMETRIC_KEY, "
                   "SECRET_DATA"))
+        parser.add_option(
+            "-o",
+            "--operation-policy-name",
+            action="store",
+            type="str",
+            default=None,
+            dest="operation_policy_name",
+            help="Operation policy name for the secret (e.g., 'default')"
+        )
     elif operation is Operation.DISCOVER_VERSIONS:
         parser.add_option(
             "-v",


### PR DESCRIPTION
This change adds the ability to set the operation policy name attribute to object creation demo scripts, including demos for the Create, CreateKeyPair, and Register operations.