### PR TITLE
Update the PyKMIP object hierarchy to store the KMIP version

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -38,22 +38,35 @@ from enum import Enum
 # 3.1
 class UniqueIdentifier(TextString):
 
-    def __init__(self, value=None, tag=Tags.UNIQUE_IDENTIFIER):
-        super(UniqueIdentifier, self).__init__(value, tag)
+    def __init__(self,
+                 value=None,
+                 tag=Tags.UNIQUE_IDENTIFIER,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(UniqueIdentifier, self).__init__(
+            value,
+            tag,
+            kmip_version=kmip_version
+        )
 
 
 class PrivateKeyUniqueIdentifier(UniqueIdentifier):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(PrivateKeyUniqueIdentifier, self).__init__(
-            value, Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER)
+            value,
+            Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER,
+            kmip_version=kmip_version
+        )
 
 
 class PublicKeyUniqueIdentifier(UniqueIdentifier):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(PublicKeyUniqueIdentifier, self).__init__(
-            value, Tags.PUBLIC_KEY_UNIQUE_IDENTIFIER)
+            value,
+            Tags.PUBLIC_KEY_UNIQUE_IDENTIFIER,
+            kmip_version=kmip_version
+        )
 
 
 # 3.2
@@ -61,8 +74,14 @@ class Name(Struct):
 
     class NameValue(TextString):
 
-        def __init__(self, value=None):
-            super(Name.NameValue, self).__init__(value, Tags.NAME_VALUE)
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
+            super(Name.NameValue, self).__init__(
+                value,
+                Tags.NAME_VALUE,
+                kmip_version=kmip_version
+            )
 
         def __eq__(self, other):
             if isinstance(other, Name.NameValue):
@@ -82,9 +101,15 @@ class Name(Struct):
 
     class NameType(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(Name.NameType, self).__init__(
-                enums.NameType, value, Tags.NAME_TYPE)
+                enums.NameType,
+                value,
+                Tags.NAME_TYPE,
+                kmip_version=kmip_version
+            )
 
         def __eq__(self, other):
             if isinstance(other, Name.NameType):
@@ -102,8 +127,11 @@ class Name(Struct):
         def __str__(self):
             return "{0}".format(self.value)
 
-    def __init__(self, name_value=None, name_type=None):
-        super(Name, self).__init__(tag=Tags.NAME)
+    def __init__(self,
+                 name_value=None,
+                 name_type=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Name, self).__init__(tag=Tags.NAME, kmip_version=kmip_version)
         self.name_value = name_value
         self.name_type = name_type
         self.validate()
@@ -211,25 +239,33 @@ class Name(Struct):
 # 3.3
 class ObjectType(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(ObjectType, self).__init__(
-            enums.ObjectType, value, Tags.OBJECT_TYPE)
+            enums.ObjectType,
+            value,
+            Tags.OBJECT_TYPE,
+            kmip_version=kmip_version
+        )
 
 
 # 3.4
 class CryptographicAlgorithm(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CryptographicAlgorithm, self).__init__(
-            enums.CryptographicAlgorithm, value, Tags.CRYPTOGRAPHIC_ALGORITHM)
+            enums.CryptographicAlgorithm,
+            value,
+            Tags.CRYPTOGRAPHIC_ALGORITHM,
+            kmip_version=kmip_version
+        )
 
 
 # 3.5
 class CryptographicLength(Integer):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CryptographicLength, self).__init__(
-            value, Tags.CRYPTOGRAPHIC_LENGTH)
+            value, Tags.CRYPTOGRAPHIC_LENGTH, kmip_version=kmip_version)
 
 
 # 3.6
@@ -242,7 +278,9 @@ class HashingAlgorithm(Enumeration):
     for more information.
     """
 
-    def __init__(self, value=HashingAlgorithmEnum.SHA_256):
+    def __init__(self,
+                 value=HashingAlgorithmEnum.SHA_256,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a HashingAlgorithm object.
 
@@ -250,9 +288,16 @@ class HashingAlgorithm(Enumeration):
             value (HashingAlgorithm): A HashingAlgorithm enumeration value,
                 (e.g., HashingAlgorithm.MD5). Optional, defaults to
                 HashingAlgorithm.SHA_256.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(HashingAlgorithm, self).__init__(
-            enums.HashingAlgorithm, value, Tags.HASHING_ALGORITHM)
+            enums.HashingAlgorithm,
+            value,
+            Tags.HASHING_ALGORITHM,
+            kmip_version=kmip_version
+        )
 
 
 class CryptographicParameters(Struct):
@@ -277,9 +322,12 @@ class CryptographicParameters(Struct):
                  fixed_field_length=None,
                  invocation_field_length=None,
                  counter_length=None,
-                 initial_counter_value=None):
+                 initial_counter_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CryptographicParameters, self).__init__(
-            tag=Tags.CRYPTOGRAPHIC_PARAMETERS)
+            tag=Tags.CRYPTOGRAPHIC_PARAMETERS,
+            kmip_version=kmip_version
+        )
 
         self._block_cipher_mode = None
         self._padding_method = None
@@ -779,7 +827,9 @@ class CertificateType(Enumeration):
     information.
     """
 
-    def __init__(self, value=enums.CertificateType.X_509):
+    def __init__(self,
+                 value=enums.CertificateType.X_509,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a CertificateType object.
 
@@ -787,9 +837,16 @@ class CertificateType(Enumeration):
             value (CertificateType): A CertificateType enumeration
                 value, (e.g., CertificateType.PGP). Optional, defaults to
                 CertificateType.X_509.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(CertificateType, self).__init__(
-            enums.CertificateType, value, Tags.CERTIFICATE_TYPE)
+            enums.CertificateType,
+            value,
+            Tags.CERTIFICATE_TYPE,
+            kmip_version=kmip_version
+        )
 
 
 class DigestValue(ByteString):
@@ -805,15 +862,22 @@ class DigestValue(ByteString):
         value: The bytes of the hash.
     """
 
-    def __init__(self, value=b''):
+    def __init__(self, value=b'', kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a DigestValue object.
 
         Args:
             value (bytes): The bytes of the hash. Optional, defaults to
                 the empty byte string.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(DigestValue, self).__init__(value, Tags.DIGEST_VALUE)
+        super(DigestValue, self).__init__(
+            value,
+            Tags.DIGEST_VALUE,
+            kmip_version=kmip_version
+        )
 
 
 class Digest(Struct):
@@ -834,7 +898,8 @@ class Digest(Struct):
     def __init__(self,
                  hashing_algorithm=None,
                  digest_value=None,
-                 key_format_type=None):
+                 key_format_type=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Digest object.
 
@@ -846,8 +911,11 @@ class Digest(Struct):
             key_format_type (KeyFormatType): The format type of the key the
                 hash was computed for, if the object in question is a key.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Digest, self).__init__(Tags.DIGEST)
+        super(Digest, self).__init__(Tags.DIGEST, kmip_version=kmip_version)
 
         if hashing_algorithm is None:
             self.hashing_algorithm = HashingAlgorithm()
@@ -1006,9 +1074,12 @@ class Digest(Struct):
 # 3.18
 class OperationPolicyName(TextString):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(OperationPolicyName, self).__init__(
-            value, Tags.OPERATION_POLICY_NAME)
+            value,
+            Tags.OPERATION_POLICY_NAME,
+            kmip_version=kmip_version
+        )
 
 
 # 3.19
@@ -1016,22 +1087,34 @@ class CryptographicUsageMask(Integer):
 
     ENUM_TYPE = enums.CryptographicUsageMask
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CryptographicUsageMask, self).__init__(
-            value, Tags.CRYPTOGRAPHIC_USAGE_MASK)
+            value,
+            Tags.CRYPTOGRAPHIC_USAGE_MASK,
+            kmip_version=kmip_version
+        )
 
 
 class State(Enumeration):
 
-    def __init__(self, value=None):
-        super(State, self).__init__(enums.State, value, Tags.STATE)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(State, self).__init__(
+            enums.State,
+            value,
+            Tags.STATE,
+            kmip_version=kmip_version
+        )
 
 
 # 3.33
 class ObjectGroup(TextString):
 
-    def __init__(self, value=None):
-        super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ObjectGroup, self).__init__(
+            value,
+            Tags.OBJECT_GROUP,
+            kmip_version=kmip_version
+        )
 
 
 # 3.36
@@ -1044,16 +1127,22 @@ class ApplicationNamespace(TextString):
     specification for more information.
     """
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ApplicationNamespace object.
 
         Args:
             value (str): A string representing a namespace. Optional, defaults
                 to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ApplicationNamespace, self).__init__(
-            value, Tags.APPLICATION_NAMESPACE)
+            value,
+            Tags.APPLICATION_NAMESPACE,
+            kmip_version=kmip_version
+        )
 
 
 class ApplicationData(TextString):
@@ -1064,15 +1153,22 @@ class ApplicationData(TextString):
     specification for more information.
     """
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ApplicationData object.
 
         Args:
             value (str): A string representing data for a particular namespace.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ApplicationData, self).__init__(value, Tags.APPLICATION_DATA)
+        super(ApplicationData, self).__init__(
+            value,
+            Tags.APPLICATION_DATA,
+            kmip_version=kmip_version
+        )
 
 
 class ApplicationSpecificInformation(Struct):
@@ -1090,7 +1186,10 @@ class ApplicationSpecificInformation(Struct):
     See Section 3.36 of the KMIP v1.1 specification for more information.
     """
 
-    def __init__(self, application_namespace=None, application_data=None):
+    def __init__(self,
+                 application_namespace=None,
+                 application_data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ApplicationSpecificInformation object.
 
@@ -1099,9 +1198,14 @@ class ApplicationSpecificInformation(Struct):
                 namespace supported by the server. Optional, defaults to None.
             application_data (ApplicationData): String data relevant to the
                 specified namespace. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ApplicationSpecificInformation, self).__init__(
-            Tags.APPLICATION_SPECIFIC_INFORMATION)
+            Tags.APPLICATION_SPECIFIC_INFORMATION,
+            kmip_version=kmip_version
+        )
 
         if application_namespace is None:
             self.application_namespace = ApplicationNamespace()
@@ -1235,9 +1339,12 @@ class ApplicationSpecificInformation(Struct):
 # 3.37
 class ContactInformation(TextString):
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(ContactInformation, self).__init__(
-            value, Tags.CONTACT_INFORMATION)
+            value,
+            Tags.CONTACT_INFORMATION,
+            kmip_version=kmip_version
+        )
 
 
 # 3.39
