### PR TITLE
Update the PyKMIP clients to support changing their KMIP version

### DIFF
--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -391,6 +391,14 @@ class KeyWrapType(enum.Enum):
     AS_REGISTERED = 0x00000002
 
 
+class KMIPVersion(enum.Enum):
+    KMIP_1_0 = "KMIP 1.0"
+    KMIP_1_1 = "KMIP 1.1"
+    KMIP_1_2 = "KMIP 1.2"
+    KMIP_1_3 = "KMIP 1.3"
+    KMIP_1_4 = "KMIP 1.4"
+
+
 class LinkType(enum.Enum):
     CERTIFICATE_LINK            = 0x00000101
     PUBLIC_KEY_LINK             = 0x00000102

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -62,7 +62,8 @@ class ProxyKmipClient(object):
                  username=None,
                  password=None,
                  config='client',
-                 config_file=None):
+                 config_file=None,
+                 kmip_version=None):
         """
         Construct a ProxyKmipClient.
 
@@ -91,6 +92,9 @@ class ProxyKmipClient(object):
                 Optional, defaults to the default client section, 'client'.
             config_file (string): The path to the client's configuration file.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): The KMIP version the client should use
+                when making requests. Optional, defaults to None. If None at
+                request time, the client will use KMIP 1.2.
 
         """
         self.logger = logging.getLogger(__name__)
@@ -109,11 +113,46 @@ class ProxyKmipClient(object):
             username=username,
             password=password,
             config=config,
-            config_file=config_file
+            config_file=config_file,
+            kmip_version=kmip_version
         )
 
         # TODO (peter-hamilton) Add a multiprocessing lock for synchronization.
         self._is_open = False
+
+    @property
+    def kmip_version(self):
+        """
+        Get the KMIP version for the client.
+
+        Return:
+            kmip_version (KMIPVersion): The KMIPVersion enumeration used by
+                the client for KMIP requests.
+        """
+        return self.proxy.kmip_version
+
+    @kmip_version.setter
+    def kmip_version(self, value):
+        """
+        Set the KMIP version for the client.
+
+        Args:
+            value (KMIPVersion): A KMIPVersion enumeration
+
+        Return:
+            None
+
+        Raises:
+            ValueError: if value is not a KMIPVersion enumeration
+
+        Example:
+            >>> client.kmip_version = enums.KMIPVersion.KMIP_1_1
+            >>>
+        """
+        if isinstance(value, enums.KMIPVersion):
+            self.proxy.kmip_version = value
+        else:
+            raise ValueError("KMIP version must be a KMIPVersion enumeration")
 
     def open(self):
         """

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -68,6 +68,36 @@ class TestProxyKmipClient(testtools.TestCase):
             password='password',
             config='test')
 
+    def test_kmip_version_get(self):
+        """
+        Test that the KMIP version can be obtained from the client.
+        """
+        client = ProxyKmipClient()
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_2)
+
+    def test_kmip_version_set(self):
+        """
+        Test that the KMIP version of the client can be set to a new value.
+        """
+        client = ProxyKmipClient()
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_2)
+        client.kmip_version = enums.KMIPVersion.KMIP_1_1
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_1)
+
+    def test_kmip_version_set_error(self):
+        """
+        Test that the right error gets raised when setting the client KMIP
+        version with an invalid value.
+        """
+        client = ProxyKmipClient()
+        args = (client, "kmip_version", None)
+        self.assertRaisesRegexp(
+            ValueError,
+            "KMIP version must be a KMIPVersion enumeration",
+            setattr,
+            *args
+        )
+
     @mock.patch('kmip.pie.client.KMIPProxy',
                 mock.MagicMock(spec_set=KMIPProxy))
     def test_open(self):

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -96,6 +96,36 @@ class TestKMIPClient(TestCase):
     def tearDown(self):
         super(TestKMIPClient, self).tearDown()
 
+    def test_kmip_version_get(self):
+        """
+        Test that the KMIP version can be obtained from the client.
+        """
+        client = KMIPProxy()
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_2)
+
+    def test_kmip_version_set(self):
+        """
+        Test that the KMIP version of the client can be set to a new value.
+        """
+        client = KMIPProxy()
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_2)
+        client.kmip_version = enums.KMIPVersion.KMIP_1_1
+        self.assertEqual(client.kmip_version, enums.KMIPVersion.KMIP_1_1)
+
+    def test_kmip_version_set_error(self):
+        """
+        Test that the right error gets raised when setting the client KMIP
+        version with an invalid value.
+        """
+        client = KMIPProxy()
+        args = (client, "kmip_version", None)
+        self.assertRaisesRegexp(
+            ValueError,
+            "KMIP version must be a KMIPVersion enumeration",
+            setattr,
+            *args
+        )
+
     def test_init_with_invalid_config_file_value(self):
         """
         Test that the right error is raised when an invalid configuration file


### PR DESCRIPTION
This change updates the PyKMIP clients, adding support for getting and setting the KMIP version they use when making KMIP requests. You can now do:

>>> client.kmip_version

to get the KMIP version enumeration the client is using. Use:

>>> client.kmip_version = enums.KMIPVersion.KMIP_1_1

to set the KMIP version the client uses.

The client unit tests have been updated to check and cover these changes.

Fixes #470