### PR TITLE
Secure logging by default

### DIFF
--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -47,6 +47,10 @@ class ConfigHelper(object):
 
     def __init__(self, path=None):
         self.logger = logging.getLogger(__name__)
+        # DEBUG logging here may expose passwords, so log at INFO by default.
+        # However, if consumers know the risks, let them go ahead and override.
+        if self.logger.level == logging.NOTSET:
+            self.logger.setLevel(logging.INFO)
 
         self.conf = SafeConfigParser()
 

--- a/kmip/services/server/kmip_protocol.py
+++ b/kmip/services/server/kmip_protocol.py
@@ -27,6 +27,10 @@ class KMIPProtocol(object):
     def __init__(self, socket, buffer_size=1024):
         self.socket = socket
         self.logger = logging.getLogger(__name__)
+        # DEBUG logging here may expose secrets, so log at INFO by default.
+        # However, if consumers know the risks, let them go ahead and override.
+        if self.logger.level == logging.NOTSET:
+            self.logger.setLevel(logging.INFO)
 
     def write(self, data):
         if len(data) > 0:


### PR DESCRIPTION
As an application developer, you might expect to be able to turn on debug logging at the root logger with something like

    logging.basicConfig(level=logging.DEBUG)

However, if the application needed to fetch any secrets from a KMIP server, these previously would be logged as part of the wire protocol. Further, any passwords in configs would also get logged at DEBUG. Applications would need to proactively silence such logging, as in https://github.com/openstack/swift/commit/12b6d46

Now, we will default the logger level to INFO to suppress the debug logging. However, seeing the on-wire data may still be useful, for example when developing a new KMIP server. So, allow developers to still consciously set the logger level to DEBUG.