### PR TITLE
Add Ubuntu 16.04 LTS as a target test platform for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,19 @@ matrix:
           env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
+          dist: xenial
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
           dist: precise
           env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
         - python: 2.7
           os: linux
           dist: trusty
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
+        - python: 2.7
+          os: linux
+          dist: xenial
           env: TOXENV=py27 RUN_INTEGRATION_TESTS=1
         - python: 2.7
           os: linux
@@ -25,6 +33,10 @@ matrix:
         - python: 2.7
           os: linux
           dist: trusty
+          env: TOXENV=py27 RUN_INTEGRATION_TESTS=2
+        - python: 2.7
+          os: linux
+          dist: xenial
           env: TOXENV=py27 RUN_INTEGRATION_TESTS=2
         - python: 3.4
           os: linux
@@ -33,6 +45,10 @@ matrix:
         - python: 3.4
           os: linux
           dist: trusty
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
+        - python: 3.4
+          os: linux
+          dist: xenial
           env: TOXENV=py34 RUN_INTEGRATION_TESTS=0
         - python: 3.4
           os: linux
@@ -41,6 +57,10 @@ matrix:
         - python: 3.4
           os: linux
           dist: trusty
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
+        - python: 3.4
+          os: linux
+          dist: xenial
           env: TOXENV=py34 RUN_INTEGRATION_TESTS=1
         - python: 3.4
           os: linux
@@ -49,6 +69,10 @@ matrix:
         - python: 3.4
           os: linux
           dist: trusty
+          env: TOXENV=py34 RUN_INTEGRATION_TESTS=2
+        - python: 3.4
+          os: linux
+          dist: xenial
           env: TOXENV=py34 RUN_INTEGRATION_TESTS=2
         - python: 3.5
           os: linux
@@ -57,6 +81,10 @@ matrix:
         - python: 3.5
           os: linux
           dist: trusty
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
+        - python: 3.5
+          os: linux
+          dist: xenial
           env: TOXENV=py35 RUN_INTEGRATION_TESTS=0
         - python: 3.5
           os: linux
@@ -65,6 +93,10 @@ matrix:
         - python: 3.5
           os: linux
           dist: trusty
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
+        - python: 3.5
+          os: linux
+          dist: xenial
           env: TOXENV=py35 RUN_INTEGRATION_TESTS=1
         - python: 3.5
           os: linux
@@ -73,6 +105,10 @@ matrix:
         - python: 3.5
           os: linux
           dist: trusty
+          env: TOXENV=py35 RUN_INTEGRATION_TESTS=2
+        - python: 3.5
+          os: linux
+          dist: xenial
           env: TOXENV=py35 RUN_INTEGRATION_TESTS=2
         - python: 3.6
           os: linux
@@ -81,6 +117,10 @@ matrix:
         - python: 3.6
           os: linux
           dist: trusty
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
+        - python: 3.6
+          os: linux
+          dist: xenial
           env: TOXENV=py36 RUN_INTEGRATION_TESTS=0
         - python: 3.6
           os: linux
@@ -89,6 +129,10 @@ matrix:
         - python: 3.6
           os: linux
           dist: trusty
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
+        - python: 3.6
+          os: linux
+          dist: xenial
           env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
         - python: 3.6
           os: linux
@@ -97,6 +141,10 @@ matrix:
         - python: 3.6
           os: linux
           dist: trusty
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=2
+        - python: 3.6
+          os: linux
+          dist: xenial
           env: TOXENV=py36 RUN_INTEGRATION_TESTS=2
         - python: 2.7
           os: linux
@@ -105,6 +153,10 @@ matrix:
         - python: 2.7
           os: linux
           dist: trusty
+          env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
+          dist: xenial
           env: TOXENV=pep8 RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
@@ -113,6 +165,10 @@ matrix:
         - python: 2.7
           os: linux
           dist: trusty
+          env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
+          dist: xenial
           env: TOXENV=bandit RUN_INTEGRATION_TESTS=0
         - python: 2.7
           os: linux
@@ -121,6 +177,10 @@ matrix:
         - python: 2.7
           os: linux
           dist: trusty
+          env: TOXENV=docs RUN_INTEGRATION_TESTS=0
+        - python: 2.7
+          os: linux
+          dist: xenial
           env: TOXENV=docs RUN_INTEGRATION_TESTS=0
 install:
   # Pin six to >= 1.11.0 to avoid setuptools/pip race condition


### PR DESCRIPTION
This change adds Ubuntu 16.04 LTS (Xenial Xerus) as a target test platform in the Travis CI configuration file. New test builds for all unit, integration, functional, style, security, and doc checks should now be built for Xenial during continuous integration runs.