### PR TITLE
Fix a client bug for cryptographic parameter handling

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -1243,12 +1243,15 @@ class ProxyKmipClient(object):
                 CryptographicParameters struct.
 
         Returns:
+            None: if value is None
             CryptographicParameters: a CryptographicParameters struct
 
         Raises:
             TypeError: if the input argument is invalid
         """
-        if not isinstance(value, dict):
+        if value is None:
+            return None
+        elif not isinstance(value, dict):
             raise TypeError("Cryptographic parameters must be a dictionary.")
 
         cryptographic_parameters = CryptographicParameters(

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -2600,6 +2600,15 @@ class TestProxyKmipClient(testtools.TestCase):
         self.assertRaises(
            ClientConnectionNotOpen, client.locate, *args)
 
+    def test_build_cryptographic_parameters_with_none(self):
+        """
+        Test that an empty set of cryptographic parameters is processed
+        correctly.
+        """
+        client = ProxyKmipClient()
+        result = client._build_cryptographic_parameters(None)
+        self.assertEqual(None, result)
+
     def test_build_cryptographic_parameters_invalid(self):
         """
         Test that the right error is raised when attempting to build


### PR DESCRIPTION
This change fixes a bug with the ProxyKmipClient handling of cryptographic parameters, specifically handling the case where no cryptographic parameters are provided for an operation method call. When no parameters are specified, None is now correctly propagated through to request handling. A client unit test has been added to cover this fix.

Fixes #406