### PR TITLE
Add a better error message when reading unparseable attributes

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -112,6 +112,8 @@ class Attribute(Struct):
             enum_type = name
 
         value = self.value_factory.create_attribute_value(enum_type, None)
+        if value is None:
+            raise Exception("No value type for {}".format(enum_name))
         self.attribute_value = value
         self.attribute_value.tag = Tags.ATTRIBUTE_VALUE
         self.attribute_value.read(tstream)


### PR DESCRIPTION
This change adds a basic error message that gets raised when attempting to read an unparseable attribute (i.e., an attribute that is not supported by the library).

Fixes #429