### PR TITLE
Add server support for customizing the backend storage file

### DIFF
--- a/kmip/services/server/config.py
+++ b/kmip/services/server/config.py
@@ -51,7 +51,8 @@ class KmipServerConfig(object):
             'policy_path',
             'enable_tls_client_auth',
             'tls_cipher_suites',
-            'logging_level'
+            'logging_level',
+            'database_path'
         ]
 
     def set_setting(self, setting, value):
@@ -93,8 +94,10 @@ class KmipServerConfig(object):
             self._set_enable_tls_client_auth(value)
         elif setting == 'tls_cipher_suites':
             self._set_tls_cipher_suites(value)
-        else:
+        elif setting == 'logging_level':
             self._set_logging_level(value)
+        else:
+            self._set_database_path(value)
 
     def load_settings(self, path):
         """
@@ -179,6 +182,8 @@ class KmipServerConfig(object):
             self._set_logging_level(
                 parser.get('server', 'logging_level')
             )
+        if parser.has_option('server', 'database_path'):
+            self._set_database_path(parser.get('server', 'database_path'))
 
     def _set_hostname(self, value):
         if isinstance(value, six.string_types):
@@ -333,4 +338,15 @@ class KmipServerConfig(object):
             raise exceptions.ConfigurationError(
                 "The logging level must be a string representing a valid "
                 "logging level."
+            )
+
+    def _set_database_path(self, value):
+        if not value:
+            self.settings['database_path'] = None
+        elif isinstance(value, six.string_types):
+            self.settings['database_path'] = value
+        else:
+            raise exceptions.ConfigurationError(
+                "The database path, if specified, must be a valid path to a "
+                "SQLite database file."
             )

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -74,7 +74,7 @@ class KmipEngine(object):
         * Cryptographic usage mask enforcement per object type
     """
 
-    def __init__(self, policies=None):
+    def __init__(self, policies=None, database_path=None):
         """
         Create a KmipEngine.
 
@@ -82,13 +82,20 @@ class KmipEngine(object):
             policy_path (string): The path to the filesystem directory
                 containing PyKMIP server operation policy JSON files.
                 Optional, defaults to None.
+            database_path (string): The path to the SQLite database file
+                used to store all server data. Optional, defaults to None.
+                If none, database path defaults to '/tmp/pykmip.database'.
         """
         self._logger = logging.getLogger('kmip.server.engine')
 
         self._cryptography_engine = engine.CryptographyEngine()
 
+        self.database_path = 'sqlite:///{}'.format(database_path)
+        if not database_path:
+            self.database_path = 'sqlite:////tmp/pykmip.database'
+
         self._data_store = sqlalchemy.create_engine(
-            'sqlite:////tmp/pykmip.database',
+            self.database_path,
             echo=False,
             connect_args={'check_same_thread': False}
         )

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -121,7 +121,8 @@ class TestKmipServer(testtools.TestCase):
             '/etc/pykmip/policies',
             False,
             'TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA',
-            'DEBUG'
+            'DEBUG',
+            '/var/pykmip/pykmip.db'
         )
 
         s.config.load_settings.assert_called_with('/etc/pykmip/server.conf')
@@ -156,6 +157,10 @@ class TestKmipServer(testtools.TestCase):
             ]
         )
         s.config.set_setting.assert_any_call('logging_level', 'DEBUG')
+        s.config.set_setting.assert_any_call(
+            'database_path',
+            '/var/pykmip/pykmip.db'
+        )
 
         # Test that an attempt is made to instantiate the TLS 1.2 auth suite
         s = server.KmipServer(


### PR DESCRIPTION
This change updates the server, adding in support for customizing the backend storage file used to store all server data. The server currently uses a simple SQLite database for storage. Prior versions of the server kept this database file in /tmp, to emphasize the testing focus of the server. This change loosens that restriction, now allowing users to customize where the database file lives. A new configuration option, 'database_path', has been added that will override the default /tmp location for the database file. This value can also be passed in if invoking the server via script using the '-d' flag.