### PR TITLE
Fix AttributeError in client Rekey results with missing payloads

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -405,8 +405,9 @@ class KMIPProxy(object):
 
         if payload:
             result['unique_identifier'] = payload.unique_identifier
-        if payload.template_attribute is not None:
-            result['template_attribute'] = payload.template_attribute
+
+            if payload.template_attribute is not None:
+                result['template_attribute'] = payload.template_attribute
 
         result['result_status'] = batch_item.result_status.value
         try:


### PR DESCRIPTION
This change fixes a bug in the KMIPProxy client's support for the Rekey operation. Specifically, if the operation fails and does not return a payload, the client will still try to reference the payload object when checking for TemplateAttribute data. This causes an AttributeError since the payload is None. This change fixes this and adds a unit test that covers this specific case.

Fixes #474