### PR TITLE
Reraise exceptions to preserve stack traces

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -132,7 +132,7 @@ class ProxyKmipClient(object):
                 self._is_open = True
             except Exception as e:
                 self.logger.exception("could not open client connection", e)
-                raise e
+                raise
 
     def close(self):
         """
@@ -149,7 +149,7 @@ class ProxyKmipClient(object):
                 self._is_open = False
             except Exception as e:
                 self.logger.exception("could not close client connection", e)
-                raise e
+                raise
 
     @is_connected
     def create(self, algorithm, length, operation_policy_name=None, name=None,


### PR DESCRIPTION
Otherwise, you can hit errors with tracebacks like

    Traceback (most recent call last):
      ...
      File ".../kmip/pie/client.py", line 1573, in __enter__
        self.open()
      File ".../kmip/pie/client.py", line 135, in open
        raise e
    IOError: [Errno 2] No such file or directory

... which isn't terribly useful; it doesn't give you any information about *what* file wasn't found. By using a bare `raise`, you preserve the rest of the stack and get

    Traceback (most recent call last):
      ...
      File ".../kmip/pie/client.py", line 1573, in __enter__
        self.open()
      File ".../kmip/pie/client.py", line 131, in open
        self.proxy.open()
      File ".../kmip/services/kmip_client.py", line 221, in open
        self._create_socket(sock)
      File ".../kmip/services/kmip_client.py", line 246, in _create_socket
        suppress_ragged_eofs=self.suppress_ragged_eofs)
      File ".../eventlet/green/ssl.py", line 379, in wrap_socket
        return GreenSSLSocket(sock, *a, **kw)
      File ".../eventlet/green/ssl.py", line 68, in __init__
        ca_certs, do_handshake_on_connect and six.PY2, *args, **kw)
      File ".../ssl.py", line 558, in __init__
        self._context.load_verify_locations(ca_certs)
    IOError: [Errno 2] No such file or directory

... which makes it clear that it was a problem with the CA certificate
bundle.