@@ -1246,8 +1353,12 @@ class ContactInformation(TextString):
 # TODO (peter-hamilton) temporary stopgap.
 class CustomAttribute(TextString):
 
-    def __init__(self, value=None):
-        super(CustomAttribute, self).__init__(value, Tags.ATTRIBUTE_VALUE)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CustomAttribute, self).__init__(
+            value,
+            Tags.ATTRIBUTE_VALUE,
+            kmip_version=kmip_version
+        )
 
 
 class DerivationParameters(Struct):
@@ -1263,7 +1374,8 @@ class DerivationParameters(Struct):
                  initialization_vector=None,
                  derivation_data=None,
                  salt=None,
-                 iteration_count=None):
+                 iteration_count=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a DerivationParameters struct.
 
@@ -1283,9 +1395,13 @@ class DerivationParameters(Struct):
                 Optional, defaults to None.
             iteration_count (bytes): An iteration count value required by
                 the PBKDF2 algorithm. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(DerivationParameters, self).__init__(
-            tag=Tags.DERIVATION_PARAMETERS
+            tag=Tags.DERIVATION_PARAMETERS,
+            kmip_version=kmip_version
         )
 
         self._cryptographic_parameters = None

--- a/kmip/core/messages/contents.py
+++ b/kmip/core/messages/contents.py
@@ -38,7 +38,10 @@ class ProtocolVersion(primitives.Struct):
         minor: The minor protocol version number.
     """
 
-    def __init__(self, major=None, minor=None):
+    def __init__(self,
+                 major=None,
+                 minor=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a ProtocolVersion struct.
 
@@ -47,8 +50,14 @@ class ProtocolVersion(primitives.Struct):
                 to None.
             minor (int): The minor protocol version number. Optional, defaults
                 to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ProtocolVersion, self).__init__(enums.Tags.PROTOCOL_VERSION)
+        super(ProtocolVersion, self).__init__(
+            enums.Tags.PROTOCOL_VERSION,
+            kmip_version=kmip_version
+        )
 
         self._major = None
         self._minor = None
@@ -240,29 +249,51 @@ class ProtocolVersion(primitives.Struct):
 # 6.2
 class Operation(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(Operation, self).__init__(
-            enums.Operation, value, enums.Tags.OPERATION)
+            enums.Operation,
+            value,
+            enums.Tags.OPERATION,
+            kmip_version=kmip_version
+        )
 
 
 # 6.3
 class MaximumResponseSize(Integer):
-    def __init__(self, value=None):
-        super(MaximumResponseSize, self).\
-            __init__(value, enums.Tags.MAXIMUM_RESPONSE_SIZE)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(MaximumResponseSize, self).__init__(
+            value,
+            enums.Tags.MAXIMUM_RESPONSE_SIZE,
+            kmip_version=kmip_version
+        )
 
 
 # 6.4
 class UniqueBatchItemID(ByteString):
-    def __init__(self, value=None):
-        super(UniqueBatchItemID, self)\
-            .__init__(value, enums.Tags.UNIQUE_BATCH_ITEM_ID)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(UniqueBatchItemID, self).__init__(
+            value,
+            enums.Tags.UNIQUE_BATCH_ITEM_ID,
+            kmip_version=kmip_version
+        )
 
 
 # 6.5
 class TimeStamp(DateTime):
-    def __init__(self, value=None):
-        super(TimeStamp, self).__init__(value, enums.Tags.TIME_STAMP)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(TimeStamp, self).__init__(
+            value,
+            enums.Tags.TIME_STAMP,
+            kmip_version=kmip_version
+        )
 
 
 class Authentication(Struct):
@@ -274,15 +305,23 @@ class Authentication(Struct):
             authentication.
     """
 
-    def __init__(self, credentials=None):
+    def __init__(self,
+                 credentials=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Authentication struct.
 
         Args:
             credentials (list): A list of Credential structs to be used for
                 authentication. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Authentication, self).__init__(enums.Tags.AUTHENTICATION)
+        super(Authentication, self).__init__(
+            enums.Tags.AUTHENTICATION,
+            kmip_version=kmip_version
+        )
 
         self._credentials = []
         self.credentials = credentials
@@ -383,71 +422,124 @@ class Authentication(Struct):
 
 # 6.7
 class AsynchronousIndicator(Boolean):
-    def __init__(self, value=None):
-        super(AsynchronousIndicator, self).\
-            __init__(value, enums.Tags.ASYNCHRONOUS_INDICATOR)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(AsynchronousIndicator, self).__init__(
+            value,
+            enums.Tags.ASYNCHRONOUS_INDICATOR,
+            kmip_version=kmip_version
+        )
 
 
 # 6.8
 class AsynchronousCorrelationValue(ByteString):
-    def __init__(self, value=None):
-        super(AsynchronousCorrelationValue, self).\
-            __init__(value, enums.Tags.ASYNCHRONOUS_CORRELATION_VALUE)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(AsynchronousCorrelationValue, self).__init__(
+            value,
+            enums.Tags.ASYNCHRONOUS_CORRELATION_VALUE,
+            kmip_version=kmip_version
+        )
 
 
 # 6.9
 class ResultStatus(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(ResultStatus, self).__init__(
-            enums.ResultStatus, value, enums.Tags.RESULT_STATUS)
+            enums.ResultStatus,
+            value,
+            enums.Tags.RESULT_STATUS,
+            kmip_version=kmip_version
+        )
 
 
 # 6.10
 class ResultReason(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(ResultReason, self).__init__(
-            enums.ResultReason, value, enums.Tags.RESULT_REASON)
+            enums.ResultReason,
+            value,
+            enums.Tags.RESULT_REASON,
+            kmip_version=kmip_version
+        )
 
 
 # 6.11
 class ResultMessage(TextString):
-    def __init__(self, value=None):
-        super(ResultMessage, self).__init__(value, enums.Tags.RESULT_MESSAGE)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResultMessage, self).__init__(
+            value,
+            enums.Tags.RESULT_MESSAGE,
+            kmip_version=kmip_version
+        )
 
 
 # 6.12
 class BatchOrderOption(Boolean):
-    def __init__(self, value=None):
-        super(BatchOrderOption, self).\
-            __init__(value, enums.Tags.BATCH_ORDER_OPTION)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(BatchOrderOption, self).__init__(
+            value,
+            enums.Tags.BATCH_ORDER_OPTION,
+            kmip_version=kmip_version
+        )
 
 
 # 6.13
 class BatchErrorContinuationOption(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(BatchErrorContinuationOption, self).__init__(
-            enums.BatchErrorContinuationOption, value,
-            enums.Tags.BATCH_ERROR_CONTINUATION_OPTION)
+            enums.BatchErrorContinuationOption,
+            value,
+            enums.Tags.BATCH_ERROR_CONTINUATION_OPTION,
+            kmip_version=kmip_version
+        )
 
 
 # 6.14
 class BatchCount(Integer):
-    def __init__(self, value=None):
-        super(BatchCount, self).__init__(value, enums.Tags.BATCH_COUNT)
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(BatchCount, self).__init__(
+            value,
+            enums.Tags.BATCH_COUNT,
+            kmip_version=kmip_version
+        )
 
 
 # 6.16
 class MessageExtension(Struct):
-    def __init__(self):
-        super(MessageExtension, self).__init__(enums.Tags.MESSAGE_EXTENSION)
+    def __init__(self, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(MessageExtension, self).__init__(
+            enums.Tags.MESSAGE_EXTENSION,
+            kmip_version=kmip_version
+        )
 
 
 # 9.1.3.2.2
 class KeyCompressionType(Enumeration):
 
-    def __init__(self, value=None):
+    def __init__(self,
+                 value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(KeyCompressionType, self).__init__(
-            enums.KeyCompressionType, value, enums.Tags.KEY_COMPRESSION_TYPE)
+            enums.KeyCompressionType,
+            value,
+            enums.Tags.KEY_COMPRESSION_TYPE,
+            kmip_version=kmip_version
+        )

--- a/kmip/core/messages/messages.py
+++ b/kmip/core/messages/messages.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 
 from kmip.core.messages import contents
@@ -37,8 +38,12 @@ class RequestHeader(Struct):
                  batch_error_cont_option=None,
                  batch_order_option=None,
                  time_stamp=None,
-                 batch_count=None):
-        super(RequestHeader, self).__init__(tag=Tags.REQUEST_HEADER)
+                 batch_count=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestHeader, self).__init__(
+            tag=Tags.REQUEST_HEADER,
+            kmip_version=kmip_version
+        )
         self.protocol_version = protocol_version
         self.maximum_response_size = maximum_response_size
         self.asynchronous_indicator = asynchronous_indicator
@@ -120,8 +125,12 @@ class ResponseHeader(Struct):
     def __init__(self,
                  protocol_version=None,
                  time_stamp=None,
-                 batch_count=None):
-        super(ResponseHeader, self).__init__(tag=Tags.RESPONSE_HEADER)
+                 batch_count=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseHeader, self).__init__(
+            tag=Tags.RESPONSE_HEADER,
+            kmip_version=kmip_version
+        )
         self.protocol_version = protocol_version
         self.time_stamp = time_stamp
         self.batch_count = batch_count
@@ -171,8 +180,12 @@ class RequestBatchItem(Struct):
                  operation=None,
                  unique_batch_item_id=None,
                  request_payload=None,
-                 message_extension=None):
-        super(RequestBatchItem, self).__init__(tag=Tags.REQUEST_BATCH_ITEM)
+                 message_extension=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestBatchItem, self).__init__(
+            tag=Tags.REQUEST_BATCH_ITEM,
+            kmip_version=kmip_version
+        )
 
         self.payload_factory = RequestPayloadFactory()
 
@@ -237,8 +250,12 @@ class ResponseBatchItem(Struct):
                  result_message=None,
                  async_correlation_value=None,
                  response_payload=None,
-                 message_extension=None):
-        super(ResponseBatchItem, self).__init__(tag=Tags.RESPONSE_BATCH_ITEM)
+                 message_extension=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseBatchItem, self).__init__(
+            tag=Tags.RESPONSE_BATCH_ITEM,
+            kmip_version=kmip_version
+        )
 
         self.payload_factory = ResponsePayloadFactory()
 
@@ -334,8 +351,14 @@ class ResponseBatchItem(Struct):
 
 class RequestMessage(Struct):
 
-    def __init__(self, request_header=None, batch_items=None,):
-        super(RequestMessage, self).__init__(tag=Tags.REQUEST_MESSAGE)
+    def __init__(self,
+                 request_header=None,
+                 batch_items=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestMessage, self).__init__(
+            tag=Tags.REQUEST_MESSAGE,
+            kmip_version=kmip_version
+        )
         self.request_header = request_header
         self.batch_items = batch_items
 
