### PR TITLE
Rename the 'default' policy section to 'preset'

### DIFF
--- a/.travis/functional/pykmip/policies/policy.json
+++ b/.travis/functional/pykmip/policies/policy.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "default": {
+    "preset": {
       "SYMMETRIC_KEY": {
         "GET": "DISALLOW_ALL",
         "DESTROY": "DISALLOW_ALL"

--- a/.travis/policy.json
+++ b/.travis/policy.json
@@ -20,7 +20,7 @@
                 }
             }
         },
-        "default": {
+        "preset": {
             "CERTIFICATE": {
                 "LOCATE": "ALLOW_ALL",
                 "CHECK": "ALLOW_ALL",

--- a/examples/policy.json
+++ b/examples/policy.json
@@ -1,6 +1,6 @@
 {
     "example": {
-        "default": {
+        "preset": {
             "CERTIFICATE": {
                 "LOCATE": "ALLOW_ALL",
                 "CHECK": "ALLOW_ALL",

--- a/kmip/core/policy.py
+++ b/kmip/core/policy.py
@@ -71,7 +71,7 @@ def read_policy_from_file(path):
                 "{}".format(path, e)
             )
 
-    policy_sections = {'groups', 'default'}
+    policy_sections = {'groups', 'preset'}
     object_types = set([t.name for t in enums.ObjectType])
     result = {}
 
@@ -84,9 +84,9 @@ def read_policy_from_file(path):
         if sections <= policy_sections:
             parsed_policies = dict()
 
-            default_policy = object_policy.get('default')
+            default_policy = object_policy.get('preset')
             if default_policy:
-                parsed_policies['default'] = parse_policy(default_policy)
+                parsed_policies['preset'] = parse_policy(default_policy)
 
             group_policies = object_policy.get('groups')
             if group_policies:
@@ -100,7 +100,7 @@ def read_policy_from_file(path):
             result[name] = parsed_policies
         elif sections <= object_types:
             policy = parse_policy(object_policy)
-            result[name] = {'default': policy}
+            result[name] = {'preset': policy}
         else:
             invalid_sections = sections - policy_sections - object_types
             raise ValueError(
@@ -113,7 +113,7 @@ def read_policy_from_file(path):
 
 policies = {
     'default': {
-        'default': {
+        'preset': {
             enums.ObjectType.CERTIFICATE: {
                 enums.Operation.LOCATE:             enums.Policy.ALLOW_ALL,
                 enums.Operation.CHECK:              enums.Policy.ALLOW_ALL,
@@ -279,7 +279,7 @@ policies = {
         }
     },
     'public': {
-        'default': {
+        'preset': {
             enums.ObjectType.TEMPLATE: {
                 enums.Operation.LOCATE:             enums.Policy.ALLOW_ALL,
                 enums.Operation.GET:                enums.Policy.ALLOW_ALL,

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -859,7 +859,7 @@ class KmipEngine(object):
                 else:
                     return group_policy
         else:
-            return policy_bundle.get('default')
+            return policy_bundle.get('preset')
 
     def is_allowed(
             self,

--- a/kmip/tests/unit/core/test_policy.py
+++ b/kmip/tests/unit/core/test_policy.py
@@ -106,7 +106,7 @@ class TestPolicy(testtools.TestCase):
             f.write(
                 '{"test": {'
                 '"groups": {"group_A": {"SPLIT_KEY": {"GET": "ALLOW_ALL"}}}, '
-                '"default": {"SPLIT_KEY": {"GET": "ALLOW_ALL"}}}'
+                '"preset": {"SPLIT_KEY": {"GET": "ALLOW_ALL"}}}'
                 '}'
             )
 
@@ -123,7 +123,7 @@ class TestPolicy(testtools.TestCase):
                     }
                 }
             },
-            'default': {
+            'preset': {
                 enums.ObjectType.SPLIT_KEY: {
                     enums.Operation.GET: enums.Policy.ALLOW_ALL
                 }
@@ -166,7 +166,7 @@ class TestPolicy(testtools.TestCase):
 
     def test_read_policy_from_file_default_only(self):
         """
-        Test that reading a policy file with only a default section works
+        Test that reading a policy file with only a preset section works
         correctly.
         """
         policy_file = tempfile.NamedTemporaryFile(
@@ -176,7 +176,7 @@ class TestPolicy(testtools.TestCase):
         with open(policy_file.name, 'w') as f:
             f.write(
                 '{"test": '
-                '{"default": {"SPLIT_KEY": {"GET": "ALLOW_ALL"}}}}'
+                '{"preset": {"SPLIT_KEY": {"GET": "ALLOW_ALL"}}}}'
             )
 
         policies = policy.read_policy_from_file(policy_file.name)
@@ -185,7 +185,7 @@ class TestPolicy(testtools.TestCase):
         self.assertIn('test', policies.keys())
 
         expected = {
-            'default': {
+            'preset': {
                 enums.ObjectType.SPLIT_KEY: {
                     enums.Operation.GET: enums.Policy.ALLOW_ALL
                 }
@@ -239,7 +239,7 @@ class TestPolicy(testtools.TestCase):
         self.assertIn('test', policies.keys())
 
         expected = {
-            'default': {
+            'preset': {
                 enums.ObjectType.CERTIFICATE: {
                     enums.Operation.LOCATE: enums.Policy.ALLOW_ALL
                 }

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -2047,7 +2047,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._operation_policies = {
             'test_policy': {
-                'default': {
+                'preset': {
                     enums.ObjectType.SYMMETRIC_KEY: {
                         enums.Operation.GET: enums.Policy.ALLOW_OWNER
                     }
@@ -2072,7 +2072,7 @@ class TestKmipEngine(testtools.TestCase):
         e = engine.KmipEngine()
         e._operation_policies = {
             'test_policy': {
-                'default': {
+                'preset': {
                     enums.ObjectType.SYMMETRIC_KEY: {
                         enums.Operation.GET: enums.Policy.ALLOW_OWNER
                     }
@@ -2105,7 +2105,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._operation_policies = {
             'test_policy': {
-                'default': {
+                'preset': {
                     enums.ObjectType.SYMMETRIC_KEY: {
                         enums.Operation.GET: enums.Policy.ALLOW_OWNER
                     }
@@ -2136,7 +2136,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger = mock.MagicMock()
         e._operation_policies = {
             'test_policy': {
-                'default': {
+                'preset': {
                     enums.ObjectType.SYMMETRIC_KEY: {
                         enums.Operation.GET: enums.Policy.ALLOW_OWNER
                     }


### PR DESCRIPTION
This change tweaks the format of operation policy files, renaming the 'default' section of each policy to 'preset'. This reinforces the idea that this section of the policy is used only when group-based access control is disabled. It also removes any ambiguity between this section of the policy and the actual 'default' policy built into the server.