### PR TITLE
Raise PermissionDenied on access control violations

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -938,7 +938,7 @@ class KmipEngine(object):
             operation
         )
         if not is_allowed:
-            raise exceptions.ItemNotFound(
+            raise exceptions.PermissionDenied(
                 "Could not locate object: {0}".format(uid)
             )
 

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -2376,7 +2376,7 @@ class TestKmipEngine(testtools.TestCase):
         args = [id_a, enums.Operation.GET]
         six.assertRaisesRegex(
             self,
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._get_object_with_access_controls,
             *args
@@ -4659,7 +4659,7 @@ class TestKmipEngine(testtools.TestCase):
         args = [payload]
         six.assertRaisesRegex(
             self,
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_get,
             *args
@@ -5505,7 +5505,7 @@ class TestKmipEngine(testtools.TestCase):
         # be retrieved.
         args = [payload]
         self.assertRaisesRegex(
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_get_attributes,
             *args
@@ -5694,7 +5694,7 @@ class TestKmipEngine(testtools.TestCase):
         # be retrieved.
         args = [payload]
         self.assertRaisesRegex(
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_get_attribute_list,
             *args
@@ -5876,7 +5876,7 @@ class TestKmipEngine(testtools.TestCase):
         # Test by specifying the ID of the object to activate.
         args = [payload]
         self.assertRaisesRegex(
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_activate,
             *args
@@ -6197,7 +6197,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = [payload]
         self.assertRaisesRegex(
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_revoke,
             *args
@@ -6340,7 +6340,7 @@ class TestKmipEngine(testtools.TestCase):
         args = [payload]
         six.assertRaisesRegex(
             self,
-            exceptions.ItemNotFound,
+            exceptions.PermissionDenied,
             "Could not locate object: {0}".format(id_a),
             e._process_destroy,
             *args


### PR DESCRIPTION
This change changes the error the server uses when access control violations occur, specifically swapping from the more agnostic ItemNotFound to the more explicit PermissionDenied. This change better conforms with the expected behavior of a KMIP server.