@@ -367,8 +390,14 @@ class RequestMessage(Struct):
 
 class ResponseMessage(Struct):
 
-    def __init__(self, response_header=None, batch_items=None,):
-        super(ResponseMessage, self).__init__(tag=Tags.RESPONSE_MESSAGE)
+    def __init__(self,
+                 response_header=None,
+                 batch_items=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseMessage, self).__init__(
+            tag=Tags.RESPONSE_MESSAGE,
+            kmip_version=kmip_version
+        )
         self.response_header = response_header
         self.batch_items = batch_items
         self.validate()

--- a/kmip/core/messages/payloads/activate.py
+++ b/kmip/core/messages/payloads/activate.py
@@ -33,15 +33,21 @@ class ActivateRequestPayload(Struct):
         unique_identifier: The UUID of a managed cryptographic object
     """
     def __init__(self,
-                 unique_identifier=None):
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a ActivateRequestPayload object.
         Args:
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ActivateRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+            tag=enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.unique_identifier = unique_identifier
         self.validate()
 
@@ -102,16 +108,22 @@ class ActivateResponsePayload(Struct):
         unique_identifier: The UUID of a managed cryptographic object.
     """
     def __init__(self,
-                 unique_identifier=None):
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a ActivateResponsePayload object.
 
         Args:
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ActivateResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+            tag=enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
         if unique_identifier is None:
             self.unique_identifier = attributes.UniqueIdentifier()
         else:

--- a/kmip/core/messages/payloads/archive.py
+++ b/kmip/core/messages/payloads/archive.py
@@ -28,16 +28,22 @@ class ArchiveRequestPayload(primitives.Struct):
         unique_identifier: The unique ID of the object to archive.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Archive request payload struct.
 
         Args:
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) to archive. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ArchiveRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -141,16 +147,22 @@ class ArchiveResponsePayload(primitives.Struct):
         unique_identifier: The unique ID of the object that was archived.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Archive response payload struct.
 
         Args:
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was archived. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ArchiveResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/cancel.py
+++ b/kmip/core/messages/payloads/cancel.py
@@ -29,16 +29,22 @@ class CancelRequestPayload(primitives.Struct):
             operation to cancel.
     """
 
-    def __init__(self, asynchronous_correlation_value=None):
+    def __init__(self,
+                 asynchronous_correlation_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Cancel request payload struct.
 
         Args:
             asynchronous_correlation_value (bytes): The ID of a pending
                 operation to cancel, in bytes. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(CancelRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._asynchronous_correlation_value = None
@@ -153,7 +159,8 @@ class CancelResponsePayload(primitives.Struct):
 
     def __init__(self,
                  asynchronous_correlation_value=None,
-                 cancellation_result=None):
+                 cancellation_result=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Cancel response payload struct.
 
@@ -164,9 +171,13 @@ class CancelResponsePayload(primitives.Struct):
             cancellation_result (enum): A CancellationResult enumeration
                 specifying the result of canceling the operation. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(CancelResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._asynchronous_correlation_value = None

--- a/kmip/core/messages/payloads/check.py
+++ b/kmip/core/messages/payloads/check.py
@@ -38,7 +38,8 @@ class CheckRequestPayload(primitives.Struct):
                  unique_identifier=None,
                  usage_limits_count=None,
                  cryptographic_usage_mask=None,
-                 lease_time=None):
+                 lease_time=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Check request payload struct.
 
@@ -54,8 +55,14 @@ class CheckRequestPayload(primitives.Struct):
             lease_time (int): The date in seconds since the epoch that a
                 lease should be available for on the checked object. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(CheckRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(CheckRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._usage_limits_count = None
@@ -270,7 +277,8 @@ class CheckResponsePayload(primitives.Struct):
                  unique_identifier=None,
                  usage_limits_count=None,
                  cryptographic_usage_mask=None,
-                 lease_time=None):
+                 lease_time=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Check response payload struct.
 
@@ -286,8 +294,14 @@ class CheckResponsePayload(primitives.Struct):
             lease_time (int): The date in seconds since the epoch that a
                 lease should be available for on the checked object. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(CheckResponsePayload, self).__init__(enums.Tags.RESPONSE_PAYLOAD)
+        super(CheckResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._usage_limits_count = None

--- a/kmip/core/messages/payloads/create.py
+++ b/kmip/core/messages/payloads/create.py
@@ -28,9 +28,12 @@ class CreateRequestPayload(Struct):
 
     def __init__(self,
                  object_type=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CreateRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+            tag=enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.object_type = object_type
         self.template_attribute = template_attribute
         self.validate()
@@ -70,9 +73,12 @@ class CreateResponsePayload(Struct):
     def __init__(self,
                  object_type=None,
                  unique_identifier=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CreateResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+            tag=enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.object_type = object_type
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute

--- a/kmip/core/messages/payloads/create_key_pair.py
+++ b/kmip/core/messages/payloads/create_key_pair.py
@@ -16,6 +16,7 @@
 from kmip.core import attributes
 from kmip.core import objects
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 
 from kmip.core.primitives import Struct
@@ -28,8 +29,12 @@ class CreateKeyPairRequestPayload(Struct):
     def __init__(self,
                  common_template_attribute=None,
                  private_key_template_attribute=None,
-                 public_key_template_attribute=None):
-        super(CreateKeyPairRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+                 public_key_template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CreateKeyPairRequestPayload, self).__init__(
+            Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self.common_template_attribute = common_template_attribute
         self.private_key_template_attribute = private_key_template_attribute
@@ -112,9 +117,12 @@ class CreateKeyPairResponsePayload(Struct):
                  private_key_uuid=None,
                  public_key_uuid=None,
                  private_key_template_attribute=None,
-                 public_key_template_attribute=None):
+                 public_key_template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CreateKeyPairResponsePayload, self).__init__(
-            Tags.RESPONSE_PAYLOAD)
+            Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         # Private and public UUIDs are required so make defaults as backup
         if private_key_uuid is None:

--- a/kmip/core/messages/payloads/decrypt.py
+++ b/kmip/core/messages/payloads/decrypt.py
@@ -39,7 +39,8 @@ class DecryptRequestPayload(primitives.Struct):
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  data=None,
-                 iv_counter_nonce=None):
+                 iv_counter_nonce=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Decrypt request payload struct.
 
@@ -56,9 +57,13 @@ class DecryptRequestPayload(primitives.Struct):
                 encoding and decoding.
             iv_counter_nonce (bytes): The IV/counter/nonce value to be used
                 with the decryption algorithm. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(DecryptRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -274,7 +279,8 @@ class DecryptResponsePayload(primitives.Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 data=None):
+                 data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Decrypt response payload struct.
 
@@ -284,9 +290,13 @@ class DecryptResponsePayload(primitives.Struct):
                 and decoding.
             data (bytes): The decrypted data in binary form. Required for
                 encoding and decoding.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(DecryptResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/derive_key.py
+++ b/kmip/core/messages/payloads/derive_key.py
@@ -43,7 +43,8 @@ class DeriveKeyRequestPayload(primitives.Struct):
                  unique_identifiers=None,
                  derivation_method=None,
                  derivation_parameters=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a DeriveKey request payload struct.
 
@@ -68,9 +69,13 @@ class DeriveKeyRequestPayload(primitives.Struct):
                 cryptographic length) that should be set on the newly derived
                 cryptographic object. Optional, defaults to None. Required
                 for encoding and decoding.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(DeriveKeyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._object_type = None
@@ -366,7 +371,8 @@ class DeriveKeyResponsePayload(primitives.Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a DeriveKey response payload struct.
 
@@ -379,9 +385,13 @@ class DeriveKeyResponsePayload(primitives.Struct):
                 cryptographic length) implicitly set by the server on the
                 newly derived cryptographic object. Optional, defaults to
                 None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(DeriveKeyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/destroy.py
+++ b/kmip/core/messages/payloads/destroy.py
@@ -26,8 +26,12 @@ from kmip.core.utils import BytearrayStream
 class DestroyRequestPayload(Struct):
 
     def __init__(self,
-                 unique_identifier=None):
-        super(DestroyRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(DestroyRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.unique_identifier = unique_identifier
         self.validate()
 
@@ -64,9 +68,12 @@ class DestroyRequestPayload(Struct):
 class DestroyResponsePayload(Struct):
 
     def __init__(self,
-                 unique_identifier=None):
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(DestroyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.unique_identifier = unique_identifier
         self.validate()
 

--- a/kmip/core/messages/payloads/discover_versions.py
+++ b/kmip/core/messages/payloads/discover_versions.py
@@ -15,6 +15,7 @@
 
 from six.moves import xrange
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 
 from kmip.core.messages.contents import ProtocolVersion
@@ -26,9 +27,13 @@ from kmip.core.utils import BytearrayStream
 
 class DiscoverVersionsRequestPayload(Struct):
 
-    def __init__(self, protocol_versions=None):
+    def __init__(self,
+                 protocol_versions=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(DiscoverVersionsRequestPayload, self).__init__(
-            Tags.REQUEST_PAYLOAD)
+            Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         if protocol_versions is None:
             self.protocol_versions = list()
@@ -80,9 +85,13 @@ class DiscoverVersionsRequestPayload(Struct):
 
 class DiscoverVersionsResponsePayload(Struct):
 
-    def __init__(self, protocol_versions=None):
+    def __init__(self,
+                 protocol_versions=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(DiscoverVersionsResponsePayload, self).__init__(
-            Tags.RESPONSE_PAYLOAD)
+            Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         if protocol_versions is None:
             self.protocol_versions = list()

--- a/kmip/core/messages/payloads/encrypt.py
+++ b/kmip/core/messages/payloads/encrypt.py
@@ -39,7 +39,8 @@ class EncryptRequestPayload(primitives.Struct):
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  data=None,
-                 iv_counter_nonce=None):
+                 iv_counter_nonce=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Encrypt request payload struct.
 
@@ -56,9 +57,13 @@ class EncryptRequestPayload(primitives.Struct):
                 encoding and decoding.
             iv_counter_nonce (bytes): The IV/counter/nonce value to be used
                 with the encryption algorithm. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(EncryptRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -277,7 +282,8 @@ class EncryptResponsePayload(primitives.Struct):
     def __init__(self,
                  unique_identifier=None,
                  data=None,
-                 iv_counter_nonce=None):
+                 iv_counter_nonce=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Encrypt response payload struct.
 
@@ -291,9 +297,13 @@ class EncryptResponsePayload(primitives.Struct):
                 the encryption algorithm if it was required and if this
                 value was not originally specified by the client. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(EncryptResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/get.py
+++ b/kmip/core/messages/payloads/get.py
@@ -43,7 +43,8 @@ class GetRequestPayload(primitives.Struct):
                  unique_identifier=None,
                  key_format_type=None,
                  key_compression_type=None,
-                 key_wrapping_specification=None):
+                 key_wrapping_specification=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Get request payload struct.
 
@@ -61,9 +62,13 @@ class GetRequestPayload(primitives.Struct):
                 KeyWrappingSpecification struct that specifies keys and other
                 information for wrapping the returned object. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -278,7 +283,8 @@ class GetResponsePayload(primitives.Struct):
     def __init__(self,
                  object_type=None,
                  unique_identifier=None,
-                 secret=None):
+                 secret=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Get response payload struct.
 
@@ -293,9 +299,13 @@ class GetResponsePayload(primitives.Struct):
                 be one of the following:
 
                 Optional, defaults to None. Required for read/write.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD
+            tag=enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
         self._object_type = None
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/get_attribute_list.py
+++ b/kmip/core/messages/payloads/get_attribute_list.py
@@ -33,7 +33,9 @@ class GetAttributeListRequestPayload(primitives.Struct):
             retrieved attributes should be associated.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetAttributeList request payload.
 
@@ -41,9 +43,14 @@ class GetAttributeListRequestPayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object with
                 which the retrieved attribute names should be associated.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetAttributeListRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD)
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
 
@@ -147,7 +154,10 @@ class GetAttributeListResponsePayload(primitives.Struct):
             attributes associated with the managed object.
     """
 
