### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,42 @@ matrix:
           os: linux
           dist: xenial
           env: TOXENV=py36 RUN_INTEGRATION_TESTS=2
+#        - python: 3.7
+#          os: linux
+#          dist: precise
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+#        - python: 3.7
+#          os: linux
+#          dist: trusty
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py37 RUN_INTEGRATION_TESTS=0
+#        - python: 3.7
+#          os: linux
+#          dist: precise
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=1
+#        - python: 3.7
+#          os: linux
+#          dist: trusty
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=1
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py36 RUN_INTEGRATION_TESTS=1
+#        - python: 3.7
+#          os: linux
+#          dist: precise
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=2
+#        - python: 3.7
+#          os: linux
+#          dist: trusty
+#          env: TOXENV=py37 RUN_INTEGRATION_TESTS=2
+        - python: 3.7
+          os: linux
+          dist: xenial
+          env: TOXENV=py37 RUN_INTEGRATION_TESTS=2
         - python: 2.7
           os: linux
           dist: precise

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,py27,py34,py35,py36,bandit,docs
+envlist = pep8,py27,py34,py35,py36,py37,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This change adds official library support for Python 3.7, including updating the testing infrastructure for both tox and Travis CI and updating the library package metadata in setup.py.