### PR TITLE
Improve errors and logging

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -93,7 +93,7 @@ class ProxyKmipClient(object):
                 Optional, defaults to None.
 
         """
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(__name__)
 
         self.attribute_factory = attributes.AttributeFactory()
         self.object_factory = factory.ObjectFactory()

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -131,7 +131,7 @@ class ProxyKmipClient(object):
                 self.proxy.open()
                 self._is_open = True
             except Exception as e:
-                self.logger.exception("could not open client connection", e)
+                self.logger.error("could not open client connection: %s", e)
                 raise
 
     def close(self):
@@ -148,7 +148,7 @@ class ProxyKmipClient(object):
                 self.proxy.close()
                 self._is_open = False
             except Exception as e:
-                self.logger.exception("could not close client connection", e)
+                self.logger.error("could not close client connection: %s", e)
                 raise
 
     @is_connected

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -62,6 +62,7 @@ import os
 import six
 import socket
 import ssl
+import sys
 
 FILE_PATH = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.normpath(os.path.join(FILE_PATH, '../kmipconfig.ini'))
@@ -226,13 +227,13 @@ class KMIPProxy:
                 self.logger.error("An error occurred while connecting to "
                                   "appliance %s: %s", self.host, e)
                 self.socket.close()
-                last_error = e
+                last_error = sys.exc_info()
             else:
                 return
 
         self.socket = None
         if last_error:
-            raise last_error
+            six.reraise(*last_error)
 
     def _create_socket(self, sock):
         self.socket = ssl.wrap_socket(

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -224,7 +224,7 @@ class KMIPProxy:
                 self.socket.connect((self.host, self.port))
             except Exception as e:
                 self.logger.error("An error occurred while connecting to "
-                                  "appliance " + self.host)
+                                  "appliance %s: %s", self.host, e)
                 self.socket.close()
                 last_error = e
             else:


### PR DESCRIPTION
This started with me noticing
```
No handlers could be found for logger "root"
```
despite setting a handler for the `kmip` logger; after fixing that, I started seeing
```
TypeError: not all arguments converted during string formatting
Logged from file client.py, line 134
```
coming out of logging. Since the line was using `logger.exception()` anyway, I first dropped the not-interpolated exception, which left me with a not-terribly-helpful
```
Jun 22 18:09:45 saio kmip.pie.client: could not open client connection
Traceback (most recent call last):
  File ".../kmip/pie/client.py", line 131, in open
    self.proxy.open()
  File ".../kmip/services/kmip_client.py", line 235, in open
    raise last_error
error: [Errno 111] Connection refused
```
line in my logs -- meanwhile the caller *also* catches and logs the error, resulting in overlapping traceback lines:
```
Traceback (most recent call last):
  <application code>
  ...
  File ".../kmip/pie/client.py", line 1573, in __enter__
    self.open()
  File ".../kmip/pie/client.py", line 131, in open
    self.proxy.open()
  File ".../kmip/services/kmip_client.py", line 235, in open
    raise last_error
socket.error: [Errno 111] Connection refused
```

---

With these patches, when I accidentally set my config file to a directory, I get logs like
```
Jun 22 18:40:45 saio kmip.core.config_helper: Config file /etc/swift/proxy-server/proxy-server.conf.d not found
Jun 22 18:40:45 saio kmip.services.kmip_client: An error occurred while connecting to appliance 127.0.0.1: [Errno 111] Connection refused
Jun 22 18:40:45 saio kmip.pie.client: could not open client connection: [Errno 111] Connection refused
```
while the caller gets the (now more complete) stack trace, which it is free to log or swallow as it sees fit:
```
Traceback (most recent call last):
  <application code>
  ...
  File ".../kmip/pie/client.py", line 1573, in __enter__
    self.open()
  File ".../kmip/pie/client.py", line 131, in open
    self.proxy.open()
  File ".../kmip/services/kmip_client.py", line 236, in open
    six.reraise(*last_error)
  File ".../kmip/services/kmip_client.py", line 225, in open
    self.socket.connect((self.host, self.port))
  File ".../eventlet/green/ssl.py", line 285, in connect
    self._socket_connect(addr)
  File ".../eventlet/green/ssl.py", line 265, in _socket_connect
    real_connect(self, addr)
  File ".../socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 111] Connection refused
```