-    def __init__(self, unique_identifier=None, attribute_names=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 attribute_names=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetAttributeList response payload.
 
@@ -158,10 +168,14 @@ class GetAttributeListResponsePayload(primitives.Struct):
             attribute_names: A list of strings identifying the names of the
                 attributes associated with the managed object. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
 
         super(GetAttributeListResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/get_attributes.py
+++ b/kmip/core/messages/payloads/get_attributes.py
@@ -36,7 +36,10 @@ class GetAttributesRequestPayload(primitives.Struct):
         attribute_names: A list of strings identifying the names of the
             attributes associated with the managed object.
     """
-    def __init__(self, unique_identifier=None, attribute_names=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 attribute_names=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetAttributes request payload.
 
@@ -47,9 +50,14 @@ class GetAttributesRequestPayload(primitives.Struct):
             attribute_names: A list of strings identifying the names of the
                 attributes associated with the managed object. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetAttributesRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD)
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._attribute_names = list()
@@ -211,7 +219,10 @@ class GetAttributesResponsePayload(primitives.Struct):
         attributes: The list of attributes associated with managed object
             identified by the unique identifier above.
     """
-    def __init__(self, unique_identifier=None, attributes=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetAttributes response payload.
 
@@ -221,9 +232,14 @@ class GetAttributesResponsePayload(primitives.Struct):
                 defaults to None.
             attributes (list): A list of attribute structures associated with
                 the managed object. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetAttributesResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._attributes = list()

--- a/kmip/core/messages/payloads/get_usage_allocation.py
+++ b/kmip/core/messages/payloads/get_usage_allocation.py
@@ -31,7 +31,10 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
             reserved for the object.
     """
 
-    def __init__(self, unique_identifier=None, usage_limits_count=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 usage_limits_count=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetUsageAllocation request payload struct.
 
@@ -41,9 +44,13 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
                 defaults to None.
             usage_limits_count (int): The number of usage limits units that
                 should be reserved for the object. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetUsageAllocationRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -183,16 +190,22 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
         unique_identifier: The unique ID of the object that was allocated.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a GetUsageAllocation response payload struct.
 
         Args:
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was allocated. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(GetUsageAllocationResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/locate.py
+++ b/kmip/core/messages/payloads/locate.py
@@ -31,25 +31,49 @@ class LocateRequestPayload(Struct):
     # 9.1.3.2.33
     class ObjectGroupMember(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(LocateRequestPayload.ObjectGroupMember, self).__init__(
-                enums.ObjectGroupMember, value, Tags.OBJECT_GROUP_MEMBER)
+                enums.ObjectGroupMember,
+                value,
+                Tags.OBJECT_GROUP_MEMBER,
+                kmip_version=kmip_version
+            )
 
     class MaximumItems(Integer):
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(LocateRequestPayload.MaximumItems, self).__init__(
-                value, Tags.MAXIMUM_ITEMS)
+                value,
+                Tags.MAXIMUM_ITEMS,
+                kmip_version=kmip_version
+            )
 
     # 9.1.3.3.2
     class StorageStatusMask(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(LocateRequestPayload.StorageStatusMask, self).__init__(
-                enums.StorageStatusMask, value, Tags.STORAGE_STATUS_MASK)
+                enums.StorageStatusMask,
+                value,
+                Tags.STORAGE_STATUS_MASK,
+                kmip_version=kmip_version
+            )
 
-    def __init__(self, maximum_items=None, storage_status_mask=None,
-                 object_group_member=None, attributes=None):
-        super(LocateRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+    def __init__(self,
+                 maximum_items=None,
+                 storage_status_mask=None,
+                 object_group_member=None,
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(LocateRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.maximum_items = maximum_items
         self.storage_status_mask = storage_status_mask
         self.object_group_member = object_group_member
@@ -102,9 +126,14 @@ class LocateRequestPayload(Struct):
 
 class LocateResponsePayload(Struct):
 
-    def __init__(self, unique_identifiers=[]):
+    # TODO (ph) Remove the default list below.
+    def __init__(self,
+                 unique_identifiers=[],
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(LocateResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.unique_identifiers = unique_identifiers or []
         self.validate()
 

--- a/kmip/core/messages/payloads/mac.py
+++ b/kmip/core/messages/payloads/mac.py
@@ -30,10 +30,13 @@ class MACRequestPayload(Struct):
     def __init__(self,
                  unique_identifier=None,
                  cryptographic_parameters=None,
-                 data=None):
+                 data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
 
         super(MACRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+            tag=enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -129,9 +132,12 @@ class MACResponsePayload(Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 mac_data=None):
+                 mac_data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(MACResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+            tag=enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self._unique_identifier = None
         self._mac_data = None

--- a/kmip/core/messages/payloads/obtain_lease.py
+++ b/kmip/core/messages/payloads/obtain_lease.py
@@ -28,7 +28,9 @@ class ObtainLeaseRequestPayload(primitives.Struct):
         unique_identifier: The unique ID of the object to be leased.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ObtainLease request payload struct.
 
@@ -36,9 +38,13 @@ class ObtainLeaseRequestPayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) to obtain a lease for. Optional, defaults to
                 None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ObtainLeaseRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -150,7 +156,8 @@ class ObtainLeaseResponsePayload(primitives.Struct):
     def __init__(self,
                  unique_identifier=None,
                  lease_time=None,
-                 last_change_date=None):
+                 last_change_date=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ObtainLease response payload struct.
 
@@ -163,9 +170,13 @@ class ObtainLeaseResponsePayload(primitives.Struct):
             last_change_date (int): The date, in seconds since the epoch,
                 when the last change was made to the object or one of its
                 attributes. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(ObtainLeaseResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/poll.py
+++ b/kmip/core/messages/payloads/poll.py
@@ -29,7 +29,9 @@ class PollRequestPayload(primitives.Struct):
             operation to poll.
     """
 
-    def __init__(self, asynchronous_correlation_value=None):
+    def __init__(self,
+                 asynchronous_correlation_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Poll request payload struct.
 
@@ -37,9 +39,13 @@ class PollRequestPayload(primitives.Struct):
             asynchronous_correlation_value (bytes): The ID of a pending
                 operation to poll the status of, in bytes. Optional, defaults
                 to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(PollRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._asynchronous_correlation_value = None

--- a/kmip/core/messages/payloads/query.py
+++ b/kmip/core/messages/payloads/query.py
@@ -18,6 +18,7 @@ from six.moves import xrange
 from kmip.core.attributes import ApplicationNamespace
 from kmip.core.attributes import ObjectType
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 from kmip.core.messages.contents import Operation
 
@@ -41,14 +42,22 @@ class QueryRequestPayload(Struct):
     Attributes:
         query_functions: A list of QueryFunction enumerations.
     """
-    def __init__(self, query_functions=None):
+    def __init__(self,
+                 query_functions=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a QueryRequestPayload object.
 
         Args:
             query_functions (list): A list of QueryFunction enumerations.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(QueryRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(QueryRequestPayload, self).__init__(
+            Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         if query_functions is None:
             self.query_functions = list()
@@ -136,9 +145,14 @@ class QueryResponsePayload(Struct):
             Objects supported by the server with ItemTag values in the
             Extensions range.
     """
-    def __init__(self, operations=None, object_types=None,
-                 vendor_identification=None, server_information=None,
-                 application_namespaces=None, extension_information=None):
+    def __init__(self,
+                 operations=None,
+                 object_types=None,
+                 vendor_identification=None,
+                 server_information=None,
+                 application_namespaces=None,
+                 extension_information=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a QueryResponsePayload object.
 
@@ -154,8 +168,14 @@ class QueryResponsePayload(Struct):
             extension_information (list): A list of ExtensionInformation
                 objects detailing Objects supported by the server with ItemTag
                 values in the Extensions range.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(QueryResponsePayload, self).__init__(Tags.RESPONSE_PAYLOAD)
+        super(QueryResponsePayload, self).__init__(
+            Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         if operations is None:
             self.operations = list()

--- a/kmip/core/messages/payloads/recover.py
+++ b/kmip/core/messages/payloads/recover.py
@@ -28,16 +28,22 @@ class RecoverRequestPayload(primitives.Struct):
         unique_identifier: The unique ID of the object to recover.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Recover request payload struct.
 
         Args:
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) to recover. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RecoverRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -141,16 +147,22 @@ class RecoverResponsePayload(primitives.Struct):
         unique_identifier: The unique ID of the object that was recovered.
     """
 
-    def __init__(self, unique_identifier=None):
+    def __init__(self,
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Recover response payload struct.
 
         Args:
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was recovered. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RecoverResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -16,6 +16,7 @@
 from kmip.core.factories.secrets import SecretFactory
 
 from kmip.core import attributes
+from kmip.core import enums
 from kmip.core.enums import Tags
 
 from kmip.core.objects import TemplateAttribute
@@ -31,8 +32,12 @@ class RegisterRequestPayload(Struct):
     def __init__(self,
                  object_type=None,
                  template_attribute=None,
-                 secret=None):
-        super(RegisterRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+                 secret=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RegisterRequestPayload, self).__init__(
+            Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self.secret_factory = SecretFactory()
         self.object_type = object_type
@@ -88,8 +93,12 @@ class RegisterResponsePayload(Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 template_attribute=None):
-        super(RegisterResponsePayload, self).__init__(Tags.RESPONSE_PAYLOAD)
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RegisterResponsePayload, self).__init__(
+            Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute

--- a/kmip/core/messages/payloads/rekey.py
+++ b/kmip/core/messages/payloads/rekey.py
@@ -32,7 +32,8 @@ class RekeyRequestPayload(primitives.Struct):
     def __init__(self,
                  unique_identifier=None,
                  offset=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Rekey request payload struct.
 
@@ -46,9 +47,13 @@ class RekeyRequestPayload(primitives.Struct):
                 set of attributes (e.g., cryptographic algorithm,
                 cryptographic length) that should be set on the replacement
                 key. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RekeyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -214,7 +219,8 @@ class RekeyResponsePayload(primitives.Struct):
     """
     def __init__(self,
                  unique_identifier=None,
-                 template_attribute=None):
+                 template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Rekey response payload struct.
 
@@ -225,9 +231,13 @@ class RekeyResponsePayload(primitives.Struct):
                 set of attributes (e.g., cryptographic algorithm,
                 cryptographic length) that were set by the server on the
                 replacement key. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RekeyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/rekey_key_pair.py
+++ b/kmip/core/messages/payloads/rekey_key_pair.py
@@ -17,6 +17,7 @@ from kmip.core import attributes
 from kmip.core import misc
 from kmip.core import objects
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 from kmip.core.messages.payloads.create_key_pair import \
     CreateKeyPairResponsePayload
@@ -31,8 +32,12 @@ class RekeyKeyPairRequestPayload(Struct):
                  offset=None,
                  common_template_attribute=None,
                  private_key_template_attribute=None,
-                 public_key_template_attribute=None):
-        super(RekeyKeyPairRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+                 public_key_template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RekeyKeyPairRequestPayload, self).__init__(
+            Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
 
         self.private_key_uuid = private_key_uuid
         self.offset = offset
@@ -147,7 +152,12 @@ class RekeyKeyPairResponsePayload(CreateKeyPairResponsePayload):
                  private_key_uuid=None,
                  public_key_uuid=None,
                  private_key_template_attribute=None,
-                 public_key_template_attribute=None):
+                 public_key_template_attribute=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(RekeyKeyPairResponsePayload, self).__init__(
-            private_key_uuid, public_key_uuid, private_key_template_attribute,
-            public_key_template_attribute)
+            private_key_uuid,
+            public_key_uuid,
+            private_key_template_attribute,
+            public_key_template_attribute,
+            kmip_version=kmip_version
+        )

--- a/kmip/core/messages/payloads/revoke.py
+++ b/kmip/core/messages/payloads/revoke.py
@@ -40,7 +40,8 @@ class RevokeRequestPayload(Struct):
     def __init__(self,
                  unique_identifier=None,
                  revocation_reason=None,
-                 compromise_occurrence_date=None):
+                 compromise_occurrence_date=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a RevokeRequestPayload object.
         Args:
@@ -50,9 +51,14 @@ class RevokeRequestPayload(Struct):
                 revoked.
             compromise_occurrence_date (DateTime): the datetime when the object
                 was first believed to be compromised.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RevokeRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+            tag=enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
+        )
         self.unique_identifier = unique_identifier
         self.compromise_occurrence_date = compromise_occurrence_date
         self.revocation_reason = revocation_reason
@@ -136,15 +142,21 @@ class RevokeResponsePayload(Struct):
         unique_identifier: The UUID of a managed cryptographic object.
     """
     def __init__(self,
-                 unique_identifier=None):
+                 unique_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a RevokeResponsePayload object.
         Args:
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(RevokeResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+            tag=enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
+        )
         if unique_identifier is None:
             self.unique_identifier = attributes.UniqueIdentifier()
         else:

--- a/kmip/core/messages/payloads/sign.py
+++ b/kmip/core/messages/payloads/sign.py
@@ -36,7 +36,8 @@ class SignRequestPayload(primitives.Struct):
     def __init__(self,
                  unique_identifier=None,
                  cryptographic_parameters=None,
-                 data=None):
+                 data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Sign request payload struct.
 
@@ -50,9 +51,13 @@ class SignRequestPayload(primitives.Struct):
                 included, the CryptographicParameters associated with the
                 managed object will be used instead.
             data (bytes): The data to be signed, in binary form.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(SignRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -235,9 +240,11 @@ class SignResponsePayload(primitives.Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 signature_data=None):
+                 signature_data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(SignResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/signature_verify.py
+++ b/kmip/core/messages/payloads/signature_verify.py
@@ -49,7 +49,8 @@ class SignatureVerifyRequestPayload(primitives.Struct):
                  signature_data=None,
                  correlation_value=None,
                  init_indicator=None,
-                 final_indicator=None):
+                 final_indicator=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a SignatureVerify request payload struct.
 
@@ -76,9 +77,13 @@ class SignatureVerifyRequestPayload(primitives.Struct):
             final_indicator (boolean): A boolean value indicating whether or
                 not the payload is the last in a series for a multi-payload
                 operation. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(SignatureVerifyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
+            enums.Tags.REQUEST_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -416,7 +421,8 @@ class SignatureVerifyResponsePayload(primitives.Struct):
                  unique_identifier=None,
                  validity_indicator=None,
                  data=None,
-                 correlation_value=None):
+                 correlation_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a SignatureVerify response payload struct.
 
@@ -432,9 +438,13 @@ class SignatureVerifyResponsePayload(primitives.Struct):
             correlation_value (bytes): The bytes representing a correlation
                 value, allowing the linking together of individual payloads
                 for a single overarching operation. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(SignatureVerifyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
+            enums.Tags.RESPONSE_PAYLOAD,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None

--- a/kmip/core/misc.py
+++ b/kmip/core/misc.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import KeyFormatType as KeyFormatTypeEnum
 from kmip.core.enums import Tags
 from kmip.core.enums import QueryFunction as QueryFunctionEnum
@@ -35,7 +36,7 @@ class CertificateValue(ByteString):
     information.
     """
 
-    def __init__(self, value=b''):
+    def __init__(self, value=b'', kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a CertificateValue byte string.
 
@@ -43,8 +44,15 @@ class CertificateValue(ByteString):
             value (bytes): A byte string (e.g., b'\x00\x01...') containing the
                 certificate bytes to store. Optional, defaults to the empty
                 byte string.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(CertificateValue, self).__init__(value, Tags.CERTIFICATE_VALUE)
+        super(CertificateValue, self).__init__(
+            value,
+            Tags.CERTIFICATE_VALUE,
+            kmip_version=kmip_version
+        )
 
 
 class Offset(Interval):
@@ -57,15 +65,22 @@ class Offset(Interval):
     specification for more information.
     """
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an Offset object.
 
         Args:
             value (int): An integer representing a positive change in time.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Offset, self).__init__(value, Tags.OFFSET)
+        super(Offset, self).__init__(
+            value,
+            Tags.OFFSET,
+            kmip_version=kmip_version
+        )
 
 
 class QueryFunction(Enumeration):
@@ -77,7 +92,7 @@ class QueryFunction(Enumeration):
     specification for more information.
     """
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a QueryFunction object.
 
@@ -85,9 +100,16 @@ class QueryFunction(Enumeration):
             value (QueryFunction enum): A QueryFunction enumeration value,
                 (e.g., QueryFunction.QUERY_OPERATIONS). Optional, default to
                 None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(QueryFunction, self).__init__(
-            QueryFunctionEnum, value, Tags.QUERY_FUNCTION)
+            QueryFunctionEnum,
+            value,
+            Tags.QUERY_FUNCTION,
+            kmip_version=kmip_version
+        )
 
 
 class VendorIdentification(TextString):
@@ -99,16 +121,22 @@ class VendorIdentification(TextString):
     information.
     """
 
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a VendorIdentification object.
 
         Args:
             value (str): A string describing a KMIP vendor. Optional, defaults
                 to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(VendorIdentification, self).__init__(
-            value, Tags.VENDOR_IDENTIFICATION)
+            value,
+            Tags.VENDOR_IDENTIFICATION,
+            kmip_version=kmip_version
+        )
 
 
 class ServerInformation(Struct):
@@ -130,11 +158,14 @@ class ServerInformation(Struct):
     validate the object's contents.
     """
 
-    def __init__(self):
+    def __init__(self, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a ServerInformation object.
         """
-        super(ServerInformation, self).__init__(Tags.SERVER_INFORMATION)
+        super(ServerInformation, self).__init__(
+            Tags.SERVER_INFORMATION,
+            kmip_version=kmip_version
+        )
 
         self.data = BytearrayStream()
 
@@ -217,7 +248,9 @@ class KeyFormatType(Enumeration):
     4.11, and 9.1.3.2.3 of the KMIP 1.1 specification for more information.
     """
 
-    def __init__(self, value=KeyFormatTypeEnum.RAW):
+    def __init__(self,
+                 value=KeyFormatTypeEnum.RAW,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a KeyFormatType object.
 
@@ -225,6 +258,13 @@ class KeyFormatType(Enumeration):
             value (KeyFormatType): A KeyFormatType enumeration value,
                 (e.g., KeyFormatType.PKCS_1). Optional, default to
                 KeyFormatType.RAW.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(KeyFormatType, self).__init__(
-            KeyFormatTypeEnum, value, Tags.KEY_FORMAT_TYPE)
+            KeyFormatTypeEnum,
+            value,
+            Tags.KEY_FORMAT_TYPE,
+            kmip_version=kmip_version
+        )

--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -47,9 +47,14 @@ class Attribute(Struct):
 
     class AttributeName(TextString):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(Attribute.AttributeName, self).__init__(
-                value, Tags.ATTRIBUTE_NAME)
+                value,
+                Tags.ATTRIBUTE_NAME,
+                kmip_version=kmip_version
+            )
 
         def __eq__(self, other):
             if isinstance(other, Attribute.AttributeName):
@@ -68,15 +73,24 @@ class Attribute(Struct):
 
     class AttributeIndex(Integer):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(Attribute.AttributeIndex, self).__init__(
-                value, Tags.ATTRIBUTE_INDEX)
+                value,
+                Tags.ATTRIBUTE_INDEX,
+                kmip_version=kmip_version
+            )
 
     def __init__(self,
                  attribute_name=None,
                  attribute_index=None,
-                 attribute_value=None):
-        super(Attribute, self).__init__(tag=Tags.ATTRIBUTE)
+                 attribute_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Attribute, self).__init__(
+            tag=Tags.ATTRIBUTE,
+            kmip_version=kmip_version
+        )
 
         self.value_factory = AttributeValueFactory()
 
@@ -184,7 +198,10 @@ class Nonce(primitives.Struct):
         nonce_value (bytes): A binary string representing a random value.
     """
 
-    def __init__(self, nonce_id=None, nonce_value=None):
+    def __init__(self,
+                 nonce_id=None,
+                 nonce_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Nonce struct.
 
@@ -194,8 +211,14 @@ class Nonce(primitives.Struct):
                 decoding.
             nonce_value (bytes): A binary string representing a random value.
                 Optional, defaults to None. Required for encoding and decoding.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Nonce, self).__init__(tag=enums.Tags.NONCE)
+        super(Nonce, self).__init__(
+            tag=enums.Tags.NONCE,
+            kmip_version=kmip_version
+        )
 
         self._nonce_id = None
         self._nonce_value = None
@@ -357,7 +380,10 @@ class UsernamePasswordCredential(CredentialValue):
         password: The password associated with the username.
     """
 
-    def __init__(self, username=None, password=None):
+    def __init__(self,
+                 username=None,
+                 password=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a UsernamePasswordCredential struct.
 
@@ -366,9 +392,13 @@ class UsernamePasswordCredential(CredentialValue):
                 Optional, defaults to None. Required for encoding and decoding.
             password (string): The password associated with the username.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(UsernamePasswordCredential, self).__init__(
-            tag=Tags.CREDENTIAL_VALUE
+            tag=Tags.CREDENTIAL_VALUE,
+            kmip_version=kmip_version
         )
 
         self._username = None
@@ -528,7 +558,8 @@ class DeviceCredential(CredentialValue):
                  device_identifier=None,
                  network_identifier=None,
                  machine_identifier=None,
-                 media_identifier=None):
+                 media_identifier=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a DeviceCredential struct.
 
@@ -545,8 +576,14 @@ class DeviceCredential(CredentialValue):
                 credential. Optional, defaults to None.
             media_identifier (string): The media identifier for the
                 credential. Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(DeviceCredential, self).__init__(tag=Tags.CREDENTIAL_VALUE)
+        super(DeviceCredential, self).__init__(
+            tag=Tags.CREDENTIAL_VALUE,
+            kmip_version=kmip_version
+        )
 
         self._device_serial_number = None
         self._password = None
@@ -817,7 +854,8 @@ class AttestationCredential(CredentialValue):
                  nonce=None,
                  attestation_type=None,
                  attestation_measurement=None,
-                 attestation_assertion=None):
+                 attestation_assertion=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an AttestationCredential struct.
 
