### PR TITLE
Integrate policy file monitoring with the server

### DIFF
--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -311,6 +311,12 @@ class InvalidPrimitiveLength(Exception):
     pass
 
 
+class ShutdownError(Exception):
+    """
+    An error generated when a problem occurs with shutting down the server.
+    """
+
+
 class StreamNotEmptyError(Exception):
     def __init__(self, cls, extra):
         super(StreamNotEmptyError, self).__init__()

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -15,7 +15,6 @@
 
 import copy
 import logging
-import os
 import six
 import sqlalchemy
 
@@ -41,8 +40,6 @@ from kmip.core.messages import messages
 from kmip.core.messages import payloads
 
 from kmip.core import misc
-
-from kmip.core import policy as operation_policy
 
 from kmip.pie import factory
 from kmip.pie import objects
@@ -77,7 +74,7 @@ class KmipEngine(object):
         * Cryptographic usage mask enforcement per object type
     """
 
-    def __init__(self, policy_path=None):
+    def __init__(self, policies=None):
         """
         Create a KmipEngine.
 
@@ -124,68 +121,8 @@ class KmipEngine(object):
         }
 
         self._attribute_policy = policy.AttributePolicy(self._protocol_version)
-        self._operation_policies = copy.deepcopy(operation_policy.policies)
-        self._load_operation_policies(policy_path)
-
+        self._operation_policies = policies
         self._client_identity = [None, None]
-
-    def _load_operation_policies(self, policy_path):
-        if (policy_path is None) or (not os.path.isdir(policy_path)):
-            self._logger.warning(
-                "The specified operation policy directory{0} is not "
-                "valid. No user-defined policies will be loaded.".format(
-                    " (" + policy_path + ")" if policy_path else ''
-                )
-            )
-            return dict()
-        else:
-            self._logger.info(
-                "Loading user-defined operation policy files from: {0}".format(
-                    policy_path
-                )
-            )
-
-        for filename in os.listdir(policy_path):
-            file_path = os.path.join(policy_path, filename)
-            if os.path.isfile(file_path):
-                self._logger.info(
-                    "Loading user-defined operation policies "
-                    "from file: {0}".format(file_path)
-                )
-
-                try:
-                    policies = operation_policy.read_policy_from_file(
-                        file_path
-                    )
-                except ValueError as e:
-                    self._logger.error(
-                        "A failure occurred while loading policies."
-                    )
-                    self._logger.exception(e)
-                    continue
-
-                reserved_policies = ['default', 'public']
-                for policy_name in six.iterkeys(policies):
-                    if policy_name in reserved_policies:
-                        self._logger.warning(
-                            "Loaded policy '{0}' overwrites a reserved "
-                            "policy and will be thrown out.".format(
-                                policy_name
-                            )
-                        )
-                    elif policy_name in six.iterkeys(
-                            self._operation_policies
-                    ):
-                        self._logger.warning(
-                            "Loaded policy '{0}' overwrites a "
-                            "preexisting policy and will be thrown "
-                            "out.".format(policy_name)
-                        )
-                    else:
-                        self._operation_policies.update([(
-                            policy_name,
-                            policies.get(policy_name)
-                        )])
 
     def _get_enum_string(self, e):
         return ''.join([x.capitalize() for x in e.name.split('_')])
@@ -981,6 +918,8 @@ class KmipEngine(object):
         managed_object = self._data_session.query(object_type).filter(
             object_type.unique_identifier == uid
         ).one()
+
+        # TODO (peter-hamilton) Add debug log with policy contents?
 
         # Determine if the request should be carried out under the object's
         # operation policy. If not, feign ignorance of the object.

--- a/kmip/services/server/monitor.py
+++ b/kmip/services/server/monitor.py
@@ -35,7 +35,7 @@ class PolicyDirectoryMonitor(multiprocessing.Process):
     A file monitor that tracks modifications made within the policy directory.
     """
 
-    def __init__(self, policy_directory, policy_store):
+    def __init__(self, policy_directory, policy_store, live_monitoring=True):
         """
         Set up the file monitor with the policy directory to track.
 
@@ -46,11 +46,15 @@ class PolicyDirectoryMonitor(multiprocessing.Process):
                 multiprocessing resource manager. Used to store and share the
                 policy information across server processes and threads.
                 Required.
