### PR TITLE
Fix pending deprecation warnings caused by dependency upgrades

### DIFF
--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -16,7 +16,7 @@
 import logging
 import os
 
-from six.moves.configparser import SafeConfigParser
+from six.moves.configparser import ConfigParser
 
 FILE_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -52,7 +52,7 @@ class ConfigHelper(object):
         if self.logger.level == logging.NOTSET:
             self.logger.setLevel(logging.INFO)
 
-        self.conf = SafeConfigParser()
+        self.conf = ConfigParser()
 
         filenames = path
         if not path:

--- a/kmip/services/server/config.py
+++ b/kmip/services/server/config.py
@@ -122,7 +122,7 @@ class KmipServerConfig(object):
             "Loading server configuration settings from: {0}".format(path)
         )
 
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.read(path)
         self._parse_settings(parser)
         self.parse_auth_settings(parser)

--- a/kmip/tests/unit/core/attributes/test_application_specific_information.py
+++ b/kmip/tests/unit/core/attributes/test_application_specific_information.py
@@ -91,7 +91,7 @@ class TestApplicationSpecificInformation(TestCase):
         application_data = ApplicationData()
         args = [application_namespace, application_data]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid application namespace",
             ApplicationSpecificInformation, *args)
 
@@ -105,7 +105,7 @@ class TestApplicationSpecificInformation(TestCase):
         application_data = "invalid"
         args = [application_namespace, application_data]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid application data",
             ApplicationSpecificInformation, *args)
 

--- a/kmip/tests/unit/core/attributes/test_attributes.py
+++ b/kmip/tests/unit/core/attributes/test_attributes.py
@@ -44,16 +44,16 @@ class TestNameValue(TestCase):
         super(TestNameValue, self).tearDown()
 
     def test_write_no_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_write_with_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_read_no_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_read_with_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test__eq(self):
         name_val = Name.NameValue(self.stringName1)
@@ -91,16 +91,16 @@ class TestNameType(TestCase):
         super(TestNameType, self).tearDown()
 
     def test_write_no_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_write_with_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_read_no_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test_read_with_padding(self):
-        self.skip('Not implemented')
+        self.skipTest('Not implemented')
 
     def test__eq(self):
         type_uri = Name.NameType(self.enum_uri)
@@ -642,7 +642,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'block_cipher_mode', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "block cipher mode must be a BlockCipherMode enumeration",
             setattr,
@@ -656,7 +656,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'padding_method', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "padding method must be a PaddingMethod enumeration",
             setattr,
@@ -670,7 +670,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'hashing_algorithm', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "hashing algorithm must be a HashingAlgorithm enumeration",
             setattr,
@@ -684,7 +684,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'key_role_type', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "key role type must be a KeyRoleType enumeration",
             setattr,
@@ -702,7 +702,7 @@ class TestCryptographicParameters(TestCase):
             'digital_signature_algorithm',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "digital signature algorithm must be a "
             "DigitalSignatureAlgorithm enumeration",
@@ -717,7 +717,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'cryptographic_algorithm', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic algorithm must be a CryptographicAlgorithm "
             "enumeration",
@@ -732,7 +732,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'random_iv', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "random iv must be a boolean",
             setattr,
@@ -746,7 +746,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'iv_length', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "iv length must be an integer",
             setattr,
@@ -760,7 +760,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'tag_length', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "tag length must be an integer",
             setattr,
@@ -774,7 +774,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'fixed_field_length', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "fixed field length must be an integer",
             setattr,
@@ -788,7 +788,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'invocation_field_length', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "invocation field length must be an integer",
             setattr,
@@ -802,7 +802,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'counter_length', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "counter length must be an integer",
             setattr,