@@ -834,8 +872,14 @@ class AttestationCredential(CredentialValue):
             attestation_assertion (bytes): The network identifier for the
                 credential. Optional, defaults to None. Required for encoding
                 and decoding if the attestation measurement is not provided.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(AttestationCredential, self).__init__(tag=Tags.CREDENTIAL_VALUE)
+        super(AttestationCredential, self).__init__(
+            tag=Tags.CREDENTIAL_VALUE,
+            kmip_version=kmip_version
+        )
 
         self._nonce = None
         self._attestation_type = None
@@ -1079,7 +1123,10 @@ class Credential(primitives.Struct):
         credential_value: The credential value, a CredentialValue instance.
     """
 
-    def __init__(self, credential_type=None, credential_value=None):
+    def __init__(self,
+                 credential_type=None,
+                 credential_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Credential struct.
 
@@ -1090,8 +1137,14 @@ class Credential(primitives.Struct):
             credential_value (CredentialValue): The credential value
                 corresponding to the credential type. Optional, defaults to
                 None. Required for encoding and decoding.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Credential, self).__init__(tag=Tags.CREDENTIAL)
+        super(Credential, self).__init__(
+            tag=Tags.CREDENTIAL,
+            kmip_version=kmip_version
+        )
 
         self._credential_type = None
         self._credential_value = None
@@ -1253,9 +1306,15 @@ class KeyBlock(Struct):
 
     class KeyCompressionType(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(KeyBlock.KeyCompressionType, self).__init__(
-                enums.KeyCompressionType, value, Tags.KEY_COMPRESSION_TYPE)
+                enums.KeyCompressionType,
+                value,
+                Tags.KEY_COMPRESSION_TYPE,
+                kmip_version=kmip_version
+            )
 
     def __init__(self,
                  key_format_type=None,
@@ -1263,8 +1322,12 @@ class KeyBlock(Struct):
                  key_value=None,
                  cryptographic_algorithm=None,
                  cryptographic_length=None,
-                 key_wrapping_data=None):
-        super(KeyBlock, self).__init__(Tags.KEY_BLOCK)
+                 key_wrapping_data=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyBlock, self).__init__(
+            Tags.KEY_BLOCK,
+            kmip_version=kmip_version
+        )
         self.key_format_type = key_format_type
         self.key_compression_type = key_compression_type
         self.key_value = key_value
@@ -1345,15 +1408,22 @@ class KeyBlock(Struct):
 # 2.1.4
 class KeyMaterial(ByteString):
 
-    def __init__(self, value=None):
-        super(KeyMaterial, self).__init__(value, Tags.KEY_MATERIAL)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyMaterial, self).__init__(
+            value,
+            Tags.KEY_MATERIAL,
+            kmip_version=kmip_version
+        )
 
 
 # TODO (peter-hamilton) Get rid of this and replace with a KeyMaterial factory.
 class KeyMaterialStruct(Struct):
 
-    def __init__(self):
-        super(KeyMaterialStruct, self).__init__(Tags.KEY_MATERIAL)
+    def __init__(self, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyMaterialStruct, self).__init__(
+            Tags.KEY_MATERIAL,
+            kmip_version=kmip_version
+        )
 
         self.data = BytearrayStream()
 
@@ -1388,8 +1458,12 @@ class KeyValue(Struct):
 
     def __init__(self,
                  key_material=None,
-                 attributes=None):
-        super(KeyValue, self).__init__(Tags.KEY_VALUE)
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyValue, self).__init__(
+            Tags.KEY_VALUE,
+            kmip_version=kmip_version
+        )
 
         if key_material is None:
             self.key_material = KeyMaterial()
@@ -1468,7 +1542,8 @@ class EncryptionKeyInformation(Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 cryptographic_parameters=None):
+                 cryptographic_parameters=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an EncryptionKeyInformation struct.
 
@@ -1481,9 +1556,13 @@ class EncryptionKeyInformation(Struct):
                 the encryption process. Optional, defaults to None. If not
                 included, the CryptographicParameters associated with the
                 managed object will be used instead.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(EncryptionKeyInformation, self).__init__(
-            tag=Tags.ENCRYPTION_KEY_INFORMATION
+            tag=Tags.ENCRYPTION_KEY_INFORMATION,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -1626,7 +1705,8 @@ class MACSignatureKeyInformation(primitives.Struct):
 
     def __init__(self,
                  unique_identifier=None,
-                 cryptographic_parameters=None):
+                 cryptographic_parameters=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a MACSignatureKeyInformation struct.
 
@@ -1639,9 +1719,13 @@ class MACSignatureKeyInformation(primitives.Struct):
                 the MAC/signing process. Optional, defaults to None. If not
                 included, the CryptographicParameters associated with the
                 managed object will be used instead.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(MACSignatureKeyInformation, self).__init__(
-            tag=Tags.MAC_SIGNATURE_KEY_INFORMATION
+            tag=Tags.MAC_SIGNATURE_KEY_INFORMATION,
+            kmip_version=kmip_version
         )
 
         self._unique_identifier = None
@@ -1788,7 +1872,8 @@ class KeyWrappingData(Struct):
                  mac_signature_key_information=None,
                  mac_signature=None,
                  iv_counter_nonce=None,
-                 encoding_option=None):
+                 encoding_option=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a KeyWrappingData struct.
 
@@ -1812,8 +1897,14 @@ class KeyWrappingData(Struct):
             encoding_option (EncodingOption): An enumeration value that
                 specifies the encoding of the key value before it is wrapped.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(KeyWrappingData, self).__init__(Tags.KEY_WRAPPING_DATA)
+        super(KeyWrappingData, self).__init__(
+            Tags.KEY_WRAPPING_DATA,
+            kmip_version=kmip_version
+        )
 
         self._wrapping_method = None
         self._encryption_key_information = None
@@ -2102,7 +2193,8 @@ class KeyWrappingSpecification(primitives.Struct):
                  encryption_key_information=None,
                  mac_signature_key_information=None,
                  attribute_names=None,
-                 encoding_option=None):
+                 encoding_option=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a KeyWrappingSpecification struct.
 
@@ -2124,9 +2216,13 @@ class KeyWrappingSpecification(primitives.Struct):
             encoding_option (EncodingOption): An enumeration value that
                 specifies the encoding of the key value before it is wrapped.
                 Optional, defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         super(KeyWrappingSpecification, self).__init__(
-            tag=Tags.KEY_WRAPPING_SPECIFICATION
+            tag=Tags.KEY_WRAPPING_SPECIFICATION,
+            kmip_version=kmip_version
         )
 
         self._wrapping_method = None
@@ -2390,8 +2486,9 @@ class TemplateAttribute(Struct):
     def __init__(self,
                  names=None,
                  attributes=None,
-                 tag=Tags.TEMPLATE_ATTRIBUTE):
-        super(TemplateAttribute, self).__init__(tag)
+                 tag=Tags.TEMPLATE_ATTRIBUTE,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(TemplateAttribute, self).__init__(tag, kmip_version=kmip_version)
 
         if names is None:
             self.names = list()
@@ -2486,27 +2583,42 @@ class CommonTemplateAttribute(TemplateAttribute):
 
     def __init__(self,
                  names=None,
-                 attributes=None):
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(CommonTemplateAttribute, self).__init__(
-            names, attributes, Tags.COMMON_TEMPLATE_ATTRIBUTE)
+            names,
+            attributes,
+            Tags.COMMON_TEMPLATE_ATTRIBUTE,
+            kmip_version=kmip_version
+        )
 
 
 class PrivateKeyTemplateAttribute(TemplateAttribute):
 
     def __init__(self,
                  names=None,
-                 attributes=None):
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(PrivateKeyTemplateAttribute, self).__init__(
-            names, attributes, Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE)
+            names,
+            attributes,
+            Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+            kmip_version=kmip_version
+        )
 
 
 class PublicKeyTemplateAttribute(TemplateAttribute):
 
     def __init__(self,
                  names=None,
-                 attributes=None):
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(PublicKeyTemplateAttribute, self).__init__(
-            names, attributes, Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE)
+            names,
+            attributes,
+            Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE,
+            kmip_version=kmip_version
+        )
 
 
 # 2.1.9
@@ -2521,15 +2633,22 @@ class ExtensionName(TextString):
     Attributes:
         value: The string data representing the extension name.
     """