+            live_monitoring (boolean): A boolean indicating whether or not
+                live monitoring should continue indefinitely. Optional,
+                defaults to True.
         """
         super(PolicyDirectoryMonitor, self).__init__()
 
         self.halt_trigger = multiprocessing.Event()
         self.policy_directory = policy_directory
+        self.live_monitoring = live_monitoring
 
         self.file_timestamps = None
         self.policy_cache = None
@@ -71,69 +75,77 @@ class PolicyDirectoryMonitor(multiprocessing.Process):
     def stop(self):
         self.halt_trigger.set()
 
+    def scan_policies(self):
+        """
+        Scan the policy directory for policy data.
+        """
+        policy_files = get_json_files(self.policy_directory)
+        for f in set(policy_files) - set(self.policy_files):
+            self.file_timestamps[f] = 0
+        for f in set(self.policy_files) - set(policy_files):
+            self.logger.info("Removing policies for file: {}".format(f))
+            self.file_timestamps.pop(f, None)
+            for p in self.policy_cache.keys():
+                self.disassociate_policy_and_file(p, f)
+            for p in [k for k, v in self.policy_map.items() if v == f]:
+                self.restore_or_delete_policy(p)
+        self.policy_files = policy_files
+
+        for f in sorted(self.file_timestamps.keys()):
+            t = os.path.getmtime(f)
+            if t > self.file_timestamps[f]:
+                self.logger.info("Loading policies for file: {}".format(f))
+                self.file_timestamps[f] = t
+                old_p = [k for k, v in self.policy_map.items() if v == f]
+                try:
+                    new_p = operation_policy.read_policy_from_file(f)
+                except ValueError:
+                    self.logger.error("Failure loading file: {}".format(f))
+                    self.logger.debug("", exc_info=True)
+                    continue
+                for p in new_p.keys():
+                    self.logger.info("Loading policy: {}".format(p))
+                    if p in self.reserved_policies:
+                        self.logger.warning(
+                            "Policy '{}' overwrites a reserved policy and "
+                            "will be thrown out.".format(p)
+                        )
+                        continue
+                    if p in sorted(self.policy_store.keys()):
+                        self.logger.debug(
+                            "Policy '{}' overwrites an existing "
+                            "policy.".format(p)
+                        )
+                        if f != self.policy_map.get(p):
+                            self.policy_cache.get(p).append(
+                                (
+                                    time.time(),
+                                    self.policy_map.get(p),
+                                    self.policy_store.get(p)
+                                )
+                            )
+                    else:
+                        self.policy_cache[p] = []
+                    self.policy_store[p] = new_p.get(p)
+                    self.policy_map[p] = f
+                for p in set(old_p) - set(new_p.keys()):
+                    self.disassociate_policy_and_file(p, f)
+                    self.restore_or_delete_policy(p)
+
     def run(self):
         """
         Start monitoring operation policy files.
         """
         self.initialize_tracking_structures()
 
-        self.logger.info("Starting up the operation policy file monitor.")
-        while not self.halt_trigger.is_set():
-            time.sleep(1)
-
-            policy_files = get_json_files(self.policy_directory)
-            for f in set(policy_files) - set(self.policy_files):
-                self.file_timestamps[f] = 0
-            for f in set(self.policy_files) - set(policy_files):
-                self.logger.info("Removing policies for file: {}".format(f))
-                self.file_timestamps.pop(f, None)
-                for p in self.policy_cache.keys():
-                    self.disassociate_policy_and_file(p, f)
-                for p in [k for k, v in self.policy_map.items() if v == f]:
-                    self.restore_or_delete_policy(p)
-            self.policy_files = policy_files
-
-            for f in sorted(self.file_timestamps.keys()):
-                t = os.path.getmtime(f)
-                if t > self.file_timestamps[f]:
-                    self.logger.info("Loading policies for file: {}".format(f))
-                    self.file_timestamps[f] = t
-                    old_p = [k for k, v in self.policy_map.items() if v == f]
-                    try:
-                        new_p = operation_policy.read_policy_from_file(f)
-                    except ValueError:
-                        self.logger.error("Failure loading file: {}".format(f))
-                        self.logger.debug("", exc_info=True)
-                        continue
-                    for p in new_p.keys():
-                        self.logger.info("Loading policy: {}".format(p))
-                        if p in self.reserved_policies:
-                            self.logger.warning(
-                                "Policy '{}' overwrites a reserved policy and "
-                                "will be thrown out.".format(p)
-                            )
-                            continue
-                        if p in sorted(self.policy_store.keys()):
-                            self.logger.debug(
-                                "Policy '{}' overwrites an existing "
-                                "policy.".format(p)
-                            )
-                            if f != self.policy_map.get(p):
-                                self.policy_cache.get(p).append(
-                                    (
-                                        time.time(),
-                                        self.policy_map.get(p),
-                                        self.policy_store.get(p)
-                                    )
-                                )
-                        else:
-                            self.policy_cache[p] = []
-                        self.policy_store[p] = new_p.get(p)
-                        self.policy_map[p] = f
-                    for p in set(old_p) - set(new_p.keys()):
-                        self.disassociate_policy_and_file(p, f)
-                        self.restore_or_delete_policy(p)
-        self.logger.info("Stopping the operation policy file monitor.")
+        if self.live_monitoring:
+            self.logger.info("Starting up the operation policy file monitor.")
+            while not self.halt_trigger.is_set():
+                time.sleep(1)
+                self.scan_policies()
+            self.logger.info("Stopping the operation policy file monitor.")
+        else:
+            self.scan_policies()
 
     def initialize_tracking_structures(self):
         self.file_timestamps = {}
@@ -142,7 +154,8 @@ class PolicyDirectoryMonitor(multiprocessing.Process):
         self.policy_map = {}
 
         for k in self.policy_store.keys():
-            self.policy_store.pop(k, None)
+            if k not in self.reserved_policies:
+                self.policy_store.pop(k, None)
 
     def disassociate_policy_and_file(self, policy, file_name):
         c = self.policy_cache.get(policy, [])


### PR DESCRIPTION
This change updates the server, integrating policy file monitoring and restructuring the engine. The top-level server entity now handles loading policy files using the PolicyDirectoryMonitor subprocess. A shared memory dictionary is used to share newly modified policy data across the session threads managed by the server and used by the engine. The legacy policy loading code in the engine has been removed.

Unit tests have been added and modified for both the server and engine to verify the functionality of these modifications.