### PR TITLE
Fix a bug with timeout error handling

### DIFF
--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -111,7 +111,11 @@ class KmipSession(threading.Thread):
         self._logger.info("Stopping session: {0}".format(self.name))
 
     def _handle_message_loop(self):
-        request_data = self._receive_request()
+        try:
+            request_data = self._receive_request()
+        except socket.timeout:
+            return
+
         request = messages.RequestMessage()
 
         max_size = self._max_response_size


### PR DESCRIPTION
This change updates how the server handles SSL/TLS timeout errors when reading incoming client requests. Timeouts are now interpreted as session ending events, resulting in a closed connection as opposed to the original recurring error log message that was produced.