-    def __init__(self, value=''):
+    def __init__(self, value='', kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ExtensionName object.
 
         Args:
             value (str): The string data representing the extension name.
                 Optional, defaults to the empty string.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ExtensionName, self).__init__(value, Tags.EXTENSION_NAME)
+        super(ExtensionName, self).__init__(
+            value,
+            Tags.EXTENSION_NAME,
+            kmip_version=kmip_version
+        )
 
 
 class ExtensionTag(Integer):
@@ -2542,15 +2661,22 @@ class ExtensionTag(Integer):
     Attributes:
         value: The tag number identifying the extended object.
     """
-    def __init__(self, value=0):
+    def __init__(self, value=0, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ExtensionTag object.
 
         Args:
             value (int): A number representing the extension tag. Often
                 displayed in hex format. Optional, defaults to 0.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ExtensionTag, self).__init__(value, Tags.EXTENSION_TAG)
+        super(ExtensionTag, self).__init__(
+            value,
+            Tags.EXTENSION_TAG,
+            kmip_version=kmip_version
+        )
 
 
 class ExtensionType(Integer):
@@ -2564,7 +2690,7 @@ class ExtensionType(Integer):
     Attributes:
         value: The type enumeration for the extended object.
     """
-    def __init__(self, value=None):
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ExtensionType object.
 
