### PR TITLE
Update the server to nominally support KMIP 1.3 and 1.4

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -109,12 +109,14 @@ class KmipEngine(object):
         self._id_placeholder = None
 
         self._protocol_versions = [
+            contents.ProtocolVersion(1, 4),
+            contents.ProtocolVersion(1, 3),
             contents.ProtocolVersion(1, 2),
             contents.ProtocolVersion(1, 1),
             contents.ProtocolVersion(1, 0)
         ]
 
-        self._protocol_version = self._protocol_versions[0]
+        self._protocol_version = self._protocol_versions[2]
 
         self._object_map = {
             enums.ObjectType.CERTIFICATE: objects.X509Certificate,

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -6692,18 +6692,26 @@ class TestKmipEngine(testtools.TestCase):
             payloads.DiscoverVersionsResponsePayload
         )
         self.assertIsNotNone(result.protocol_versions)
-        self.assertEqual(3, len(result.protocol_versions))
+        self.assertEqual(5, len(result.protocol_versions))
         self.assertEqual(
-            contents.ProtocolVersion(1, 2),
+            contents.ProtocolVersion(1, 4),
             result.protocol_versions[0]
         )
         self.assertEqual(
-            contents.ProtocolVersion(1, 1),
+            contents.ProtocolVersion(1, 3),
             result.protocol_versions[1]
         )
         self.assertEqual(
-            contents.ProtocolVersion(1, 0),
+            contents.ProtocolVersion(1, 2),
             result.protocol_versions[2]
+        )
+        self.assertEqual(
+            contents.ProtocolVersion(1, 1),
+            result.protocol_versions[3]
+        )
+        self.assertEqual(
+            contents.ProtocolVersion(1, 0),
+            result.protocol_versions[4]
         )
 
         # Test detailed request.


### PR DESCRIPTION
This change updates the list of KMIP versions supported by the server. While the server does not support any specific KMIP 1.3 or 1.4 features, the protocol formats are compatible across KMIP 1.0 to 1.4. Without this change, KMIP 1.3 and 1.4 requests for older operations, like Create, Get, and Destroy, would fail.

This change also updates the server unit tests impacted by this change.

Closes #451