### PR TITLE
Remove invalid escape sequences

### DIFF
--- a/kmip/demos/units/discover_versions.py
+++ b/kmip/demos/units/discover_versions.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     protocol_versions = list()
     if opts.protocol_versions is not None:
         for version in re.split(',| ', opts.protocol_versions):
-            mm = re.split('\.', version)
+            mm = re.split(r'\.', version)
             protocol_versions.append(ProtocolVersion(int(mm[0]), int(mm[1])))
 
     # Build the client and connect to the server

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1444,7 +1444,7 @@ class KmipEngine(object):
             else:
                 raise exceptions.InvalidField(
                     "The cryptographic length must correspond to a valid "
-                    "number of bytes (i.e., it must be a multiple of 8)."
+                    "number of bytes; it must be a multiple of 8."
                 )
         else:
             raise exceptions.InvalidField(

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -4108,7 +4108,7 @@ class TestKmipEngine(testtools.TestCase):
         self.assertRaisesRegexp(
             exceptions.InvalidField,
             "The cryptographic length must correspond to a valid number of "
-            "bytes \(i.e., it must be a multiple of 8\).",
+            "bytes; it must be a multiple of 8.",
             e._process_derive_key,
             *args
         )


### PR DESCRIPTION
A recent style update to Python 3.6 adds deprecation W605, which tightens the usage of invalid escape sequences. This patch removes any instances of invalid escape sequences from the PyKMIP code base, bringing the library back up to compliance with Python style.