@@ -2572,8 +2698,15 @@ class ExtensionType(Integer):
             value (Types): A number representing a Types enumeration value,
                 indicating the type of the extended Object. Optional, defaults
                 to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ExtensionType, self).__init__(value, Tags.EXTENSION_TYPE)
+        super(ExtensionType, self).__init__(
+            value,
+            Tags.EXTENSION_TYPE,
+            kmip_version=kmip_version
+        )
 
 
 class ExtensionInformation(Struct):
@@ -2590,8 +2723,11 @@ class ExtensionInformation(Struct):
         extension_tag: The tag of the extended Object.
         extension_type: The type of the extended Object.
     """
-    def __init__(self, extension_name=None, extension_tag=None,
-                 extension_type=None):
+    def __init__(self,
+                 extension_name=None,
+                 extension_tag=None,
+                 extension_type=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct an ExtensionInformation object.
 
@@ -2599,8 +2735,14 @@ class ExtensionInformation(Struct):
             extension_name (ExtensionName): The name of the extended Object.
             extension_tag (ExtensionTag): The tag of the extended Object.
             extension_type (ExtensionType): The type of the extended Object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(ExtensionInformation, self).__init__(Tags.EXTENSION_INFORMATION)
+        super(ExtensionInformation, self).__init__(
+            Tags.EXTENSION_INFORMATION,
+            kmip_version=kmip_version
+        )
 
         if extension_name is None:
             self.extension_name = ExtensionName()
@@ -2753,24 +2895,37 @@ class ExtensionInformation(Struct):
 # 2.1.10
 class Data(ByteString):
 
-    def __init__(self, value=None):
-        super(Data, self).__init__(value, Tags.DATA)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Data, self).__init__(
+            value,
+            Tags.DATA,
+            kmip_version=kmip_version
+        )
 
 
 # 2.1.13
 class MACData(ByteString):
 
-    def __init__(self, value=None):
-        super(MACData, self).__init__(value, Tags.MAC_DATA)
+    def __init__(self, value=None, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(MACData, self).__init__(
+            value,
+            Tags.MAC_DATA,
+            kmip_version=kmip_version
+        )
 
 
 # 3.31, 9.1.3.2.19
 class RevocationReasonCode(Enumeration):
 
-    def __init__(self, value=RevocationReasonCodeEnum.UNSPECIFIED):
+    def __init__(self,
+                 value=RevocationReasonCodeEnum.UNSPECIFIED,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         super(RevocationReasonCode, self).__init__(
-            RevocationReasonCodeEnum, value=value,
-            tag=Tags.REVOCATION_REASON_CODE)
+            RevocationReasonCodeEnum,
+            value=value,
+            tag=Tags.REVOCATION_REASON_CODE,
+            kmip_version=kmip_version
+        )
 
 
 # 3.31
@@ -2786,15 +2941,24 @@ class RevocationReason(Struct):
         message: An optional revocation message
     """
 
