### PR TITLE
Change EOFError text

### DIFF
--- a/kmip/services/server/kmip_protocol.py
+++ b/kmip/services/server/kmip_protocol.py
@@ -40,7 +40,7 @@ class KMIPProtocol(object):
             header = self._recv_all(self.HEADER_SIZE)
         except RequestLengthMismatch as e:
             if e.received == 0:
-                raise EOFError("No request to process")
+                raise EOFError("No data read from socket")
             else:
                 raise
         msg_size = unpack('!I', header[4:])[0]


### PR DESCRIPTION
The old text made perfect sense when in a server context, trying to read requests from clients, but `KMIPProtocol` is also used by *clients* to read *responses*. Let's change it to something a little more request/response agnostic.