### PR TITLE
Add Rekey support to the payload factories

### DIFF
--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -31,6 +31,9 @@ class RequestPayloadFactory(PayloadFactory):
     def _create_derive_key_payload(self):
         return payloads.DeriveKeyRequestPayload()
 
+    def _create_rekey_payload(self):
+        return payloads.RekeyRequestPayload()
+
     def _create_rekey_key_pair_payload(self):
         return payloads.RekeyKeyPairRequestPayload()
 

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -31,6 +31,9 @@ class ResponsePayloadFactory(PayloadFactory):
     def _create_derive_key_payload(self):
         return payloads.DeriveKeyResponsePayload()
 
+    def _create_rekey_payload(self):
+        return payloads.RekeyResponsePayload()
+
     def _create_rekey_key_pair_payload(self):
         return payloads.RekeyKeyPairResponsePayload()
 

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -53,7 +53,8 @@ class TestRequestPayloadFactory(testtools.TestCase):
         self._test_payload_type(payload, payloads.RegisterRequestPayload)
 
     def test_create_rekey_payload(self):
-        self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
+        payload = self.factory.create(enums.Operation.REKEY)
+        self._test_payload_type(payload, payloads.RekeyRequestPayload)
 
     def test_create_derive_key_payload(self):
         payload = self.factory.create(enums.Operation.DERIVE_KEY)

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -53,7 +53,8 @@ class TestResponsePayloadFactory(testtools.TestCase):
         self._test_payload_type(payload, payloads.RegisterResponsePayload)
 
     def test_create_rekey_payload(self):
-        self._test_not_implemented(self.factory.create, enums.Operation.REKEY)
+        payload = self.factory.create(enums.Operation.REKEY)
+        self._test_payload_type(payload, payloads.RekeyResponsePayload)
 
     def test_create_derive_key_payload(self):
         payload = self.factory.create(enums.Operation.DERIVE_KEY)


### PR DESCRIPTION
This change adds Rekey payload support to the payload factories. Payload factory unit tests have been updated to account for the change.

Fixes #424