### PR TITLE
Add Rekey support to the KMIPProxy client

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -283,6 +283,83 @@ class KMIPProxy:
         """
         return self._activate(uuid, credential=credential)
 
+    def rekey(self,
+              uuid=None,
+              offset=None,
+              template_attribute=None,
+              credential=None):
+        """
+        Check object usage according to specific constraints.
+
+        Args:
+            uuid (string): The unique identifier of a managed cryptographic
+                object that should be checked. Optional, defaults to None.
+            offset (int): An integer specifying, in seconds, the difference
+                between the rekeyed objects initialization date and activation
+                date. Optional, defaults to None.
+            template_attribute (TemplateAttribute): A TemplateAttribute struct
+                containing the attributes to set on the newly rekeyed object.
+                Optional, defaults to None.
+            credential (Credential): A Credential struct containing a set of
+                authorization parameters for the operation. Optional, defaults
+                to None.
+
+        Returns:
+            dict: The results of the check operation, containing the following
+                key/value pairs:
+
+                Key                        | Value
+                ---------------------------|-----------------------------------
+                'unique_identifier'        | (string) The unique ID of the
+                                           | checked cryptographic object.
+                'template_attribute'       | (TemplateAttribute) A struct
+                                           | containing attribute set by the
+                                           | server. Optional.
+                'result_status'            | (ResultStatus) An enumeration
+                                           | indicating the status of the
+                                           | operation result.
+                'result_reason'            | (ResultReason) An enumeration
+                                           | providing context for the result
+                                           | status.
+                'result_message'           | (string) A message providing
+                                           | additional context for the
+                                           | operation result.
+        """
+        operation = Operation(OperationEnum.REKEY)
+        request_payload = payloads.RekeyRequestPayload(
+            unique_identifier=uuid,
+            offset=offset,
+            template_attribute=template_attribute
+        )
+        batch_item = messages.RequestBatchItem(
+            operation=operation,
+            request_payload=request_payload
+        )
+
+        request = self._build_request_message(credential, [batch_item])
+        response = self._send_and_receive_message(request)
+        batch_item = response.batch_items[0]
+        payload = batch_item.response_payload
+
+        result = {}
+
+        if payload:
+            result['unique_identifier'] = payload.unique_identifier
+        if payload.template_attribute is not None:
+            result['template_attribute'] = payload.template_attribute
+
+        result['result_status'] = batch_item.result_status.value
+        try:
+            result['result_reason'] = batch_item.result_reason.value
+        except Exception:
+            result['result_reason'] = batch_item.result_reason
+        try:
+            result['result_message'] = batch_item.result_message.value
+        except Exception:
+            result['result_message'] = batch_item.result_message
+
+        return result
+
     def derive_key(self,
                    object_type,
                    unique_identifiers,


### PR DESCRIPTION
This change adds Rekey operation support to the KMIPProxy client. The client unit test suite has been updated to cover the new additions.

Partially addresses #405