### PR TITLE
Update the Travis CI config to output log files on test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -232,3 +232,7 @@ script:
   - ./.travis/run.sh
 after_success:
   - codecov
+after_failure:
+  - if [ -f "/tmp/pykmip/server.log" ]; then cat /tmp/pykmip/server.log; fi
+  - if [ -f "/tmp/slugs/access.log"  ]; then cat /tmp/slugs/access.log;  fi
+  - if [ -f "/tmp/slugs/error.log"   ]; then cat /tmp/slugs/error.log;   fi


### PR DESCRIPTION
This change updates the Travis CI configuration file to output the contents of the PyKMIP server and SLUGS log files if:

* a test failure occurred, and
* the log files exist in the test environment

This makes debugging server and service failures much easier in Travis CI, specifically during integration and functional test suite runs.