### PR TITLE
Add cryptographic usage mask support for DeriveKey

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -484,6 +484,13 @@ class ProxyKmipClient(object):
                     kwargs.get('cryptographic_algorithm')
                 )
             )
+        if kwargs.get('cryptographic_usage_mask'):
+            attributes.append(
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    kwargs.get('cryptographic_usage_mask')
+                )
+            )
         template_attribute = cobjects.TemplateAttribute(
             attributes=attributes
         )

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -1586,7 +1586,11 @@ class TestProxyKmipClient(testtools.TestCase):
                 'derivation_data': b'\xFF\xFE\xFE\xFC'
             },
             cryptographic_length=128,
-            cryptographic_algorithm=enums.CryptographicAlgorithm.AES
+            cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+            cryptographic_usage_mask=[
+                enums.CryptographicUsageMask.ENCRYPT,
+                enums.CryptographicUsageMask.DECRYPT
+            ]
         )
 
         self.assertEqual('1', derived_id)


### PR DESCRIPTION
This change updates the ProxyKmipClient support for the DeriveKey operation, now allowing the caller to specify a list of CryptographicUsageMask enumerations to set on the newly derived key.

Fixes #417