@@ -816,7 +816,7 @@ class TestCryptographicParameters(TestCase):
         """
         cryptographic_parameters = CryptographicParameters()
         args = (cryptographic_parameters, 'initial_counter_value', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "initial counter value must be an integer",
             setattr,
@@ -1776,7 +1776,7 @@ class TestDerivationParameters(TestCase):
         the cryptographic parameters of a DerivationParameters struct.
         """
         kwargs = {'cryptographic_parameters': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be a CryptographicParameters "
             "struct",
@@ -1786,7 +1786,7 @@ class TestDerivationParameters(TestCase):
 
         derivation_parameters = DerivationParameters()
         args = (derivation_parameters, 'cryptographic_parameters', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be a CryptographicParameters "
             "struct",
@@ -1801,7 +1801,7 @@ class TestDerivationParameters(TestCase):
         """
         derivation_parameters = DerivationParameters()
         args = (derivation_parameters, 'initialization_vector', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "initialization vector must be bytes",
             setattr,
@@ -1815,7 +1815,7 @@ class TestDerivationParameters(TestCase):
         """
         derivation_parameters = DerivationParameters()
         args = (derivation_parameters, 'derivation_data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "derivation data must be bytes",
             setattr,
@@ -1829,7 +1829,7 @@ class TestDerivationParameters(TestCase):
         """
         derivation_parameters = DerivationParameters()
         args = (derivation_parameters, 'salt', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "salt must be bytes",
             setattr,
@@ -1843,7 +1843,7 @@ class TestDerivationParameters(TestCase):
         """
         derivation_parameters = DerivationParameters()
         args = (derivation_parameters, 'iteration_count', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "iteration count must be an integer",
             setattr,

--- a/kmip/tests/unit/core/attributes/test_digest.py
+++ b/kmip/tests/unit/core/attributes/test_digest.py
@@ -104,7 +104,7 @@ class TestDigest(TestCase):
         hashing_algorithm = "invalid"
         kwargs = {'hashing_algorithm': hashing_algorithm}
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid hashing algorithm", Digest, **kwargs)
 
     def test_validate_with_invalid_digest_value(self):
@@ -115,7 +115,7 @@ class TestDigest(TestCase):
         digest_value = "invalid"
         kwargs = {'digest_value': digest_value}
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid digest value", Digest, **kwargs)
 
     def test_validate_with_invalid_key_format_type(self):
@@ -126,7 +126,7 @@ class TestDigest(TestCase):
         key_format_type = "invalid"
         kwargs = {'key_format_type': key_format_type}
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid key format type", Digest, **kwargs)
 
     def _test_read(self, stream, hashing_algorithm, digest_value,

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -35,7 +35,7 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a UniqueIdentifier attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_name(self):
         """
@@ -73,13 +73,13 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a CryptographicAlgorithm attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_cryptographic_length(self):
         """
         Test that a CryptographicLength attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_cryptographic_parameters(self):
         """
@@ -255,7 +255,7 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that a CryptographicUsageMask attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_lease_time(self):
         """
@@ -390,7 +390,7 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that an ObjectGroup attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_fresh(self):
         """
@@ -415,13 +415,13 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that an ApplicationSpecificInformation attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_contact_information(self):
         """
         Test that a ContactInformation attribute can be created.
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_create_last_change_date(self):
         """

--- a/kmip/tests/unit/core/messages/contents/test_authentication.py
+++ b/kmip/tests/unit/core/messages/contents/test_authentication.py
@@ -175,7 +175,7 @@ class TestAuthentication(testtools.TestCase):
         the credentials of an Authentication struct.
         """
         kwargs = {'credentials': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credentials must be a list of Credential structs.",
             contents.Authentication,
@@ -184,7 +184,7 @@ class TestAuthentication(testtools.TestCase):
 
         authentication = contents.Authentication()
         args = (authentication, "credentials", 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credentials must be a list of Credential structs.",
             setattr,
@@ -208,7 +208,7 @@ class TestAuthentication(testtools.TestCase):
                 'invalid'
             ]
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credentials must be a list of Credential structs. Item 2 has "
             "type: {}".format(type('invalid')),
@@ -231,7 +231,7 @@ class TestAuthentication(testtools.TestCase):
                 'invalid'
             ]
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credentials must be a list of Credential structs. Item 2 has "
             "type: {}".format(type('invalid')),
@@ -328,7 +328,7 @@ class TestAuthentication(testtools.TestCase):
         self.assertEqual([], authentication.credentials)
 
         args = (self.encoding_missing_credentials, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Authentication encoding missing credentials.",
             authentication.read,
@@ -420,7 +420,7 @@ class TestAuthentication(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Authentication struct missing credentials.",
             authentication.write,

--- a/kmip/tests/unit/core/messages/contents/test_protocol_version.py
+++ b/kmip/tests/unit/core/messages/contents/test_protocol_version.py
@@ -77,7 +77,7 @@ class TestProtocolVersion(testtools.TestCase):
         """
         struct = contents.ProtocolVersion()
         args = (struct, 'major', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Major protocol version number must be an integer.",
             setattr,
@@ -91,7 +91,7 @@ class TestProtocolVersion(testtools.TestCase):
         """
         struct = contents.ProtocolVersion()
         args = (struct, 'minor', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Minor protocol version number must be an integer.",
             setattr,
@@ -119,7 +119,7 @@ class TestProtocolVersion(testtools.TestCase):
         """
         struct = contents.ProtocolVersion()
         args = (self.encoding_no_major_number, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid encoding missing the major protocol version number.",
             struct.read,
@@ -133,7 +133,7 @@ class TestProtocolVersion(testtools.TestCase):
         """
         struct = contents.ProtocolVersion()
         args = (self.encoding_no_minor_number, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid encoding missing the minor protocol version number.",
             struct.read,
@@ -159,7 +159,7 @@ class TestProtocolVersion(testtools.TestCase):
         struct = contents.ProtocolVersion(None, 1)
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the major protocol version number.",
             struct.write,
@@ -174,7 +174,7 @@ class TestProtocolVersion(testtools.TestCase):
         struct = contents.ProtocolVersion(1, None)
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the minor protocol version number.",
             struct.write,

--- a/kmip/tests/unit/core/messages/payloads/test_activate.py
+++ b/kmip/tests/unit/core/messages/payloads/test_activate.py
@@ -63,7 +63,7 @@ class TestActivateRequestPayload(TestCase):
         Test that a TypeError exception is raised when an invalid UUID type
         is used to construct a ActivateRequestPayload object.
         """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid unique identifier",
             payloads.ActivateRequestPayload, "not-a-uuid")
 
@@ -146,7 +146,7 @@ class TestActivateResponsePayload(TestCase):
         Test that a TypeError exception is raised when an invalid Operations
         list is used to construct a ActivateResponsePayload object.
         """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid unique identifier",
             payloads.ActivateResponsePayload, "not-a-uuid")
 

--- a/kmip/tests/unit/core/messages/payloads/test_archive.py
+++ b/kmip/tests/unit/core/messages/payloads/test_archive.py
@@ -77,7 +77,7 @@ class TestArchiveRequestPayload(testtools.TestCase):
         the unique identifier of an Archive request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.ArchiveRequestPayload,
@@ -86,7 +86,7 @@ class TestArchiveRequestPayload(testtools.TestCase):
 
         payload = payloads.ArchiveRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -329,7 +329,7 @@ class TestArchiveResponsePayload(testtools.TestCase):
         the unique identifier of an Archive response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.ArchiveResponsePayload,
@@ -338,7 +338,7 @@ class TestArchiveResponsePayload(testtools.TestCase):
 
         payload = payloads.ArchiveResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_cancel.py
+++ b/kmip/tests/unit/core/messages/payloads/test_cancel.py
@@ -72,7 +72,7 @@ class TestCancelRequestPayload(testtools.TestCase):
         the asynchronous correlation value of an Cancel request payload.
         """
         kwargs = {'asynchronous_correlation_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             payloads.CancelRequestPayload,
@@ -81,7 +81,7 @@ class TestCancelRequestPayload(testtools.TestCase):
 
         payload = payloads.CancelRequestPayload()
         args = (payload, 'asynchronous_correlation_value', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             setattr,
@@ -325,7 +325,7 @@ class TestCancelResponsePayload(testtools.TestCase):
         the asynchronous correlation value of an Cancel response payload.
         """
         kwargs = {'asynchronous_correlation_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             payloads.CancelResponsePayload,
@@ -334,7 +334,7 @@ class TestCancelResponsePayload(testtools.TestCase):
 
         payload = payloads.CancelResponsePayload()
         args = (payload, 'asynchronous_correlation_value', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             setattr,
@@ -347,7 +347,7 @@ class TestCancelResponsePayload(testtools.TestCase):
         the cancellation result of an Cancel response payload.
         """
         kwargs = {'cancellation_result': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cancellation result must be a CancellationResult enumeration.",
             payloads.CancelResponsePayload,
@@ -356,7 +356,7 @@ class TestCancelResponsePayload(testtools.TestCase):
 
         payload = payloads.CancelResponsePayload()
         args = (payload, 'cancellation_result', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cancellation result must be a CancellationResult enumeration.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_check.py
+++ b/kmip/tests/unit/core/messages/payloads/test_check.py
@@ -104,7 +104,7 @@ class TestCheckRequestPayload(testtools.TestCase):
         the unique identifier of a Check request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.CheckRequestPayload,
@@ -113,7 +113,7 @@ class TestCheckRequestPayload(testtools.TestCase):
 
         payload = payloads.CheckRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -126,7 +126,7 @@ class TestCheckRequestPayload(testtools.TestCase):
         the usage limits count of a Check request payload.
         """
         kwargs = {'usage_limits_count': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             payloads.CheckRequestPayload,
@@ -135,7 +135,7 @@ class TestCheckRequestPayload(testtools.TestCase):
 
         payload = payloads.CheckRequestPayload()
         args = (payload, 'usage_limits_count', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             setattr,
@@ -148,7 +148,7 @@ class TestCheckRequestPayload(testtools.TestCase):
         the cryptographic usage mask of a Check request payload.
         """
         kwargs = {'cryptographic_usage_mask': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic usage mask must be an integer.",
             payloads.CheckRequestPayload,
@@ -157,7 +157,7 @@ class TestCheckRequestPayload(testtools.TestCase):
 
         payload = payloads.CheckRequestPayload()
         args = (payload, 'cryptographic_usage_mask', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic usage mask must be an integer.",
             setattr,
@@ -170,7 +170,7 @@ class TestCheckRequestPayload(testtools.TestCase):
         the lease time of a Check request payload.
         """
         kwargs = {'lease_time': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             payloads.CheckRequestPayload,
@@ -179,7 +179,7 @@ class TestCheckRequestPayload(testtools.TestCase):
 
         payload = payloads.CheckRequestPayload()
         args = (payload, 'lease_time', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             setattr,
@@ -617,7 +617,7 @@ class TestCheckResponsePayload(testtools.TestCase):
         the unique identifier of a Check response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.CheckResponsePayload,
@@ -626,7 +626,7 @@ class TestCheckResponsePayload(testtools.TestCase):
 
         payload = payloads.CheckResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -639,7 +639,7 @@ class TestCheckResponsePayload(testtools.TestCase):
         the usage limits count of a Check response payload.
         """
         kwargs = {'usage_limits_count': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             payloads.CheckResponsePayload,
@@ -648,7 +648,7 @@ class TestCheckResponsePayload(testtools.TestCase):
 
         payload = payloads.CheckResponsePayload()
         args = (payload, 'usage_limits_count', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             setattr,
@@ -661,7 +661,7 @@ class TestCheckResponsePayload(testtools.TestCase):
         the cryptographic usage mask of a Check response payload.
         """
         kwargs = {'cryptographic_usage_mask': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic usage mask must be an integer.",
             payloads.CheckResponsePayload,
@@ -670,7 +670,7 @@ class TestCheckResponsePayload(testtools.TestCase):
 
         payload = payloads.CheckResponsePayload()
         args = (payload, 'cryptographic_usage_mask', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic usage mask must be an integer.",
             setattr,
@@ -683,7 +683,7 @@ class TestCheckResponsePayload(testtools.TestCase):
         the lease time of a Check response payload.
         """
         kwargs = {'lease_time': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             payloads.CheckResponsePayload,
@@ -692,7 +692,7 @@ class TestCheckResponsePayload(testtools.TestCase):
 
         payload = payloads.CheckResponsePayload()
         args = (payload, 'lease_time', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
@@ -56,7 +56,7 @@ class TestCreateKeyPairRequestPayload(TestCase):
         kwargs = {'common_template_attribute': 'invalid',
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid common template attribute",
             payloads.CreateKeyPairRequestPayload, **kwargs)
 
@@ -64,7 +64,7 @@ class TestCreateKeyPairRequestPayload(TestCase):
         kwargs = {'common_template_attribute': None,
                   'private_key_template_attribute': 'invalid',
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key template attribute",
             payloads.CreateKeyPairRequestPayload, **kwargs)
 
@@ -195,7 +195,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_uuid': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key unique identifier",
             payloads.CreateKeyPairResponsePayload, **kwargs)
 
@@ -204,7 +204,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_uuid': 'invalid',
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid public key unique identifier",
             payloads.CreateKeyPairResponsePayload, **kwargs)
 
@@ -213,7 +213,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_uuid': self.public_key_uuid,
                   'private_key_template_attribute': 'invalid',
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key template attribute",
             payloads.CreateKeyPairResponsePayload, **kwargs)
 
@@ -222,7 +222,7 @@ class TestCreateKeyPairResponsePayload(TestCase):
                   'public_key_uuid': self.public_key_uuid,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid public key template attribute",
             payloads.CreateKeyPairResponsePayload, **kwargs)
 

--- a/kmip/tests/unit/core/messages/payloads/test_decrypt.py
+++ b/kmip/tests/unit/core/messages/payloads/test_decrypt.py
@@ -135,7 +135,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.DecryptRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -149,7 +149,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.DecryptRequestPayload()
         args = (payload, 'cryptographic_parameters', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be a CryptographicParameters "
             "struct",
@@ -164,7 +164,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.DecryptRequestPayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             setattr,
@@ -178,7 +178,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.DecryptRequestPayload()
         args = (payload, 'iv_counter_nonce', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "IV/counter/nonce must be bytes",
             setattr,
@@ -272,7 +272,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.DecryptRequestPayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.read,
@@ -332,7 +332,7 @@ class TestDecryptRequestPayload(testtools.TestCase):
         payload = payloads.DecryptRequestPayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.write,
@@ -752,7 +752,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.DecryptResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -766,7 +766,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.DecryptResponsePayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             setattr,
@@ -797,7 +797,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.DecryptResponsePayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.read,
@@ -806,7 +806,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
 
         payload = payloads.DecryptResponsePayload()
         args = (self.incomplete_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.read,
@@ -836,7 +836,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         self.assertIsNone(payload.unique_identifier)
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.write,
@@ -848,7 +848,7 @@ class TestDecryptResponsePayload(testtools.TestCase):
         )
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_derive_key.py
+++ b/kmip/tests/unit/core/messages/payloads/test_derive_key.py
@@ -199,7 +199,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'object_type', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "object type must be an ObjectType enumeration",
             setattr,
@@ -213,7 +213,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'unique_identifiers', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifiers must be a list of strings",
             setattr,
@@ -221,7 +221,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (payload, 'unique_identifiers', [0])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifiers must be a list of strings",
             setattr,
@@ -229,7 +229,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (payload, 'unique_identifiers', ['valid', 'valid', 0])
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifiers must be a list of strings",
             setattr,
@@ -243,7 +243,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'derivation_method', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "derivation method must be a DerivationMethod enumeration",
             setattr,
@@ -257,7 +257,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'derivation_parameters', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "derivation parameters must be a DerivationParameters struct",
             setattr,
@@ -271,7 +271,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyRequestPayload()
         args = (payload, 'template_attribute', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "template attribute must be a TemplateAttribute struct",
             setattr,
@@ -356,7 +356,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_object_type, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing object type",
             payload.read,
@@ -377,7 +377,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_unique_identifiers, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing unique identifiers",
             payload.read,
@@ -398,7 +398,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_derivation_method, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing derivation method",
             payload.read,
@@ -419,7 +419,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_derivation_parameters, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing derivation parameters",
             payload.read,
@@ -440,7 +440,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_template_attribute, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing template attribute",
             payload.read,
@@ -504,7 +504,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         payload = payloads.DeriveKeyRequestPayload()
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing object type",
             payload.write,
@@ -521,7 +521,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing unique identifiers",
             payload.write,
@@ -543,7 +543,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing derivation method",
             payload.write,
@@ -566,7 +566,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing derivation parameters",
             payload.write,
@@ -596,7 +596,7 @@ class TestDeriveKeyRequestPayload(testtools.TestCase):
         )
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing template attribute",
             payload.write,
@@ -1537,7 +1537,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -1551,7 +1551,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         """
         payload = payloads.DeriveKeyResponsePayload()
         args = (payload, 'template_attribute', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "template attribute must be a TemplateAttribute struct",
             setattr,
@@ -1611,7 +1611,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         self.assertEqual(None, payload.template_attribute)
 
         args = (self.partial_encoding_no_unique_identifier, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing unique identifier",
             payload.read,
@@ -1681,7 +1681,7 @@ class TestDeriveKeyResponsePayload(testtools.TestCase):
         payload = payloads.DeriveKeyResponsePayload()
 
         args = (utils.BytearrayStream(), )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing unique identifier",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
+++ b/kmip/tests/unit/core/messages/payloads/test_discover_versions.py
@@ -62,13 +62,13 @@ class TestDiscoverVersionsRequestPayload(TestCase):
 
     def test_validate_with_invalid_protocol_versions(self):
         kwargs = {'protocol_versions': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid protocol versions list",
             payloads.DiscoverVersionsRequestPayload, **kwargs)
 
     def test_validate_with_invalid_protocol_version(self):
         kwargs = {'protocol_versions': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid protocol version",
             payloads.DiscoverVersionsRequestPayload, **kwargs)
 
@@ -189,13 +189,13 @@ class TestDiscoverVersionsResponsePayload(TestCase):
 
     def test_validate_with_invalid_protocol_versions(self):
         kwargs = {'protocol_versions': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid protocol versions list",
             payloads.DiscoverVersionsResponsePayload, **kwargs)
 
     def test_validate_with_invalid_protocol_version(self):
         kwargs = {'protocol_versions': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid protocol version",
             payloads.DiscoverVersionsResponsePayload, **kwargs)
 

--- a/kmip/tests/unit/core/messages/payloads/test_encrypt.py
+++ b/kmip/tests/unit/core/messages/payloads/test_encrypt.py
@@ -135,7 +135,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.EncryptRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -149,7 +149,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.EncryptRequestPayload()
         args = (payload, 'cryptographic_parameters', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be a CryptographicParameters "
             "struct",
@@ -164,7 +164,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.EncryptRequestPayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             setattr,
@@ -178,7 +178,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.EncryptRequestPayload()
         args = (payload, 'iv_counter_nonce', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "IV/counter/nonce must be bytes",
             setattr,
@@ -272,7 +272,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         """
         payload = payloads.EncryptRequestPayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.read,
@@ -332,7 +332,7 @@ class TestEncryptRequestPayload(testtools.TestCase):
         payload = payloads.EncryptRequestPayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.write,
@@ -769,7 +769,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.EncryptResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -783,7 +783,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.EncryptResponsePayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             setattr,
@@ -797,7 +797,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.EncryptResponsePayload()
         args = (payload, 'iv_counter_nonce', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "IV/counter/nonce must be bytes",
             setattr,
@@ -850,7 +850,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         """
         payload = payloads.EncryptResponsePayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.read,
@@ -859,7 +859,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
 
         payload = payloads.EncryptResponsePayload()
         args = (self.incomplete_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.read,
@@ -905,7 +905,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         self.assertIsNone(payload.unique_identifier)
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.write,
@@ -917,7 +917,7 @@ class TestEncryptResponsePayload(testtools.TestCase):
         )
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_get.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get.py
@@ -140,7 +140,7 @@ class TestGetRequestPayload(testtools.TestCase):
         the unique identifier of a Get request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.GetRequestPayload,
@@ -148,7 +148,7 @@ class TestGetRequestPayload(testtools.TestCase):
         )
 
         args = (payloads.GetRequestPayload(), 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -161,7 +161,7 @@ class TestGetRequestPayload(testtools.TestCase):
         the key format type of a Get request payload.
         """
         kwargs = {'key_format_type': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key format type must be a KeyFormatType enumeration.",
             payloads.GetRequestPayload,
@@ -169,7 +169,7 @@ class TestGetRequestPayload(testtools.TestCase):
         )
 
         args = (payloads.GetRequestPayload(), 'key_format_type', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key format type must be a KeyFormatType enumeration.",
             setattr,
@@ -182,7 +182,7 @@ class TestGetRequestPayload(testtools.TestCase):
         the key compression type of a Get request payload.
         """
         kwargs = {'key_compression_type': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key compression type must be a KeyCompressionType enumeration.",
             payloads.GetRequestPayload,
@@ -194,7 +194,7 @@ class TestGetRequestPayload(testtools.TestCase):
             'key_compression_type',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key compression type must be a KeyCompressionType enumeration.",
             setattr,
@@ -207,7 +207,7 @@ class TestGetRequestPayload(testtools.TestCase):
         the key wrapping specification of a Get request payload.
         """
         kwargs = {'key_wrapping_specification': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key wrapping specification must be a KeyWrappingSpecification "
             "struct.",
@@ -220,7 +220,7 @@ class TestGetRequestPayload(testtools.TestCase):
             'key_wrapping_specification',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key wrapping specification must be a KeyWrappingSpecification "
             "struct.",
@@ -939,7 +939,7 @@ class TestGetResponsePayload(testtools.TestCase):
         the object type of a GetResponsePayload struct.
         """
         kwargs = {'object_type': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Object type must be an ObjectType enumeration.",
             payloads.GetResponsePayload,
@@ -947,7 +947,7 @@ class TestGetResponsePayload(testtools.TestCase):
         )
 
         args = (payloads.GetResponsePayload(), 'object_type', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Object type must be an ObjectType enumeration.",
             setattr,
@@ -960,7 +960,7 @@ class TestGetResponsePayload(testtools.TestCase):
         the unique identifier of a GetResponsePayload struct.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.GetResponsePayload,
@@ -968,7 +968,7 @@ class TestGetResponsePayload(testtools.TestCase):
         )
 
         args = (payloads.GetResponsePayload(), 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -981,7 +981,7 @@ class TestGetResponsePayload(testtools.TestCase):
         the secret of a GetResponsePayload struct.
         """
         kwargs = {'secret': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Secret must be one of the following structs: Certificate, "
             "OpaqueObject, PrivateKey, PublicKey, SecretData, SplitKey, "
@@ -991,7 +991,7 @@ class TestGetResponsePayload(testtools.TestCase):
         )
 
         args = (payloads.GetResponsePayload(), 'secret', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Secret must be one of the following structs: Certificate, "
             "OpaqueObject, PrivateKey, PublicKey, SecretData, SplitKey, "
@@ -1067,7 +1067,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_object_type, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Parsed payload encoding is missing the object type field.",
             payload.read,
@@ -1081,7 +1081,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_unique_id, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Parsed payload encoding is missing the unique identifier field.",
             payload.read,
@@ -1095,7 +1095,7 @@ class TestGetResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetResponsePayload()
         args = (self.partial_encoding_missing_secret, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Parsed payload encoding is missing the secret field.",
             payload.read,
@@ -1142,7 +1142,7 @@ class TestGetResponsePayload(testtools.TestCase):
         payload = payloads.GetResponsePayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Payload is missing the object type field.",
             payload.write,
@@ -1159,7 +1159,7 @@ class TestGetResponsePayload(testtools.TestCase):
         )
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Payload is missing the unique identifier field.",
             payload.write,
@@ -1177,7 +1177,7 @@ class TestGetResponsePayload(testtools.TestCase):
         )
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Payload is missing the secret field.",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_get_attribute_list.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attribute_list.py
@@ -91,7 +91,7 @@ class TestGetAttributeListRequestPayload(testtools.TestCase):
         """
         payload = payloads.GetAttributeListRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -439,7 +439,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetAttributeListResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -487,7 +487,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetAttributeListResponsePayload()
         args = (payload, 'attribute_names', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attribute_names must be a list of strings",
             setattr,
@@ -506,7 +506,7 @@ class TestGetAttributeListResponsePayload(testtools.TestCase):
             'attribute_names',
             ['test-attribute-name-1', 0]
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attribute_names must be a list of strings; "
             "item 2 has type {0}".format(type(0)),

--- a/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
@@ -122,7 +122,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         payload = payloads.GetAttributesRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -170,7 +170,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         """
         payload = payloads.GetAttributesRequestPayload()
         args = (payload, 'attribute_names', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attribute_names must be a list of strings",
             setattr,
@@ -189,7 +189,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
             'attribute_names',
             ['test-attribute-name-1', 0]
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attribute_names must be a list of strings; "
             "item 2 has type {0}".format(type(0)),
@@ -831,7 +831,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetAttributesResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -865,7 +865,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         """
         payload = payloads.GetAttributesResponsePayload()
         args = (payload, 'attributes', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attributes must be a list of attribute objects",
             setattr,
@@ -884,7 +884,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
             'attributes',
             [objects.Attribute(), 0]
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "attributes must be a list of attribute objects; "
             "item 2 has type {0}".format(type(0)),
@@ -933,7 +933,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         self.assertEqual(list(), payload._attributes)
 
         args = (self.encoding_sans_unique_identifier, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidKmipEncoding,
             "expected GetAttributes response unique identifier not found",
             payload.read,
@@ -990,7 +990,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The GetAttributes response unique identifier is required.",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_get_usage_allocation.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_usage_allocation.py
@@ -90,7 +90,7 @@ class TestGetUsageAllocationRequestPayload(testtools.TestCase):
         the unique identifier of a GetUsageAllocation request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.GetUsageAllocationRequestPayload,
@@ -99,7 +99,7 @@ class TestGetUsageAllocationRequestPayload(testtools.TestCase):
 
         payload = payloads.GetUsageAllocationRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -112,7 +112,7 @@ class TestGetUsageAllocationRequestPayload(testtools.TestCase):
         the usage limits count of a GetUsageAllocation request payload.
         """
         kwargs = {'usage_limits_count': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             payloads.GetUsageAllocationRequestPayload,
@@ -121,7 +121,7 @@ class TestGetUsageAllocationRequestPayload(testtools.TestCase):
 
         payload = payloads.GetUsageAllocationRequestPayload()
         args = (payload, 'usage_limits_count', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Usage limits count must be an integer.",
             setattr,
@@ -438,7 +438,7 @@ class TestGetUsageAllocationResponsePayload(testtools.TestCase):
         the unique identifier of a GetUsageAllocation response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.GetUsageAllocationResponsePayload,
@@ -447,7 +447,7 @@ class TestGetUsageAllocationResponsePayload(testtools.TestCase):
 
         payload = payloads.GetUsageAllocationResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_mac.py
+++ b/kmip/tests/unit/core/messages/payloads/test_mac.py
@@ -75,7 +75,7 @@ class TestMACRequestPayload(TestCase):
         kwargs = {'unique_identifier': 'invalid',
                   'cryptographic_parameters': None,
                   'data': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "unique identifier must be UniqueIdentifier type",
             payloads.MACRequestPayload, **kwargs)
 
@@ -83,7 +83,7 @@ class TestMACRequestPayload(TestCase):
         kwargs = {'unique_identifier': None,
                   'cryptographic_parameters': 'invalid',
                   'data': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be CryptographicParameters type",
             payloads.MACRequestPayload, **kwargs)
@@ -113,7 +113,7 @@ class TestMACRequestPayload(TestCase):
         """
         payload = payloads.MACRequestPayload()
         args = (self.encoding_no_data,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidKmipEncoding,
             "expected mac request data not found",
             payload.read,
@@ -143,7 +143,7 @@ class TestMACRequestPayload(TestCase):
             self.cryptographic_parameters,
             None)
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The mac request data is required",
             payload.write,
@@ -205,7 +205,7 @@ class TestMACResponsePayload(TestCase):
     def test_init_with_invalid_unique_identifier(self):
         kwargs = {'unique_identifier': 'invalid',
                   'mac_data': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "unique identifier must be UniqueIdentifier type",
             payloads.MACResponsePayload, **kwargs)
 
@@ -231,7 +231,7 @@ class TestMACResponsePayload(TestCase):
         """
         payload = payloads.MACResponsePayload()
         args = (self.encoding_no_unique_identifier,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidKmipEncoding,
             "expected mac response unique identifier not found",
             payload.read,
@@ -245,7 +245,7 @@ class TestMACResponsePayload(TestCase):
         """
         payload = payloads.MACResponsePayload()
         args = (self.encoding_no_mac_data,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidKmipEncoding,
             "expected mac response mac data not found",
             payload.read,
@@ -273,7 +273,7 @@ class TestMACResponsePayload(TestCase):
             None,
             self.mac_data)
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The mac response unique identifier is required",
             payload.write,
@@ -290,7 +290,7 @@ class TestMACResponsePayload(TestCase):
             self.unique_identifier,
             None)
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The mac response mac data is required",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_obtain_lease.py
+++ b/kmip/tests/unit/core/messages/payloads/test_obtain_lease.py
@@ -77,7 +77,7 @@ class TestObtainLeaseRequestPayload(testtools.TestCase):
         the unique identifier of an ObtainLease request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.ObtainLeaseRequestPayload,
@@ -86,7 +86,7 @@ class TestObtainLeaseRequestPayload(testtools.TestCase):
 
         payload = payloads.ObtainLeaseRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -352,7 +352,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
         the unique identifier of an ObtainLease response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.ObtainLeaseResponsePayload,
@@ -361,7 +361,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
 
         payload = payloads.ObtainLeaseResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -374,7 +374,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
         the lease time of an ObtainLease response payload.
         """
         kwargs = {'lease_time': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             payloads.ObtainLeaseResponsePayload,
@@ -383,7 +383,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
 
         payload = payloads.ObtainLeaseResponsePayload()
         args = (payload, 'lease_time', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Lease time must be an integer.",
             setattr,
@@ -396,7 +396,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
         the last change date of an ObtainLease response payload.
         """
         kwargs = {'last_change_date': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Last change date must be an integer.",
             payloads.ObtainLeaseResponsePayload,
@@ -405,7 +405,7 @@ class TestObtainLeaseResponsePayload(testtools.TestCase):
 
         payload = payloads.ObtainLeaseResponsePayload()
         args = (payload, 'last_change_date', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Last change date must be an integer.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_poll.py
+++ b/kmip/tests/unit/core/messages/payloads/test_poll.py
@@ -70,7 +70,7 @@ class TestPollRequestPayload(testtools.TestCase):
         the asynchronous correlation value of an Poll request payload.
         """
         kwargs = {'asynchronous_correlation_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             payloads.PollRequestPayload,
@@ -79,7 +79,7 @@ class TestPollRequestPayload(testtools.TestCase):
 
         payload = payloads.PollRequestPayload()
         args = (payload, 'asynchronous_correlation_value', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Asynchronous correlation value must be bytes.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_query.py
+++ b/kmip/tests/unit/core/messages/payloads/test_query.py
@@ -99,7 +99,7 @@ class TestQueryRequestPayload(TestCase):
         list is used to construct a QueryRequestPayload object.
         """
         kwargs = {'query_functions': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid query functions list",
             payloads.QueryRequestPayload, **kwargs)
 
@@ -109,7 +109,7 @@ class TestQueryRequestPayload(TestCase):
         item is used to construct a QueryRequestPayload object.
         """
         kwargs = {'query_functions': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid query function",
             payloads.QueryRequestPayload, **kwargs)
 
@@ -328,7 +328,7 @@ class TestQueryResponsePayload(TestCase):
         list is used to construct a QueryResponsePayload object.
         """
         kwargs = {'operations': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid operations list",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -338,7 +338,7 @@ class TestQueryResponsePayload(TestCase):
         item is used to construct a QueryResponsePayload object.
         """
         kwargs = {'operations': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid operation",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -348,7 +348,7 @@ class TestQueryResponsePayload(TestCase):
         list is used to construct a QueryResponsePayload object.
         """
         kwargs = {'object_types': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid object types list",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -358,7 +358,7 @@ class TestQueryResponsePayload(TestCase):
         item is used to construct a QueryResponsePayload object.
         """
         kwargs = {'object_types': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid object type",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -369,7 +369,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'vendor_identification': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid vendor identification",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -380,7 +380,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'server_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid server information",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -391,7 +391,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'application_namespaces': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid application namespaces list",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -402,7 +402,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'application_namespaces': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid application namespace",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -413,7 +413,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'extension_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid extension information list",
             payloads.QueryResponsePayload, **kwargs)
 
@@ -424,7 +424,7 @@ class TestQueryResponsePayload(TestCase):
         object.
         """
         kwargs = {'extension_information': ['invalid']}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid extension information",
             payloads.QueryResponsePayload, **kwargs)
 

--- a/kmip/tests/unit/core/messages/payloads/test_recover.py
+++ b/kmip/tests/unit/core/messages/payloads/test_recover.py
@@ -77,7 +77,7 @@ class TestRecoverRequestPayload(testtools.TestCase):
         the unique identifier of a Recover request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.RecoverRequestPayload,
@@ -86,7 +86,7 @@ class TestRecoverRequestPayload(testtools.TestCase):
 
         payload = payloads.RecoverRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -329,7 +329,7 @@ class TestRecoverResponsePayload(testtools.TestCase):
         the unique identifier of a Recover response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.RecoverResponsePayload,
@@ -338,7 +338,7 @@ class TestRecoverResponsePayload(testtools.TestCase):
 
         payload = payloads.RecoverResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,

--- a/kmip/tests/unit/core/messages/payloads/test_rekey.py
+++ b/kmip/tests/unit/core/messages/payloads/test_rekey.py
@@ -135,7 +135,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
         the unique identifier of a Rekey request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.RekeyRequestPayload,
@@ -143,7 +143,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
         )
 
         args = (payloads.RekeyRequestPayload(), 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -156,7 +156,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
         the offset of a Rekey request payload.
         """
         kwargs = {'offset': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Offset must be an integer.",
             payloads.RekeyRequestPayload,
@@ -164,7 +164,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
         )
 
         args = (payloads.RekeyRequestPayload(), 'offset', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Offset must be an integer.",
             setattr,
@@ -177,7 +177,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
         the template attribute of a Rekey request payload.
         """
         kwargs = {'template_attribute': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Template attribute must be a TemplateAttribute struct.",
             payloads.RekeyRequestPayload,
@@ -189,7 +189,7 @@ class TestRekeyRequestPayload(testtools.TestCase):
             'template_attribute',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Template attribute must be a TemplateAttribute struct.",
             setattr,
@@ -796,7 +796,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
         the unique identifier of a Rekey response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             payloads.RekeyResponsePayload,
@@ -804,7 +804,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
         )
 
         args = (payloads.RekeyResponsePayload(), 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -817,7 +817,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
         the template attribute of a Rekey response payload.
         """
         kwargs = {'template_attribute': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Template attribute must be a TemplateAttribute struct.",
             payloads.RekeyResponsePayload,
@@ -829,7 +829,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
             'template_attribute',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Template attribute must be a TemplateAttribute struct.",
             setattr,
@@ -903,7 +903,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
         """
         payload = payloads.RekeyResponsePayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "The Rekey response payload encoding is missing the unique "
             "identifier.",
@@ -969,7 +969,7 @@ class TestRekeyResponsePayload(testtools.TestCase):
         payload = payloads.RekeyResponsePayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "The Rekey response payload is missing the unique identifier.",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
@@ -66,7 +66,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'common_template_attribute': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key unique identifier",
             payloads.RekeyKeyPairRequestPayload, **kwargs)
 
@@ -75,7 +75,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'common_template_attribute': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid offset",
             payloads.RekeyKeyPairRequestPayload, **kwargs)
 
@@ -84,7 +84,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'common_template_attribute': 'invalid',
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid common template attribute",
             payloads.RekeyKeyPairRequestPayload, **kwargs)
 
@@ -93,7 +93,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'common_template_attribute': None,
                   'private_key_template_attribute': 'invalid',
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key template attribute",
             payloads.RekeyKeyPairRequestPayload, **kwargs)
 
@@ -102,7 +102,7 @@ class TestRekeyKeyPairRequestPayload(TestCase):
                   'common_template_attribute': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid public key template attribute",
             payloads.RekeyKeyPairRequestPayload, **kwargs)
 
@@ -235,7 +235,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_uuid': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key unique identifier",
             payloads.RekeyKeyPairResponsePayload, **kwargs)
 
@@ -244,7 +244,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_uuid': 'invalid',
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid public key unique identifier",
             payloads.RekeyKeyPairResponsePayload, **kwargs)
 
@@ -253,7 +253,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_uuid': None,
                   'private_key_template_attribute': 'invalid',
                   'public_key_template_attribute': None}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid private key template attribute",
             payloads.RekeyKeyPairResponsePayload, **kwargs)
 
@@ -262,7 +262,7 @@ class TestRekeyKeyPairResponsePayload(TestCase):
                   'public_key_uuid': None,
                   'private_key_template_attribute': None,
                   'public_key_template_attribute': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid public key template attribute",
             payloads.RekeyKeyPairResponsePayload, **kwargs)
 

--- a/kmip/tests/unit/core/messages/payloads/test_revoke.py
+++ b/kmip/tests/unit/core/messages/payloads/test_revoke.py
@@ -69,7 +69,7 @@ class TestRevokeRequestPayload(TestCase):
         Test that a TypeError exception is raised when an invalid UUID type
         is used to construct a RevokeRequestPayload object.
         """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid unique identifier",
             payloads.RevokeRequestPayload, "not-a-uuid")
 
@@ -79,7 +79,7 @@ class TestRevokeRequestPayload(TestCase):
         is used to construct a RevokeRequestPayload object.
         """
         reason = objects.RevocationReason()
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid compromise time",
             payloads.RevokeRequestPayload, self.uuid, reason, "not-a-date")
 
@@ -88,7 +88,7 @@ class TestRevokeRequestPayload(TestCase):
         Test that a TypeError exception is raised when an invalid UUID type
         is used to construct a RevokeRequestPayload object.
         """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid revocation reason",
             payloads.RevokeRequestPayload, self.uuid, "not-a-reason")
 
@@ -179,7 +179,7 @@ class TestRevokeResponsePayload(TestCase):
         Test that a TypeError exception is raised when an invalid Operations
         list is used to construct a RevokeResponsePayload object.
         """
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid unique identifier",
             payloads.RevokeResponsePayload, "not-a-uuid")
 

--- a/kmip/tests/unit/core/messages/payloads/test_sign.py
+++ b/kmip/tests/unit/core/messages/payloads/test_sign.py
@@ -101,7 +101,7 @@ class TestSignRequestPayload(testtools.TestCase):
         """
         payload = sign.SignRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -115,7 +115,7 @@ class TestSignRequestPayload(testtools.TestCase):
         """
         payload = sign.SignRequestPayload()
         args = (payload, 'cryptographic_parameters', b'\x01\x02\x03')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic parameters must be a CryptographicParameters "
             "struct",
@@ -130,7 +130,7 @@ class TestSignRequestPayload(testtools.TestCase):
         """
         payload = sign.SignRequestPayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             setattr,
@@ -190,7 +190,7 @@ class TestSignRequestPayload(testtools.TestCase):
         """
         payload = sign.SignRequestPayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.read,
@@ -238,7 +238,7 @@ class TestSignRequestPayload(testtools.TestCase):
         payload = sign.SignRequestPayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the data attribute",
             payload.write,
@@ -539,7 +539,7 @@ class TestSignResponsePayload(testtools.TestCase):
         """
         payload = sign.SignResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "unique identifier must be a string",
             setattr,
@@ -553,7 +553,7 @@ class TestSignResponsePayload(testtools.TestCase):
         """
         payload = sign.SignResponsePayload()
         args = (payload, 'signature_data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "signature data must be bytes",
             setattr,
@@ -588,7 +588,7 @@ class TestSignResponsePayload(testtools.TestCase):
         """
         payload = sign.SignResponsePayload()
         args = (self.empty_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.read,
@@ -597,7 +597,7 @@ class TestSignResponsePayload(testtools.TestCase):
 
         payload = sign.SignResponsePayload()
         args = (self.incomplete_encoding, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the signature data attribute",
             payload.read,
@@ -627,7 +627,7 @@ class TestSignResponsePayload(testtools.TestCase):
         payload = sign.SignResponsePayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "invalid payload missing the unique identifier attribute",
             payload.write,

--- a/kmip/tests/unit/core/messages/payloads/test_signature_verify.py
+++ b/kmip/tests/unit/core/messages/payloads/test_signature_verify.py
@@ -224,7 +224,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the unique identifier of a SignatureVerify request payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -233,7 +233,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -246,7 +246,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the cryptographic parameters of a SignatureVerify request payload.
         """
         kwargs = {'cryptographic_parameters': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -256,7 +256,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'cryptographic_parameters', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -270,7 +270,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the data of a SignatureVerify request payload.
         """
         kwargs = {'data': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Data must be bytes.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -279,7 +279,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Data must be bytes.",
             setattr,
@@ -292,7 +292,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the digested data of a SignatureVerify request payload.
         """
         kwargs = {'digested_data': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Digested data must be bytes.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -301,7 +301,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'digested_data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Digested data must be bytes.",
             setattr,
@@ -314,7 +314,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the signature data of a SignatureVerify request payload.
         """
         kwargs = {'signature_data': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Signature data must be bytes.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -323,7 +323,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'signature_data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Signature data must be bytes.",
             setattr,
@@ -336,7 +336,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the correlation value of a SignatureVerify request payload.
         """
         kwargs = {'correlation_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Correlation value must be bytes.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -345,7 +345,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'correlation_value', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Correlation value must be bytes.",
             setattr,
@@ -358,7 +358,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the init indicator of a SignatureVerify request payload.
         """
         kwargs = {'init_indicator': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Init indicator must be a boolean.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -367,7 +367,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'init_indicator', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Init indicator must be a boolean.",
             setattr,
@@ -380,7 +380,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
         the final indicator of a SignatureVerify request payload.
         """
         kwargs = {'final_indicator': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Final indicator must be a boolean.",
             signature_verify.SignatureVerifyRequestPayload,
@@ -389,7 +389,7 @@ class TestSignatureVerifyRequestPayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyRequestPayload()
         args = (payload, 'final_indicator', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Final indicator must be a boolean.",
             setattr,
@@ -1126,7 +1126,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         the unique identifier of a SignatureVerify response payload.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             signature_verify.SignatureVerifyResponsePayload,
@@ -1135,7 +1135,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (payload, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -1148,7 +1148,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         the validity indicator of a SignatureVerify response payload.
         """
         kwargs = {'validity_indicator': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Validity indicator must be a ValidityIndicator enumeration.",
             signature_verify.SignatureVerifyResponsePayload,
@@ -1157,7 +1157,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (payload, 'validity_indicator', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Validity indicator must be a ValidityIndicator enumeration.",
             setattr,
@@ -1170,7 +1170,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         the data of a SignatureVerify request payload.
         """
         kwargs = {'data': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Data must be bytes.",
             signature_verify.SignatureVerifyResponsePayload,
@@ -1179,7 +1179,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (payload, 'data', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Data must be bytes.",
             setattr,
@@ -1192,7 +1192,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         the correlation value of a SignatureVerify request payload.
         """
         kwargs = {'correlation_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Correlation value must be bytes.",
             signature_verify.SignatureVerifyResponsePayload,
@@ -1201,7 +1201,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
 
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (payload, 'correlation_value', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Correlation value must be bytes.",
             setattr,
@@ -1266,7 +1266,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         """
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (self.partial_encoding_missing_unique_id, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Parsed payload encoding is missing the unique identifier field.",
             payload.read,
@@ -1281,7 +1281,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         """
         payload = signature_verify.SignatureVerifyResponsePayload()
         args = (self.partial_encoding_missing_validity_ind, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Parsed payload encoding is missing the validity indicator field.",
             payload.read,
@@ -1329,7 +1329,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         payload = signature_verify.SignatureVerifyResponsePayload()
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Payload is missing the unique identifier field.",
             payload.write,
@@ -1347,7 +1347,7 @@ class TestSignatureVerifyResponsePayload(testtools.TestCase):
         )
         stream = utils.BytearrayStream()
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Payload is missing the validity indicator field.",
             payload.write,

--- a/kmip/tests/unit/core/objects/test_attribute.py
+++ b/kmip/tests/unit/core/objects/test_attribute.py
@@ -34,13 +34,13 @@ class TestAttribute(testtools.TestCase):
         objects.Attribute()
 
     def test_init_with_args(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_read(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_write(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_repr(self):
         """
@@ -80,31 +80,31 @@ class TestAttribute(testtools.TestCase):
         )
 
     def test_equal_on_equal(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_equal_on_not_equal_name(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_equal_on_not_equal_index(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_equal_on_not_equal_value(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_equal_on_type_mismatch(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_not_equal_on_equal(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_not_equal_on_not_equal_name(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_not_equal_on_not_equal_index(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_not_equal_on_not_equal_value(self):
-        self.skip('')
+        self.skipTest('')
 
     def test_not_equal_on_type_mismatch(self):
-        self.skip('')
+        self.skipTest('')

--- a/kmip/tests/unit/core/objects/test_credentials.py
+++ b/kmip/tests/unit/core/objects/test_credentials.py
@@ -85,7 +85,7 @@ class TestNonce(testtools.TestCase):
         the nonce ID of a Nonce struct.
         """
         kwargs = {'nonce_id': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce ID must be bytes.",
             objects.Nonce,
@@ -94,7 +94,7 @@ class TestNonce(testtools.TestCase):
 
         nonce = objects.Nonce()
         args = (nonce, "nonce_id", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce ID must be bytes.",
             setattr,
@@ -107,7 +107,7 @@ class TestNonce(testtools.TestCase):
         the nonce value of a Nonce struct.
         """
         kwargs = {'nonce_value': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce value must be bytes.",
             objects.Nonce,
@@ -116,7 +116,7 @@ class TestNonce(testtools.TestCase):
 
         nonce = objects.Nonce()
         args = (nonce, "nonce_value", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce value must be bytes.",
             setattr,
@@ -151,7 +151,7 @@ class TestNonce(testtools.TestCase):
         self.assertEqual(None, nonce.nonce_value)
 
         args = (self.encoding_missing_nonce_id, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Nonce encoding missing the nonce ID.",
             nonce.read,
@@ -169,7 +169,7 @@ class TestNonce(testtools.TestCase):
         self.assertEqual(None, nonce.nonce_value)
 
         args = (self.encoding_missing_nonce_value, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Nonce encoding missing the nonce value.",
             nonce.read,
@@ -202,7 +202,7 @@ class TestNonce(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Nonce struct is missing the nonce ID.",
             nonce.write,
@@ -220,7 +220,7 @@ class TestNonce(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Nonce struct is missing the nonce value.",
             nonce.write,
@@ -464,7 +464,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
         the username of a UsernamePasswordCredential struct.
         """
         kwargs = {'username': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Username must be a string.",
             objects.UsernamePasswordCredential,
@@ -473,7 +473,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
 
         credential = objects.UsernamePasswordCredential()
         args = (credential, "username", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Username must be a string.",
             setattr,
@@ -486,7 +486,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
         the password of a UsernamePasswordCredential struct.
         """
         kwargs = {'password': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Password must be a string.",
             objects.UsernamePasswordCredential,
@@ -495,7 +495,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
 
         credential = objects.UsernamePasswordCredential()
         args = (credential, "password", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Password must be a string.",
             setattr,
@@ -529,7 +529,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
         self.assertEqual(None, credential.password)
 
         args = (self.encoding_missing_username, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Username/password credential encoding missing the username.",
             credential.read,
@@ -579,7 +579,7 @@ class TestUsernamePasswordCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Username/password credential struct missing the username.",
             credential.write,
@@ -926,7 +926,7 @@ class TestDeviceCredential(testtools.TestCase):
         the device serial number of a DeviceCredential struct.
         """
         kwargs = {'device_serial_number': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Device serial number must be a string.",
             objects.DeviceCredential,
@@ -935,7 +935,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "device_serial_number", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Device serial number must be a string.",
             setattr,
@@ -948,7 +948,7 @@ class TestDeviceCredential(testtools.TestCase):
         the password of a DeviceCredential struct.
         """
         kwargs = {'password': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Password must be a string.",
             objects.DeviceCredential,
@@ -957,7 +957,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "password", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Password must be a string.",
             setattr,
@@ -970,7 +970,7 @@ class TestDeviceCredential(testtools.TestCase):
         the device identifier of a DeviceCredential struct.
         """
         kwargs = {'device_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Device identifier must be a string.",
             objects.DeviceCredential,
@@ -979,7 +979,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "device_identifier", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Device identifier must be a string.",
             setattr,
@@ -992,7 +992,7 @@ class TestDeviceCredential(testtools.TestCase):
         the network identifier of a DeviceCredential struct.
         """
         kwargs = {'network_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Network identifier must be a string.",
             objects.DeviceCredential,
@@ -1001,7 +1001,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "network_identifier", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Network identifier must be a string.",
             setattr,
@@ -1014,7 +1014,7 @@ class TestDeviceCredential(testtools.TestCase):
         the machine identifier of a DeviceCredential struct.
         """
         kwargs = {'machine_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Machine identifier must be a string.",
             objects.DeviceCredential,
@@ -1023,7 +1023,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "machine_identifier", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Machine identifier must be a string.",
             setattr,
@@ -1036,7 +1036,7 @@ class TestDeviceCredential(testtools.TestCase):
         the media identifier of a DeviceCredential struct.
         """
         kwargs = {'media_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Media identifier must be a string.",
             objects.DeviceCredential,
@@ -1045,7 +1045,7 @@ class TestDeviceCredential(testtools.TestCase):
 
         credential = objects.DeviceCredential()
         args = (credential, "media_identifier", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Media identifier must be a string.",
             setattr,
@@ -1837,7 +1837,7 @@ class TestAttestationCredential(testtools.TestCase):
         the nonce of an AttestationCredential struct.
         """
         kwargs = {"nonce": "invalid"}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce must be a Nonce struct.",
             objects.AttestationCredential,
@@ -1846,7 +1846,7 @@ class TestAttestationCredential(testtools.TestCase):
 
         credential = objects.AttestationCredential()
         args = (credential, "nonce", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Nonce must be a Nonce struct.",
             setattr,
@@ -1859,7 +1859,7 @@ class TestAttestationCredential(testtools.TestCase):
         the attestation type of an AttestationCredential struct.
         """
         kwargs = {"attestation_type": "invalid"}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation type must be an AttestationType enumeration.",
             objects.AttestationCredential,
@@ -1868,7 +1868,7 @@ class TestAttestationCredential(testtools.TestCase):
 
         credential = objects.AttestationCredential()
         args = (credential, "attestation_type", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation type must be an AttestationType enumeration.",
             setattr,
@@ -1881,7 +1881,7 @@ class TestAttestationCredential(testtools.TestCase):
         the attestation measurement of an AttestationCredential struct.
         """
         kwargs = {"attestation_measurement": 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation measurement must be bytes.",
             objects.AttestationCredential,
@@ -1890,7 +1890,7 @@ class TestAttestationCredential(testtools.TestCase):
 
         credential = objects.AttestationCredential()
         args = (credential, "attestation_measurement", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation measurement must be bytes.",
             setattr,
@@ -1903,7 +1903,7 @@ class TestAttestationCredential(testtools.TestCase):
         the attestation assertion of an AttestationCredential struct.
         """
         kwargs = {"attestation_assertion": 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation assertion must be bytes.",
             objects.AttestationCredential,
@@ -1912,7 +1912,7 @@ class TestAttestationCredential(testtools.TestCase):
 
         credential = objects.AttestationCredential()
         args = (credential, "attestation_assertion", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attestation assertion must be bytes.",
             setattr,
@@ -1966,7 +1966,7 @@ class TestAttestationCredential(testtools.TestCase):
         self.assertEqual(None, credential.attestation_assertion)
 
         args = (self.encoding_missing_nonce, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential encoding is missing the nonce.",
             credential.read,
@@ -1987,7 +1987,7 @@ class TestAttestationCredential(testtools.TestCase):
         self.assertEqual(None, credential.attestation_assertion)
 
         args = (self.encoding_missing_attestation_type, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential encoding is missing the attestation type.",
             credential.read,
@@ -2071,7 +2071,7 @@ class TestAttestationCredential(testtools.TestCase):
         self.assertEqual(None, credential.attestation_assertion)
 
         args = (self.encoding_missing_attestation, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential encoding is missing either the "
             "attestation measurement or the attestation assertion.",
@@ -2113,7 +2113,7 @@ class TestAttestationCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential struct is missing the nonce.",
             credential.write,
@@ -2136,7 +2136,7 @@ class TestAttestationCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential struct is missing the attestation type.",
             credential.write,
@@ -2211,7 +2211,7 @@ class TestAttestationCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Attestation credential struct is missing either the attestation "
             "measurement or the attestation assertion.",
@@ -2615,7 +2615,7 @@ class TestCredential(testtools.TestCase):
         the credential type of a Credential struct.
         """
         kwargs = {"credential_type": "invalid"}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credential type must be a CredentialType enumeration.",
             objects.Credential,
@@ -2624,7 +2624,7 @@ class TestCredential(testtools.TestCase):
 
         credential = objects.Credential()
         args = (credential, "credential_type", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credential type must be a CredentialType enumeration.",
             setattr,
@@ -2637,7 +2637,7 @@ class TestCredential(testtools.TestCase):
         the credential value of a Credential struct.
         """
         kwargs = {"credential_value": "invalid"}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credential value must be a CredentialValue struct.",
             objects.Credential,
@@ -2646,7 +2646,7 @@ class TestCredential(testtools.TestCase):
 
         credential = objects.Credential()
         args = (credential, "credential_value", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Credential value must be a CredentialValue struct.",
             setattr,
@@ -2712,7 +2712,7 @@ class TestCredential(testtools.TestCase):
         self.assertEqual(None, credential.credential_value)
 
         args = (self.encoding_missing_credential_type, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Credential encoding missing the credential type.",
             credential.read,
@@ -2739,7 +2739,7 @@ class TestCredential(testtools.TestCase):
         self.assertEqual(None, credential.credential_value)
 
         args = (self.encoding_unknown_credential_type, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Credential encoding includes unrecognized credential type.",
             credential.read,
@@ -2758,7 +2758,7 @@ class TestCredential(testtools.TestCase):
         self.assertEqual(None, credential.credential_value)
 
         args = (self.encoding_missing_credential_value, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Credential encoding missing the credential value.",
             credential.read,
@@ -2817,7 +2817,7 @@ class TestCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Credential struct missing the credential type.",
             credential.write,
@@ -2835,7 +2835,7 @@ class TestCredential(testtools.TestCase):
         stream = utils.BytearrayStream()
 
         args = (stream, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Credential struct missing the credential value.",
             credential.write,

--- a/kmip/tests/unit/core/objects/test_extension_information.py
+++ b/kmip/tests/unit/core/objects/test_extension_information.py
@@ -85,7 +85,7 @@ class TestExtensionInformation(TestCase):
         ExtensionName is used to construct an ExtensionInformation object.
         """
         kwargs = {'extension_name': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid extension name",
             ExtensionInformation, **kwargs)
 
@@ -95,7 +95,7 @@ class TestExtensionInformation(TestCase):
         ExtensionTag is used to construct an ExtensionInformation object.
         """
         kwargs = {'extension_tag': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid extension tag",
             ExtensionInformation, **kwargs)
 
@@ -105,7 +105,7 @@ class TestExtensionInformation(TestCase):
         ExtensionType is used to construct an ExtensionInformation object.
         """
         kwargs = {'extension_type': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError, "invalid extension type",
             ExtensionInformation, **kwargs)
 

--- a/kmip/tests/unit/core/objects/test_objects.py
+++ b/kmip/tests/unit/core/objects/test_objects.py
@@ -412,7 +412,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
         the unique identifier of an EncryptionKeyInformation struct.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             objects.EncryptionKeyInformation,
@@ -421,7 +421,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
 
         encryption_key_information = objects.EncryptionKeyInformation()
         args = (encryption_key_information, 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -434,7 +434,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
         the cryptographic parameters of an EncryptionKeyInformation struct.
         """
         kwargs = {'cryptographic_parameters': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -448,7 +448,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
             'cryptographic_parameters',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -517,7 +517,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
         """
         encryption_key_information = objects.EncryptionKeyInformation()
         args = (self.empty_encoding,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the unique identifier attribute.",
             encryption_key_information.read,
@@ -564,7 +564,7 @@ class TestEncryptionKeyInformation(testtools.TestCase):
         encryption_key_information = objects.EncryptionKeyInformation()
         stream = utils.BytearrayStream()
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the unique identifier attribute.",
             encryption_key_information.write,
@@ -885,7 +885,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         the unique identifier of a MACSignatureKeyInformation struct.
         """
         kwargs = {'unique_identifier': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             objects.MACSignatureKeyInformation,
@@ -893,7 +893,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         )
 
         args = (objects.MACSignatureKeyInformation(), 'unique_identifier', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             setattr,
@@ -906,7 +906,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         the cryptographic parameters of a MACSignatureKeyInformation struct.
         """
         kwargs = {'cryptographic_parameters': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -919,7 +919,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
             'cryptographic_parameters',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a CryptographicParameters "
             "struct.",
@@ -994,7 +994,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         """
         mac_signature_key_information = objects.MACSignatureKeyInformation()
         args = (self.empty_encoding,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the unique identifier attribute.",
             mac_signature_key_information.read,
@@ -1041,7 +1041,7 @@ class TestMACSignatureKeyInformation(testtools.TestCase):
         mac_signature_key_information = objects.MACSignatureKeyInformation()
         stream = utils.BytearrayStream()
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the unique identifier attribute.",
             mac_signature_key_information.write,
@@ -1479,7 +1479,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the wrapping method of a KeyWrappingData struct.
         """
         kwargs = {'wrapping_method': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Wrapping method must be a WrappingMethod enumeration.",
             objects.KeyWrappingData,
@@ -1487,7 +1487,7 @@ class TestKeyWrappingData(testtools.TestCase):
         )
 
         args = (objects.KeyWrappingData(), 'wrapping_method', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Wrapping method must be a WrappingMethod enumeration.",
             setattr,
@@ -1500,7 +1500,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the encryption key information of a KeyWrappingData struct.
         """
         kwargs = {'encryption_key_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encryption key information must be an EncryptionKeyInformation "
             "struct.",
@@ -1513,7 +1513,7 @@ class TestKeyWrappingData(testtools.TestCase):
             'encryption_key_information',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encryption key information must be an EncryptionKeyInformation "
             "struct.",
@@ -1527,7 +1527,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the MAC/signature key information of a KeyWrappingData struct.
         """
         kwargs = {'mac_signature_key_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature key information must be an "
             "MACSignatureKeyInformation struct.",
@@ -1540,7 +1540,7 @@ class TestKeyWrappingData(testtools.TestCase):
             'mac_signature_key_information',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature key information must be an "
             "MACSignatureKeyInformation struct.",
@@ -1554,7 +1554,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the MAC/signature of a KeyWrappingData struct.
         """
         kwargs = {'mac_signature': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature must be bytes.",
             objects.KeyWrappingData,
@@ -1566,7 +1566,7 @@ class TestKeyWrappingData(testtools.TestCase):
             'mac_signature',
             0
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature must be bytes.",
             setattr,
@@ -1579,7 +1579,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the IV/counter/nonce of a KeyWrappingData struct.
         """
         kwargs = {'iv_counter_nonce': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "IV/counter/nonce must be bytes.",
             objects.KeyWrappingData,
@@ -1591,7 +1591,7 @@ class TestKeyWrappingData(testtools.TestCase):
             'iv_counter_nonce',
             0
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "IV/counter/nonce must be bytes.",
             setattr,
@@ -1604,7 +1604,7 @@ class TestKeyWrappingData(testtools.TestCase):
         the encoding option of a KeyWrappingData struct.
         """
         kwargs = {'encoding_option': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encoding option must be an EncodingOption enumeration.",
             objects.KeyWrappingData,
@@ -1616,7 +1616,7 @@ class TestKeyWrappingData(testtools.TestCase):
             'encoding_option',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encoding option must be an EncodingOption enumeration.",
             setattr,
@@ -1741,7 +1741,7 @@ class TestKeyWrappingData(testtools.TestCase):
         """
         key_wrapping_data = objects.KeyWrappingData()
         args = (self.empty_encoding,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the wrapping method attribute.",
             key_wrapping_data.read,
@@ -1805,7 +1805,7 @@ class TestKeyWrappingData(testtools.TestCase):
         key_wrapping_data = objects.KeyWrappingData()
         stream = utils.BytearrayStream()
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the wrapping method attribute.",
             key_wrapping_data.write,
@@ -2447,7 +2447,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         the wrapping method of a KeyWrappingSpecification struct.
         """
         kwargs = {'wrapping_method': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Wrapping method must be a WrappingMethod enumeration.",
             objects.KeyWrappingSpecification,
@@ -2455,7 +2455,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         )
 
         args = (objects.KeyWrappingSpecification(), 'wrapping_method', 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Wrapping method must be a WrappingMethod enumeration.",
             setattr,
@@ -2468,7 +2468,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         the encryption key information of a KeyWrappingSpecification struct.
         """
         kwargs = {'encryption_key_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encryption key information must be an EncryptionKeyInformation "
             "struct.",
@@ -2481,7 +2481,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
             'encryption_key_information',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encryption key information must be an EncryptionKeyInformation "
             "struct.",
@@ -2496,7 +2496,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         struct.
         """
         kwargs = {'mac_signature_key_information': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature key information must be an "
             "MACSignatureKeyInformation struct.",
@@ -2509,7 +2509,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
             'mac_signature_key_information',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature key information must be an "
             "MACSignatureKeyInformation struct.",
@@ -2523,7 +2523,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         the attribute names of a KeyWrappingSpecification struct.
         """
         kwargs = {'attribute_names': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attribute names must be a list of strings.",
             objects.KeyWrappingSpecification,
@@ -2535,7 +2535,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
             'attribute_names',
             ['valid', 0]
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Attribute names must be a list of strings.",
             setattr,
@@ -2548,7 +2548,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         the encoding option of a KeyWrappingSpecification struct.
         """
         kwargs = {'encoding_option': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encoding option must be an EncodingOption enumeration.",
             objects.KeyWrappingSpecification,
@@ -2560,7 +2560,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
             'encoding_option',
             'invalid'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encoding option must be an EncodingOption enumeration.",
             setattr,
@@ -2698,7 +2698,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         """
         key_wrapping_specification = objects.KeyWrappingSpecification()
         args = (self.empty_encoding,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the wrapping method attribute.",
             key_wrapping_specification.read,
@@ -2761,7 +2761,7 @@ class TestKeyWrappingSpecification(testtools.TestCase):
         key_wrapping_specification = objects.KeyWrappingSpecification()
         stream = utils.BytearrayStream()
         args = (stream,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "Invalid struct missing the wrapping method attribute.",
             key_wrapping_specification.write,

--- a/kmip/tests/unit/core/primitives/test_base.py
+++ b/kmip/tests/unit/core/primitives/test_base.py
@@ -185,9 +185,11 @@ class TestBase(testtools.TestCase):
         self.assertRaises(TypeError, base.write_length, self.stream)
 
     def test_write_length_overflow(self):
-        self.skip('No easy way to test with a number requiring more than '
-                  '2 ** 0xffffffff bytes for representation. Test preserved '
-                  'for completeness.')
+        self.skipTest(
+            'No easy way to test with a number requiring more than '
+            '2 ** 0xffffffff bytes for representation. Test preserved '
+            'for completeness.'
+        )
 
     def test_write_value(self):
         base = primitives.Base()

--- a/kmip/tests/unit/core/test_policy.py
+++ b/kmip/tests/unit/core/test_policy.py
@@ -56,7 +56,7 @@ class TestPolicy(testtools.TestCase):
 
         args = (object_policy, )
         regex = "'INVALID' is not a valid ObjectType value."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             regex,
             policy.parse_policy,
@@ -71,7 +71,7 @@ class TestPolicy(testtools.TestCase):
 
         args = (object_policy, )
         regex = "'INVALID' is not a valid Operation value."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             regex,
             policy.parse_policy,
@@ -87,7 +87,7 @@ class TestPolicy(testtools.TestCase):
 
         args = (object_policy, )
         regex = "'INVALID' is not a valid Policy value."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             regex,
             policy.parse_policy,
@@ -211,7 +211,7 @@ class TestPolicy(testtools.TestCase):
 
         args = (policy_file.name, )
         regex = "Policy 'test' contains an invalid section named: invalid"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             regex,
             policy.read_policy_from_file,
@@ -263,7 +263,7 @@ class TestPolicy(testtools.TestCase):
         regex = "Loading the policy file '{}' generated a JSON error:".format(
             policy_file.name
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             regex,
             policy.read_policy_from_file,

--- a/kmip/tests/unit/core/test_utils.py
+++ b/kmip/tests/unit/core/test_utils.py
@@ -114,11 +114,11 @@ class TestBytearrayStream(TestCase):
 
     def test_read(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')
 
     def test_write(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')
 
     def test_peek(self):
         # TODO (peter-hamilton) Finish implementation.
@@ -130,16 +130,16 @@ class TestBytearrayStream(TestCase):
 
     def test_peek_overflow(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')
 
     def test_peek_empty(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')
 
     def test_peek_none(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')
 
     def test_length(self):
         # TODO (peter-hamilton) Finish implementation.
-        self.skip('')
+        self.skipTest('')

--- a/kmip/tests/unit/pie/objects/test_key.py
+++ b/kmip/tests/unit/pie/objects/test_key.py
@@ -102,7 +102,7 @@ class TestKey(TestCase):
         """
         dummy = DummyKey()
         args = (dummy, 'key_wrapping_data', 'invalid')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key wrapping data must be a dictionary.",
             setattr,

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -432,7 +432,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.create.return_value = result
         args = [enums.CryptographicAlgorithm.AES, 256]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.create, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -698,7 +698,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.create_key_pair.return_value = result
         args = [enums.CryptographicAlgorithm.RSA, 2048]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg,
             client.create_key_pair, *args)
 
@@ -738,7 +738,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'uid': 0}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The unique identifier must be a string.",
                 client.rekey,
@@ -754,7 +754,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'offset': 'invalid'}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The offset must be an integer.",
                 client.rekey,
@@ -807,7 +807,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'deactivation_date': 10000
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.rekey,
@@ -851,7 +851,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'uid': 0}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The unique identifier must be a string.",
                 client.check,
@@ -867,7 +867,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'usage_limits_count': 'invalid'}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The usage limits count must be an integer.",
                 client.check,
@@ -883,7 +883,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'cryptographic_usage_mask': 'invalid'}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The cryptographic usage mask must be a list of "
                 "CryptographicUsageMask enumerations.",
@@ -900,7 +900,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         kwargs = {'lease_time': 'invalid'}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "The lease time must be an integer.",
                 client.check,
@@ -962,7 +962,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'lease_time': 10000
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.check,
@@ -1022,7 +1022,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = ['1']
         kwargs = {'key_wrapping_specification': 'invalid'}
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "Key wrapping specification must be a dictionary.",
                 client.get,
@@ -1063,7 +1063,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.get.return_value = result
         args = ['id']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.get, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1120,7 +1120,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         args = [0]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "uid must be a string",
                 client.get_attributes,
@@ -1136,7 +1136,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         args = [None, 0]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "attribute_names must be a list of strings",
                 client.get_attributes,
@@ -1152,7 +1152,7 @@ class TestProxyKmipClient(testtools.TestCase):
         """
         args = [None, [0]]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "attribute_names must be a list of strings",
                 client.get_attributes,
@@ -1199,7 +1199,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.get_attributes.return_value = result
         args = ['id', []]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.get_attributes, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1282,7 +1282,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.get_attribute_list.return_value = result
         args = ['id']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.get_attribute_list, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1347,7 +1347,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.activate.return_value = result
         args = ['id']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.activate, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1397,7 +1397,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [revocation_reason_invalid, uuid, revocation_message,
                 compromise_occurrence_date]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "revocation_reason must be a RevocationReasonCode enumeration",
                 client.revoke,
@@ -1406,7 +1406,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [revocation_reason, uuid_invalid, revocation_message,
                 compromise_occurrence_date]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "uid must be a string",
                 client.revoke,
@@ -1415,7 +1415,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [revocation_reason, uuid, revocation_message_invalid,
                 compromise_occurrence_date]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "revocation_message must be a string",
                 client.revoke,
@@ -1424,7 +1424,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [revocation_reason, uuid, revocation_message,
                 compromise_occurrence_date_invalid]
         with ProxyKmipClient() as client:
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 TypeError,
                 "compromise_occurrence_date must be an integer",
                 client.revoke,
@@ -1476,7 +1476,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [revocation_reason, uuid, revocation_message,
                 compromise_occurrence_date]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.revoke, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1541,7 +1541,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.destroy.return_value = result
         args = ['id']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.destroy, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1626,7 +1626,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.register.return_value = result
         args = [key]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.register, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -1723,7 +1723,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_algorithm': enums.CryptographicAlgorithm.AES
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Object type must be an ObjectType enumeration.",
             client.derive_key,
@@ -1762,7 +1762,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_algorithm': enums.CryptographicAlgorithm.AES
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifiers must be a list of strings.",
             client.derive_key,
@@ -1786,7 +1786,7 @@ class TestProxyKmipClient(testtools.TestCase):
             }
         ]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifiers must be a list of strings.",
             client.derive_key,
@@ -1825,7 +1825,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_algorithm': enums.CryptographicAlgorithm.AES
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Derivation method must be a DerivationMethod enumeration.",
             client.derive_key,
@@ -1855,7 +1855,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_algorithm': enums.CryptographicAlgorithm.AES
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Derivation parameters must be a dictionary.",
             client.derive_key,
@@ -1939,7 +1939,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_algorithm': enums.CryptographicAlgorithm.AES
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.derive_key,
@@ -2005,7 +2005,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             client.encrypt,
@@ -2020,7 +2020,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "uid must be a string",
             client.encrypt,
@@ -2035,7 +2035,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic_parameters must be a dict",
             client.encrypt,
@@ -2050,7 +2050,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': {}
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "iv_counter_nonce must be bytes",
             client.encrypt,
@@ -2108,7 +2108,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.encrypt,
@@ -2172,7 +2172,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "data must be bytes",
             client.decrypt,
@@ -2187,7 +2187,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "uid must be a string",
             client.decrypt,
@@ -2202,7 +2202,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "cryptographic_parameters must be a dict",
             client.decrypt,
@@ -2217,7 +2217,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': {}
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "iv_counter_nonce must be bytes",
             client.decrypt,
@@ -2275,7 +2275,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'iv_counter_nonce': b'\x00\x00\x00\x00'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.decrypt,
@@ -2364,7 +2364,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'uid': '1',
             'cryptographic_parameters': {}
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Data to be signed must be bytes.",
             client.sign,
@@ -2379,7 +2379,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'uid': 0,
             'cryptographic_parameters': {}
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             client.sign,
@@ -2391,7 +2391,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'uid': '1',
             'cryptographic_parameters': 'invalid'
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a dictionary.",
             client.sign,
@@ -2418,7 +2418,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_parameters': {}
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Message must be bytes.",
             client.signature_verify,
@@ -2435,7 +2435,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_parameters': {}
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Signature must be bytes.",
             client.signature_verify,
@@ -2451,7 +2451,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'uid': 0,
             'cryptographic_parameters': {}
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Unique identifier must be a string.",
             client.signature_verify,
@@ -2467,7 +2467,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'uid': '1',
             'cryptographic_parameters': 'invalid'
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a dictionary.",
             client.signature_verify,
@@ -2529,7 +2529,7 @@ class TestProxyKmipClient(testtools.TestCase):
             'cryptographic_parameters': {}
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure,
             error_message,
             client.signature_verify,
@@ -2621,7 +2621,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client.proxy.mac.return_value = result
         args = [data, uuid, algorithm]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.mac, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -2819,7 +2819,7 @@ class TestProxyKmipClient(testtools.TestCase):
         args = [maximum_items, storage_status_mask,
                 object_group_member, attributes]
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             KmipOperationFailure, error_msg, client.locate, *args)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -2873,7 +2873,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client = ProxyKmipClient()
         args = ['invalid']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Cryptographic parameters must be a dictionary.",
             client._build_cryptographic_parameters,
@@ -2921,7 +2921,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client = ProxyKmipClient()
         args = ['invalid']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Encryption key information must be a dictionary.",
             client._build_encryption_key_information,
@@ -2969,7 +2969,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client = ProxyKmipClient()
         args = ['invalid']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "MAC/signature key information must be a dictionary.",
             client._build_mac_signature_key_information,
@@ -3058,7 +3058,7 @@ class TestProxyKmipClient(testtools.TestCase):
         client = ProxyKmipClient()
         args = ['invalid']
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "Key wrapping specification must be a dictionary.",
             client._build_key_wrapping_specification,

--- a/kmip/tests/unit/services/server/auth/test_slugs.py
+++ b/kmip/tests/unit/services/server/auth/test_slugs.py
@@ -95,7 +95,7 @@ class TestSLUGSConnector(testtools.TestCase):
         the URL of a SLUGSConnector.
         """
         kwargs = {'url': 0}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "URL must be a string.",
             auth.SLUGSConnector,
@@ -104,7 +104,7 @@ class TestSLUGSConnector(testtools.TestCase):
 
         connector = auth.SLUGSConnector()
         args = (connector, "url", 0)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             TypeError,
             "URL must be a string.",
             setattr,
@@ -158,7 +158,7 @@ class TestSLUGSConnector(testtools.TestCase):
         connector = auth.SLUGSConnector()
 
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The SLUGS URL must be specified.",
             connector.authenticate,
@@ -183,7 +183,7 @@ class TestSLUGSConnector(testtools.TestCase):
             url="http://127.0.0.1:8080/test/slugs/"
         )
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "A connection could not be established using the SLUGS URL.",
             connector.authenticate,
@@ -212,7 +212,7 @@ class TestSLUGSConnector(testtools.TestCase):
             url="http://127.0.0.1:8080/test/slugs/"
         )
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Unrecognized user ID: John Doe",
             connector.authenticate,
@@ -243,7 +243,7 @@ class TestSLUGSConnector(testtools.TestCase):
             url="http://127.0.0.1:8080/test/slugs/"
         )
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Group information could not be retrieved for user ID: John Doe",
             connector.authenticate,

--- a/kmip/tests/unit/services/server/auth/test_utils.py
+++ b/kmip/tests/unit/services/server/auth/test_utils.py
@@ -243,7 +243,7 @@ class TestUtils(testtools.TestCase):
         mock_get.return_value = ["John Doe", "Jane Doe"]
 
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Multiple client identities found.",
             utils.get_client_identity_from_certificate,
@@ -261,7 +261,7 @@ class TestUtils(testtools.TestCase):
         mock_get.return_value = []
 
         args = ("test", )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The certificate does not define any subject common names. Client "
             "identity unavailable.",

--- a/kmip/tests/unit/services/server/crypto/test_engine.py
+++ b/kmip/tests/unit/services/server/crypto/test_engine.py
@@ -275,7 +275,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (None, b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Encryption algorithm is required.",
             engine.encrypt,
@@ -283,7 +283,7 @@ class TestCryptographyEngine(testtools.TestCase):
         )
 
         args = ('invalid', b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Encryption algorithm 'invalid' is not a supported symmetric "
             "encryption algorithm.",
@@ -299,7 +299,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (enums.CryptographicAlgorithm.AES, b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "Invalid key bytes for the specified encryption algorithm.",
             engine.encrypt,
@@ -333,7 +333,7 @@ class TestCryptographyEngine(testtools.TestCase):
             b'\x0F\x0E\x0D\x0C\x0B\x0A\x09\x08'
             b'\x07\x06\x05\x04\x03\x02\x01\x00'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Cipher mode is required.",
             engine.encrypt,
@@ -341,7 +341,7 @@ class TestCryptographyEngine(testtools.TestCase):
         )
 
         kwargs = {'cipher_mode': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Cipher mode 'invalid' is not a supported mode.",
             engine.encrypt,
@@ -393,7 +393,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = ('invalid', b'', b'', None, None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic algorithm 'invalid' is not supported for "
             "asymmetric encryption.",
@@ -417,7 +417,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': enums.PaddingMethod.OAEP,
             'hashing_algorithm': 'invalid'
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The hashing algorithm 'invalid' is not supported for asymmetric "
             "encryption.",
@@ -442,7 +442,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': 'invalid',
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The padding method 'invalid' is not supported for asymmetric "
             "encryption.",
@@ -467,7 +467,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': enums.PaddingMethod.OAEP,
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "The public key bytes could not be loaded.",
             engine.encrypt,
@@ -483,7 +483,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = ('invalid', b'', b'', None, None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic algorithm 'invalid' is not supported for "
             "asymmetric decryption.",
@@ -507,7 +507,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': enums.PaddingMethod.OAEP,
             'hashing_algorithm': 'invalid'
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The hashing algorithm 'invalid' is not supported for asymmetric "
             "decryption.",
@@ -532,7 +532,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': 'invalid',
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The padding method 'invalid' is not supported for asymmetric "
             "decryption.",
@@ -557,7 +557,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'padding_method': enums.PaddingMethod.OAEP,
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "The private key bytes could not be loaded.",
             engine.decrypt,
@@ -573,7 +573,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (None, b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Decryption algorithm is required.",
             engine.decrypt,
@@ -581,7 +581,7 @@ class TestCryptographyEngine(testtools.TestCase):
         )
 
         args = ('invalid', b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Decryption algorithm 'invalid' is not a supported symmetric "
             "decryption algorithm.",
@@ -597,7 +597,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (enums.CryptographicAlgorithm.AES, b'', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "Invalid key bytes for the specified decryption algorithm.",
             engine.decrypt,
@@ -618,7 +618,7 @@ class TestCryptographyEngine(testtools.TestCase):
             b'\x0F\x0E\x0D\x0C\x0B\x0A\x09\x08'
             b'\x07\x06\x05\x04\x03\x02\x01\x00'
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Cipher mode is required.",
             engine.decrypt,
@@ -626,7 +626,7 @@ class TestCryptographyEngine(testtools.TestCase):
         )
 
         kwargs = {'cipher_mode': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Cipher mode 'invalid' is not a supported mode.",
             engine.decrypt,
@@ -652,7 +652,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'cipher_mode': enums.BlockCipherMode.CBC,
             'padding_method': enums.PaddingMethod.PKCS5
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "IV/nonce is required.",
             engine.decrypt,
@@ -673,7 +673,7 @@ class TestCryptographyEngine(testtools.TestCase):
             None
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Padding method is required.",
             engine._handle_symmetric_padding,
@@ -686,7 +686,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'invalid'
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Padding method 'invalid' is not supported.",
             engine._handle_symmetric_padding,
@@ -705,7 +705,7 @@ class TestCryptographyEngine(testtools.TestCase):
             16
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Hash algorithm is required.",
             engine.derive_key,
@@ -727,7 +727,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hash_algorithm': 'invalid'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Hash algorithm 'invalid' is not a supported hashing algorithm.",
             engine.derive_key,
@@ -752,7 +752,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'key_material': b'\x0A\x0B\x0C\x0D'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "For hash-based key derivation, specify only derivation data or "
             "key material, not both.",
@@ -776,7 +776,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hash_algorithm': enums.HashingAlgorithm.SHA_256
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "For hash-based key derivation, derivation data or key material "
             "must be specified.",
@@ -800,7 +800,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hash_algorithm': enums.HashingAlgorithm.SHA_256
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "For PBKDF2 key derivation, salt must be specified.",
             engine.derive_key,
@@ -824,7 +824,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'salt': b'\x11\x22\x33\x44'
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "For PBKDF2 key derivation, iteration count must be specified.",
             engine.derive_key,
@@ -847,7 +847,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hash_algorithm': enums.HashingAlgorithm.SHA_256
         }
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Derivation method 'invalid' is not a supported key derivation "
             "method.",
@@ -864,7 +864,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (b'', 'invalid', enums.BlockCipherMode.NIST_KEY_WRAP, b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Wrapping method 'invalid' is not a supported key wrapping "
             "method.",
@@ -880,7 +880,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (b'', enums.WrappingMethod.ENCRYPT, 'invalid', b'')
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Encryption algorithm 'invalid' is not a supported key wrapping "
             "algorithm.",
@@ -915,7 +915,7 @@ class TestCryptographyEngine(testtools.TestCase):
         engine = crypto.CryptographyEngine()
 
         args = (None, None, None, None, None, None)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             'For signing, either a digital signature algorithm or a hash'
             ' algorithm and a cryptographic algorithm must be specified.',
@@ -938,7 +938,7 @@ class TestCryptographyEngine(testtools.TestCase):
             None,
             None
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             'For signing, an RSA key must be used.',
             engine.sign,
@@ -960,7 +960,7 @@ class TestCryptographyEngine(testtools.TestCase):
             DER_RSA_KEY,
             None
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Padding method 'PaddingMethod.OAEP' is not a supported"
             " signature padding method.",
@@ -983,7 +983,7 @@ class TestCryptographyEngine(testtools.TestCase):
             DER_RSA_KEY,
             None
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             'For signing, a padding method must be specified.',
             engine.sign,
@@ -1006,7 +1006,7 @@ class TestCryptographyEngine(testtools.TestCase):
             None
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             'Unable to deserialize key '
             'bytes, unknown format.',
@@ -1033,7 +1033,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'digital_signature_algorithm':
                 enums.DigitalSignatureAlgorithm.SHA1_WITH_RSA_ENCRYPTION
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The signing algorithm does not match the digital signature "
             "algorithm.",
@@ -1061,7 +1061,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'digital_signature_algorithm':
                 enums.DigitalSignatureAlgorithm.SHA1_WITH_RSA_ENCRYPTION
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The hashing algorithm does not match the digital signature "
             "algorithm.",
@@ -1088,7 +1088,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hashing_algorithm': None,
             'digital_signature_algorithm': None
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "A hashing algorithm must be specified for PSS padding.",
             engine.verify_signature,
@@ -1114,7 +1114,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1,
             'digital_signature_algorithm': None
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The padding method 'invalid' is not supported for signature "
             "verification.",
@@ -1141,7 +1141,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1,
             'digital_signature_algorithm': None
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "The signing key bytes could not be loaded.",
             engine.verify_signature,
@@ -1222,7 +1222,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hashing_algorithm': None,
             'digital_signature_algorithm': None
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "The signature verification process failed.",
             engine.verify_signature,
@@ -1248,7 +1248,7 @@ class TestCryptographyEngine(testtools.TestCase):
             'hashing_algorithm': enums.HashingAlgorithm.SHA_1,
             'digital_signature_algorithm': None
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The signing algorithm 'invalid' is not supported for signature "
             "verification.",

--- a/kmip/tests/unit/services/server/test_config.py
+++ b/kmip/tests/unit/services/server/test_config.py
@@ -74,7 +74,7 @@ class TestKmipServerConfig(testtools.TestCase):
         # setting.
         args = ('invalid', None)
         regex = "Setting 'invalid' is not supported."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c.set_setting,
@@ -135,7 +135,7 @@ class TestKmipServerConfig(testtools.TestCase):
         with mock.patch('os.path.exists') as os_mock:
             os_mock.return_value = True
             with mock.patch(
-                'six.moves.configparser.SafeConfigParser.read'
+                'six.moves.configparser.ConfigParser.read'
             ) as parser_mock:
                 c.load_settings("/test/path/server.conf")
                 c._logger.info.assert_any_call(
@@ -162,7 +162,7 @@ class TestKmipServerConfig(testtools.TestCase):
         """
         Test that server authentication plugin settings are parsed correctly.
         """
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
         parser.add_section('auth:slugs')
         parser.set('auth:slugs', 'enabled', 'True')
@@ -204,7 +204,7 @@ class TestKmipServerConfig(testtools.TestCase):
         Test that server authentication plugin settings are parsed correctly,
         even when not specified.
         """
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
 
         c = config.KmipServerConfig()
@@ -239,7 +239,7 @@ class TestKmipServerConfig(testtools.TestCase):
         c._set_database_path = mock.MagicMock()
 
         # Test that the right calls are made when correctly parsing settings.
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
         parser.set('server', 'hostname', '127.0.0.1')
         parser.set('server', 'port', '5696')
@@ -277,13 +277,13 @@ class TestKmipServerConfig(testtools.TestCase):
 
         # Test that a ConfigurationError is generated when the expected
         # section is missing.
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
 
         args = (parser, )
         regex = (
             "The server configuration file does not have a 'server' section."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._parse_settings,
@@ -292,7 +292,7 @@ class TestKmipServerConfig(testtools.TestCase):
 
         # Test that a ConfigurationError is generated when an unexpected
         # setting is provided.
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
         parser.set('server', 'invalid', 'invalid')
 
@@ -301,7 +301,7 @@ class TestKmipServerConfig(testtools.TestCase):
             "Setting 'invalid' is not a supported setting. Please remove it "
             "from the configuration file."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._parse_settings,
@@ -310,14 +310,14 @@ class TestKmipServerConfig(testtools.TestCase):
 
         # Test that a ConfigurationError is generated when an expected
         # setting is missing.
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
 
         args = (parser, )
         regex = (
             "Setting 'hostname' is missing from the configuration file."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._parse_settings,
@@ -326,14 +326,14 @@ class TestKmipServerConfig(testtools.TestCase):
 
         # Test that a ConfigurationError is generated when an expected
         # setting is missing.
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section('server')
 
         args = (parser, )
         regex = (
             "Setting 'hostname' is missing from the configuration file."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._parse_settings,
@@ -356,7 +356,7 @@ class TestKmipServerConfig(testtools.TestCase):
         # value.
         args = (0, )
         regex = "The hostname value must be a string."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_hostname,
@@ -380,7 +380,7 @@ class TestKmipServerConfig(testtools.TestCase):
         # value.
         args = ('invalid', )
         regex = "The port value must be an integer in the range 0 - 65535."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_port,
@@ -390,7 +390,7 @@ class TestKmipServerConfig(testtools.TestCase):
 
         args = (65536, )
         regex = "The port value must be an integer in the range 0 - 65535."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_port,
@@ -432,7 +432,7 @@ class TestKmipServerConfig(testtools.TestCase):
             "The certificate path value, if specified, must be a valid "
             "string path to a certificate file."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_certificate_path,
@@ -447,7 +447,7 @@ class TestKmipServerConfig(testtools.TestCase):
         )
         with mock.patch('os.path.exists') as os_mock:
             os_mock.return_value = False
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 exceptions.ConfigurationError,
                 regex,
                 c._set_certificate_path,
@@ -491,7 +491,7 @@ class TestKmipServerConfig(testtools.TestCase):
             "The key path value, if specified, must be a valid string path "
             "to a certificate key file."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_key_path,
@@ -506,7 +506,7 @@ class TestKmipServerConfig(testtools.TestCase):
         )
         with mock.patch('os.path.exists') as os_mock:
             os_mock.return_value = False
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 exceptions.ConfigurationError,
                 regex,
                 c._set_key_path,
@@ -585,7 +585,7 @@ class TestKmipServerConfig(testtools.TestCase):
             "The authentication suite must be one of the following: "
             "Basic, TLS1.2"
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             regex,
             c._set_auth_suite,
@@ -658,7 +658,7 @@ class TestKmipServerConfig(testtools.TestCase):
         # Test that a ConfigurationError is generated when setting the wrong
         # value.
         args = ('invalid',)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The flag enabling the TLS certificate client auth flag check "
             "must be a boolean.",
@@ -740,7 +740,7 @@ class TestKmipServerConfig(testtools.TestCase):
         c._logger = mock.MagicMock()
 
         args = (1,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The TLS cipher suites must be a set of strings representing "
             "cipher suite names.",
@@ -757,7 +757,7 @@ class TestKmipServerConfig(testtools.TestCase):
         c._logger = mock.MagicMock()
 
         args = ([0],)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The TLS cipher suites must be a set of strings representing "
             "cipher suite names.",
@@ -810,7 +810,7 @@ class TestKmipServerConfig(testtools.TestCase):
         c._logger = mock.MagicMock()
 
         args = (0,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The logging level must be a string representing a valid logging "
             "level.",
@@ -819,7 +819,7 @@ class TestKmipServerConfig(testtools.TestCase):
         )
 
         args = ('invalid',)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ConfigurationError,
             "The logging level must be a string representing a valid logging "
             "level.",

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -3788,7 +3788,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Key derivation can only generate a SymmetricKey or SecretData "
             "object.",
@@ -3823,7 +3823,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "Object 1 is not a suitable type for key derivation. Please "
             "specify a key or secret data.",
@@ -3864,7 +3864,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The DeriveKey bit must be set in the cryptographic usage mask "
             "for object 1 for it to be used in key derivation.",
@@ -3991,7 +3991,7 @@ class TestKmipEngine(testtools.TestCase):
     def test_derive_key_unspecified_iv(self):
         """
         """
-        self.skip('')
+        self.skipTest('')
 
     def test_derive_key_missing_cryptographic_length(self):
         """
@@ -4043,7 +4043,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic length must be provided in the template "
             "attribute.",
@@ -4105,7 +4105,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic length must correspond to a valid number of "
             "bytes; it must be a multiple of 8.",
@@ -4163,7 +4163,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic algorithm must be provided in the template "
             "attribute when deriving a symmetric key.",
@@ -4228,7 +4228,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.CryptographicFailure,
             "The specified length exceeds the output of the derivation "
             "method.",
@@ -4836,7 +4836,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.OperationNotSupported,
             "Wrapping method '{0}' is not supported.".format(
                 enums.WrappingMethod.MAC_SIGN
@@ -4903,7 +4903,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Key wrapping with MAC/signing key information is not supported.",
             e._process_get,
@@ -4947,7 +4947,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Either the encryption key information or the MAC/signature key "
             "information must be specified for key wrapping to be performed.",
@@ -5000,7 +5000,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ItemNotFound,
             "Wrapping key does not exist.",
             e._process_get,
@@ -5064,7 +5064,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.IllegalOperation,
             "The wrapping encryption key specified by the encryption key "
             "information is not a key.",
@@ -5129,7 +5129,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Encryption key 1 must be activated to be used for key "
             "wrapping.",
@@ -5195,7 +5195,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The WrapKey bit must be set in the cryptographic usage mask of "
             "encryption key 1 for it to be used for key wrapping.",
@@ -5262,7 +5262,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.IllegalOperation,
             "Wrapping object attributes is not supported.",
             e._process_get,
@@ -5327,7 +5327,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.EncodingOptionError,
             "Encoding option '{0}' is not supported.".format(
                 enums.EncodingOption.TTLV_ENCODING
@@ -5751,7 +5751,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload,)
         regex = "The object state is not pre-active and cannot be activated."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_activate,
@@ -5763,7 +5763,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = payloads.ActivateRequestPayload()
         args = (payload,)
         regex = "The object state is not pre-active and cannot be activated."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_activate,
@@ -5804,7 +5804,7 @@ class TestKmipEngine(testtools.TestCase):
                 [x.capitalize() for x in name.split('_')]
             )
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.IllegalOperation,
             regex,
             e._process_activate,
@@ -5842,7 +5842,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload,)
         regex = "The object state is not pre-active and cannot be activated."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_activate,
@@ -6065,7 +6065,7 @@ class TestKmipEngine(testtools.TestCase):
         payload.revocation_reason = None
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "revocation reason code must be specified",
             e._process_revoke,
@@ -6111,7 +6111,7 @@ class TestKmipEngine(testtools.TestCase):
         args = (payload, )
         regex = "The object is not active and cannot be revoked with " \
                 "reason other than KEY_COMPROMISE"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.IllegalOperation,
             regex,
             e._process_revoke,
@@ -6157,7 +6157,7 @@ class TestKmipEngine(testtools.TestCase):
                 [x.capitalize() for x in name.split('_')]
             )
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.IllegalOperation,
             regex,
             e._process_revoke,
@@ -6915,7 +6915,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic parameters must be specified.",
             e._process_encrypt,
@@ -6966,7 +6966,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The requested encryption key is not a symmetric key. "
             "Only symmetric encryption is currently supported.",
@@ -7023,7 +7023,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The encryption key must be in the Active state to be used "
             "for encryption.",
@@ -7081,7 +7081,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The Encrypt bit must be set in the encryption key's "
             "cryptographic usage mask.",
@@ -7207,7 +7207,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic parameters must be specified.",
             e._process_decrypt,
@@ -7258,7 +7258,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The requested decryption key is not a symmetric key. "
             "Only symmetric decryption is currently supported.",
@@ -7315,7 +7315,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The decryption key must be in the Active state to be used "
             "for decryption.",
@@ -7373,7 +7373,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The Decrypt bit must be set in the decryption key's "
             "cryptographic usage mask.",
@@ -7564,7 +7564,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic parameters must be specified.",
             e._process_signature_verify,
@@ -7606,7 +7606,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The requested signing key is not a public key. A public key must "
             "be specified.",
@@ -7665,7 +7665,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The signing key must be in the Active state to be used for "
             "signature verification.",
@@ -7724,7 +7724,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The Verify bit must be set in the signing key's cryptographic "
             "usage mask.",
@@ -7841,7 +7841,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload_no_key, )
         regex = "A secret key value must be specified"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_mac,
@@ -7856,7 +7856,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload_no_algorithm, )
         regex = "The cryptographic algorithm must be specified"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_mac,
@@ -7871,7 +7871,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload_no_data, )
         regex = "No data to be MACed"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_mac,
@@ -7920,7 +7920,7 @@ class TestKmipEngine(testtools.TestCase):
 
         args = (payload,)
         regex = "Object is not in a state that can be used for MACing."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_mac,
@@ -7970,7 +7970,7 @@ class TestKmipEngine(testtools.TestCase):
         args = (payload,)
         regex = "MAC Generate must be set in the object's cryptographic " \
                 "usage mask"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             regex,
             e._process_mac,
@@ -8833,7 +8833,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload,)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.InvalidField,
             "The cryptographic parameters must be specified.",
             e._process_sign,
@@ -8877,7 +8877,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The requested signing key is not a private key. "
             "A private key must be specified.",
@@ -8965,7 +8965,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The signing key must be in the Active state to be "
             "used for signing.",
@@ -9055,7 +9055,7 @@ class TestKmipEngine(testtools.TestCase):
         )
 
         args = (payload, )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "The Sign bit must be set in the signing key's cryptographic "
             "usage mask.",

--- a/kmip/tests/unit/services/server/test_server.py
+++ b/kmip/tests/unit/services/server/test_server.py
@@ -284,7 +284,7 @@ class TestKmipServer(testtools.TestCase):
                 regex = (
                     "Server failed to bind socket handler to 127.0.0.1:5696"
                 )
-                self.assertRaisesRegexp(
+                self.assertRaisesRegex(
                     exceptions.NetworkingError,
                     regex,
                     s.start
@@ -404,7 +404,7 @@ class TestKmipServer(testtools.TestCase):
         s._socket.close = mock.MagicMock(side_effect=test_exception)
 
         regex = "Server failed to shutdown socket handler."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.NetworkingError,
             regex,
             s.stop
@@ -445,7 +445,7 @@ class TestKmipServer(testtools.TestCase):
         thread_mock.name = 'TestThread'
 
         regex = "Server failed to clean up the policy monitor."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.ShutdownError,
             regex,
             s.stop

--- a/kmip/tests/unit/services/server/test_session.py
+++ b/kmip/tests/unit/services/server/test_session.py
@@ -749,7 +749,7 @@ class TestKmipSession(testtools.TestCase):
         )
 
         args = ("fake_certificate", fake_request)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Authentication failed.",
             kmip_session.authenticate,
@@ -781,7 +781,7 @@ class TestKmipSession(testtools.TestCase):
         )
 
         args = ("fake_certificate", fake_request)
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.PermissionDenied,
             "Authentication failed.",
             kmip_session.authenticate,

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -102,7 +102,7 @@ class TestKMIPClient(TestCase):
         value is provided to the client.
         """
         kwargs = {'config_file': 1}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "The client configuration file argument must be a string.",
             KMIPProxy,
@@ -115,7 +115,7 @@ class TestKMIPClient(TestCase):
         path is provided to the client.
         """
         kwargs = {'config_file': 'invalid'}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             ValueError,
             "The client configuration file 'invalid' does not exist.",
             KMIPProxy,
@@ -510,9 +510,12 @@ class TestKMIPClient(TestCase):
         msg = base.format(expected, observed)
         self.assertEqual(expected, observed, msg)
 
-        self.assertRaisesRegexp(ValueError, "no processor for operation",
-                                self.client._get_batch_item_processor,
-                                0xA5A5A5A5)
+        self.assertRaisesRegex(
+            ValueError,
+            "no processor for operation",
+            self.client._get_batch_item_processor,
+            0xA5A5A5A5
+        )
 
         expected = self.client._process_get_attributes_batch_item
         observed = self.client._get_batch_item_processor(


### PR DESCRIPTION
This change fixes various pending deprecation warnings throughout the library caused by recent updates to different dependencies. While PyKMIP no longer directly triggers these warnings, some dependencies still do when run through the test suite.