-    def __init__(self, code=None, message=None):
+    def __init__(self,
+                 code=None,
+                 message=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a RevocationReason object.
 
         Parameters:
             code(RevocationReasonCode): revocation reason code
             message(string): An optional revocation message
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(RevocationReason, self).__init__(tag=Tags.REVOCATION_REASON)
+        super(RevocationReason, self).__init__(
+            tag=Tags.REVOCATION_REASON,
+            kmip_version=kmip_version
+        )
         if code is not None:
             self.revocation_code = RevocationReasonCode(value=code)
         else:

--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -32,10 +32,54 @@ class Base(object):
     TYPE_SIZE = 1
     LENGTH_SIZE = 4
 
-    def __init__(self, tag=enums.Tags.DEFAULT, type=enums.Types.DEFAULT):
+    def __init__(self,
+                 tag=enums.Tags.DEFAULT,
+                 type=enums.Types.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         self.tag = tag
         self.type = type
         self.length = None
+
+        self._kmip_version = None
+        self.kmip_version = kmip_version
+
+    @property
+    def kmip_version(self):
+        """
+        Get the KMIP version of the object.
+
+        Return:
+            kmip_version (KMIPVersion): The KMIPVersion enumeration used by
+                the object for encoding and decoding across KMIP versions.
+
+        Example:
+            >>> payload.kmip_version
+            <KMIPVersion.KMIP_1_0: 'KMIP 1.0'>
+        """
+        return self._kmip_version
+
+    @kmip_version.setter
+    def kmip_version(self, value):
+        """
+        Set the KMIP version for the object.
+
+        Args:
+            value (KMIPVersion): A KMIPVersion enumeration.
+
+        Return:
+            None
+
+        Raises:
+            ValueError: if value is not a KMIPVersion enumeration
+
+        Example:
+            >>> payload.kmip_version = enums.KMIPVersion.KMIP_1_2
+            >>>
+        """
+        if isinstance(value, enums.KMIPVersion):
+            self._kmip_version = value
+        else:
+            raise ValueError("KMIP version must be a KMIPVersion enumeration")
 
     # TODO (peter-hamilton) Convert this into a classmethod, class name can be
     #                       obtained from cls parameter that replaces self
@@ -172,8 +216,14 @@ class Base(object):
 
 class Struct(Base):
 
-    def __init__(self, tag=enums.Tags.DEFAULT):
-        super(Struct, self).__init__(tag, type=enums.Types.STRUCTURE)
+    def __init__(self,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Struct, self).__init__(
+            tag,
+            type=enums.Types.STRUCTURE,
+            kmip_version=kmip_version
+        )
 
     # NOTE (peter-hamilton) If seen, should indicate repr needs to be defined
     def __repr__(self):
@@ -187,8 +237,16 @@ class Integer(Base):
     MIN = -2147483648
     MAX = 2147483647
 
-    def __init__(self, value=None, tag=enums.Tags.DEFAULT, signed=True):
-        super(Integer, self).__init__(tag, type=enums.Types.INTEGER)
+    def __init__(self,
+                 value=None,
+                 tag=enums.Tags.DEFAULT,
+                 signed=True,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Integer, self).__init__(
+            tag,
+            type=enums.Types.INTEGER,
+            kmip_version=kmip_version
+        )
 
         self.value = value
         if self.value is None:
@@ -313,7 +371,10 @@ class LongInteger(Base):
     MIN = -9223372036854775808
     MAX = 9223372036854775807
 
-    def __init__(self, value=0, tag=enums.Tags.DEFAULT):
+    def __init__(self,
+                 value=0,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Create a LongInteger.
 
@@ -321,8 +382,15 @@ class LongInteger(Base):
             value (int): The value of the LongInteger. Optional, defaults to 0.
             tag (Tags): An enumeration defining the tag of the LongInteger.
                 Optional, defaults to Tags.DEFAULT.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(LongInteger, self).__init__(tag, type=enums.Types.LONG_INTEGER)
+        super(LongInteger, self).__init__(
+            tag,
+            type=enums.Types.LONG_INTEGER,
+            kmip_version=kmip_version
+        )
         self.value = value
         self.length = LongInteger.LENGTH
 
@@ -414,8 +482,15 @@ class BigInteger(Base):
     Section 9.1 of the KMIP 1.1 specification.
     """
 
-    def __init__(self, value=0, tag=enums.Tags.DEFAULT):
-        super(BigInteger, self).__init__(tag, type=enums.Types.BIG_INTEGER)
+    def __init__(self,
+                 value=0,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(BigInteger, self).__init__(
+            tag,
+            type=enums.Types.BIG_INTEGER,
+            kmip_version=kmip_version
+        )
         self.value = value
 
         self.validate()
@@ -548,7 +623,11 @@ class Enumeration(Base):
     MIN = 0
     MAX = 4294967296
 
-    def __init__(self, enum, value=None, tag=enums.Tags.DEFAULT):
+    def __init__(self,
+                 enum,
+                 value=None,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Create an Enumeration.
 
@@ -559,8 +638,15 @@ class Enumeration(Base):
                 (e.g., Tags.DEFAULT). Optional, defaults to None.
             tag (Tags): An enumeration defining the tag of the Enumeration.
                 Optional, defaults to Tags.DEFAULT.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Enumeration, self).__init__(tag, enums.Types.ENUMERATION)
+        super(Enumeration, self).__init__(
+            tag,
+            enums.Types.ENUMERATION,
+            kmip_version=kmip_version
+        )
 
         self.value = value
         self.enum = enum
@@ -673,7 +759,10 @@ class Boolean(Base):
     """
     LENGTH = 8
 
-    def __init__(self, value=True, tag=enums.Tags.DEFAULT):
+    def __init__(self,
+                 value=True,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Create a Boolean object.
 
@@ -681,8 +770,15 @@ class Boolean(Base):
             value (bool): The value of the Boolean. Optional, defaults to True.
             tag (Tags): An enumeration defining the tag of the Boolean object.
                 Optional, defaults to Tags.DEFAULT.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Boolean, self).__init__(tag, type=enums.Types.BOOLEAN)
+        super(Boolean, self).__init__(
+            tag,
+            type=enums.Types.BOOLEAN,
+            kmip_version=kmip_version
+        )
         self.logger = logging.getLogger(__name__)
         self.value = value
         self.length = self.LENGTH
@@ -788,8 +884,15 @@ class TextString(Base):
     PADDING_SIZE = 8
     BYTE_FORMAT = '!c'
 
-    def __init__(self, value=None, tag=enums.Tags.DEFAULT):
-        super(TextString, self).__init__(tag, type=enums.Types.TEXT_STRING)
+    def __init__(self,
+                 value=None,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(TextString, self).__init__(
+            tag,
+            type=enums.Types.TEXT_STRING,
+            kmip_version=kmip_version
+        )
 
         if value is None:
             self.value = ''
@@ -882,8 +985,15 @@ class ByteString(Base):
     PADDING_SIZE = 8
     BYTE_FORMAT = '!B'
 
-    def __init__(self, value=None, tag=enums.Tags.DEFAULT):
-        super(ByteString, self).__init__(tag, type=enums.Types.BYTE_STRING)
+    def __init__(self,
+                 value=None,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ByteString, self).__init__(
+            tag,
+            type=enums.Types.BYTE_STRING,
+            kmip_version=kmip_version
+        )
 
         if value is None:
             self.value = bytes()
@@ -985,7 +1095,10 @@ class DateTime(LongInteger):
     more information, see Section 9.1 of the KMIP 1.1 specification.
     """
 
-    def __init__(self, value=None, tag=enums.Tags.DEFAULT):
+    def __init__(self,
+                 value=None,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Create a DateTime.
 
@@ -995,10 +1108,13 @@ class DateTime(LongInteger):
                 Optional, defaults to the current time.
             tag (Tags): An enumeration defining the tag of the LongInteger.
                 Optional, defaults to Tags.DEFAULT.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
         if value is None:
             value = int(time.time())
-        super(DateTime, self).__init__(value, tag)
+        super(DateTime, self).__init__(value, tag, kmip_version=kmip_version)
         self.type = enums.Types.DATE_TIME
 
     def __repr__(self):
@@ -1023,8 +1139,15 @@ class Interval(Base):
     MIN = 0
     MAX = 4294967296
 
-    def __init__(self, value=0, tag=enums.Tags.DEFAULT):
-        super(Interval, self).__init__(tag, type=enums.Types.INTERVAL)
+    def __init__(self,
+                 value=0,
+                 tag=enums.Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Interval, self).__init__(
+            tag,
+            type=enums.Types.INTERVAL,
+            kmip_version=kmip_version
+        )
 
         self.value = value
         self.length = Interval.LENGTH

--- a/kmip/core/secrets.py
+++ b/kmip/core/secrets.py
@@ -47,7 +47,8 @@ class Certificate(Struct):
 
     def __init__(self,
                  certificate_type=None,
-                 certificate_value=None):
+                 certificate_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Construct a Certificate object.
 
@@ -56,8 +57,14 @@ class Certificate(Struct):
                 certificate. Optional, defaults to None.
             certificate_value (bytes): The bytes of the certificate. Optional,
                 defaults to None.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version the object will be used with. Optional, defaults to
+                KMIP 1.0.
         """
-        super(Certificate, self).__init__(Tags.CERTIFICATE)
+        super(Certificate, self).__init__(
+            Tags.CERTIFICATE,
+            kmip_version=kmip_version
+        )
 
         if certificate_type is None:
             self.certificate_type = CertificateType()
@@ -136,8 +143,11 @@ class Certificate(Struct):
 # 2.2.2
 class KeyBlockKey(Struct):
 
-    def __init__(self, key_block=None, tag=Tags.DEFAULT):
-        super(KeyBlockKey, self).__init__(tag)
+    def __init__(self,
+                 key_block=None,
+                 tag=Tags.DEFAULT,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyBlockKey, self).__init__(tag, kmip_version=kmip_version)
         self.key_block = key_block
         self.validate()
 
@@ -171,8 +181,14 @@ class KeyBlockKey(Struct):
 
 class SymmetricKey(KeyBlockKey):
 
-    def __init__(self, key_block=None):
-        super(SymmetricKey, self).__init__(key_block, Tags.SYMMETRIC_KEY)
+    def __init__(self,
+                 key_block=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(SymmetricKey, self).__init__(
+            key_block,
+            Tags.SYMMETRIC_KEY,
+            kmip_version=kmip_version
+        )
         self.validate()
 
     def validate(self):
@@ -186,8 +202,14 @@ class SymmetricKey(KeyBlockKey):
 # 2.2.3
 class PublicKey(KeyBlockKey):
 
-    def __init__(self, key_block=None):
-        super(PublicKey, self).__init__(key_block, Tags.PUBLIC_KEY)
+    def __init__(self,
+                 key_block=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(PublicKey, self).__init__(
+            key_block,
+            Tags.PUBLIC_KEY,
+            kmip_version=kmip_version
+        )
         self.validate()
 
     def validate(self):
@@ -201,8 +223,14 @@ class PublicKey(KeyBlockKey):
 # 2.2.4
 class PrivateKey(KeyBlockKey):
 
-    def __init__(self, key_block=None):
-        super(PrivateKey, self).__init__(key_block, Tags.PRIVATE_KEY)
+    def __init__(self,
+                 key_block=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(PrivateKey, self).__init__(
+            key_block,
+            Tags.PRIVATE_KEY,
+            kmip_version=kmip_version
+        )
         self.validate()
 
     def validate(self):
@@ -218,33 +246,59 @@ class SplitKey(Struct):
 
     class SplitKeyParts(Integer):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SplitKey.SplitKeyParts, self).__init__(
-                value, Tags.SPLIT_KEY_PARTS)
+                value,
+                Tags.SPLIT_KEY_PARTS,
+                kmip_version=kmip_version
+            )
 
     class KeyPartIdentifier(Integer):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SplitKey.KeyPartIdentifier, self).__init__(
-                value, Tags.KEY_PART_IDENTIFIER)
+                value,
+                Tags.KEY_PART_IDENTIFIER,
+                kmip_version=kmip_version
+            )
 
     class SplitKeyThreshold(Integer):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SplitKey.SplitKeyThreshold, self).__init__(
-                value, Tags.SPLIT_KEY_THRESHOLD)
+                value,
+                Tags.SPLIT_KEY_THRESHOLD,
+                kmip_version=kmip_version
+            )
 
     class SplitKeyMethod(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SplitKey.SplitKeyMethod, self).__init__(
-                enums.SplitKeyMethod, value, Tags.SPLIT_KEY_METHOD)
+                enums.SplitKeyMethod,
+                value,
+                Tags.SPLIT_KEY_METHOD,
+                kmip_version=kmip_version
+            )
 
     class PrimeFieldSize(BigInteger):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SplitKey.PrimeFieldSize, self).__init__(
-                value, Tags.PRIME_FIELD_SIZE)
+                value,
+                Tags.PRIME_FIELD_SIZE,
+                kmip_version=kmip_version
+            )
 
     def __init__(self,
                  split_key_parts=None,
@@ -252,8 +306,12 @@ class SplitKey(Struct):
                  split_key_threshold=None,
                  split_key_method=None,
                  prime_field_size=None,
-                 key_block=None):
-        super(SplitKey, self).__init__(Tags.SPLIT_KEY)
+                 key_block=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(SplitKey, self).__init__(
+            Tags.SPLIT_KEY,
+            kmip_version=kmip_version
+        )
         self.split_key_parts = split_key_parts
         self.key_part_identifier = key_part_identifier
         self.split_key_threshold = split_key_threshold
@@ -314,8 +372,13 @@ class SplitKey(Struct):
 # 2.2.6
 class Template(Struct):
 
-    def __init__(self, attributes=None):
-        super(Template, self).__init__(Tags.TEMPLATE)
+    def __init__(self,
+                 attributes=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Template, self).__init__(
+            Tags.TEMPLATE,
+            kmip_version=kmip_version
+        )
         self.attributes = attributes
         self.validate()
 
@@ -361,14 +424,24 @@ class SecretData(Struct):
 
     class SecretDataType(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(SecretData.SecretDataType, self).__init__(
-                enums.SecretDataType, value, Tags.SECRET_DATA_TYPE)
+                enums.SecretDataType,
+                value,
+                Tags.SECRET_DATA_TYPE,
+                kmip_version=kmip_version
+            )
 
     def __init__(self,
                  secret_data_type=None,
-                 key_block=None):
-        super(SecretData, self).__init__(Tags.SECRET_DATA)
+                 key_block=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(SecretData, self).__init__(
+            Tags.SECRET_DATA,
+            kmip_version=kmip_version
+        )
         self.secret_data_type = secret_data_type
         self.key_block = key_block
         self.validate()
@@ -410,20 +483,35 @@ class OpaqueObject(Struct):
 
     class OpaqueDataType(Enumeration):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(OpaqueObject.OpaqueDataType, self).__init__(
-                enums.OpaqueDataType, value, Tags.OPAQUE_DATA_TYPE)
+                enums.OpaqueDataType,
+                value,
+                Tags.OPAQUE_DATA_TYPE,
+                kmip_version=kmip_version
+            )
 
     class OpaqueDataValue(ByteString):
 
-        def __init__(self, value=None):
+        def __init__(self,
+                     value=None,
+                     kmip_version=enums.KMIPVersion.KMIP_1_0):
             super(OpaqueObject.OpaqueDataValue, self).__init__(
-                value, Tags.OPAQUE_DATA_VALUE)
+                value,
+                Tags.OPAQUE_DATA_VALUE,
+                kmip_version=kmip_version
+            )
 
     def __init__(self,
                  opaque_data_type=None,
-                 opaque_data_value=None):
-        super(OpaqueObject, self).__init__(Tags.OPAQUE_OBJECT)
+                 opaque_data_value=None,
+                 kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(OpaqueObject, self).__init__(
+            Tags.OPAQUE_OBJECT,
+            kmip_version=kmip_version
+        )
         self.opaque_data_type = opaque_data_type
         self.opaque_data_value = opaque_data_value
         self.validate()


### PR DESCRIPTION
This change updates the PyKMIP object hierarchy allowing it to store the KMIP version for which instantiated objects should be encoded and/or decoded. This is primarily a change in object constructors and base classes and does not greatly impact the existing object test infrastructure.