### PR TITLE
Update object hierarchy read/write to support the KMIP version

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -108,28 +108,28 @@ class Name(Struct):
         self.name_type = name_type
         self.validate()
 
-    def read(self, istream):
-        super(Name, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Name, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the value and type of the name
         self.name_value = Name.NameValue()
         self.name_type = Name.NameType()
-        self.name_value.read(tstream)
-        self.name_type.read(tstream)
+        self.name_value.read(tstream, kmip_version=kmip_version)
+        self.name_type.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the value and type of the name
-        self.name_value.write(tstream)
-        self.name_type.write(tstream)
+        self.name_value.write(tstream, kmip_version=kmip_version)
+        self.name_type.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(Name, self).write(ostream)
+        super(Name, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -576,8 +576,11 @@ class CryptographicParameters(Struct):
         else:
             raise TypeError("initial counter value must be an integer")
 
-    def read(self, istream):
-        super(CryptographicParameters, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CryptographicParameters, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.BLOCK_CIPHER_MODE, tstream):
@@ -585,109 +588,136 @@ class CryptographicParameters(Struct):
                 enums.BlockCipherMode,
                 tag=Tags.BLOCK_CIPHER_MODE
             )
-            self._block_cipher_mode.read(tstream)
+            self._block_cipher_mode.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.PADDING_METHOD, tstream):
             self._padding_method = Enumeration(
                 enums.PaddingMethod,
                 tag=Tags.PADDING_METHOD
             )
-            self._padding_method.read(tstream)
+            self._padding_method.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.HASHING_ALGORITHM, tstream):
             self._hashing_algorithm = Enumeration(
                 enums.HashingAlgorithm,
                 tag=Tags.HASHING_ALGORITHM
             )
-            self._hashing_algorithm.read(tstream)
+            self._hashing_algorithm.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.KEY_ROLE_TYPE, tstream):
             self._key_role_type = Enumeration(
                 enums.KeyRoleType,
                 tag=Tags.KEY_ROLE_TYPE
             )
-            self._key_role_type.read(tstream)
+            self._key_role_type.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.DIGITAL_SIGNATURE_ALGORITHM, tstream):
             self._digital_signature_algorithm = Enumeration(
                 enums.DigitalSignatureAlgorithm,
                 tag=Tags.DIGITAL_SIGNATURE_ALGORITHM
             )
-            self._digital_signature_algorithm.read(tstream)
+            self._digital_signature_algorithm.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(Tags.CRYPTOGRAPHIC_ALGORITHM, tstream):
             self._cryptographic_algorithm = Enumeration(
                 enums.CryptographicAlgorithm,
                 tag=Tags.CRYPTOGRAPHIC_ALGORITHM
             )
-            self._cryptographic_algorithm.read(tstream)
+            self._cryptographic_algorithm.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(Tags.RANDOM_IV, tstream):
             self._random_iv = Boolean(tag=Tags.RANDOM_IV)
-            self._random_iv.read(tstream)
+            self._random_iv.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.IV_LENGTH, tstream):
             self._iv_length = Integer(tag=Tags.IV_LENGTH)
-            self._iv_length.read(tstream)
+            self._iv_length.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.TAG_LENGTH, tstream):
             self._tag_length = Integer(tag=Tags.TAG_LENGTH)
-            self._tag_length.read(tstream)
+            self._tag_length.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.FIXED_FIELD_LENGTH, tstream):
             self._fixed_field_length = Integer(tag=Tags.FIXED_FIELD_LENGTH)
-            self._fixed_field_length.read(tstream)
+            self._fixed_field_length.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.INVOCATION_FIELD_LENGTH, tstream):
             self._invocation_field_length = Integer(
                 tag=Tags.INVOCATION_FIELD_LENGTH
             )
-            self._invocation_field_length.read(tstream)
+            self._invocation_field_length.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(Tags.COUNTER_LENGTH, tstream):
             self._counter_length = Integer(tag=Tags.COUNTER_LENGTH)
-            self._counter_length.read(tstream)
+            self._counter_length.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.INITIAL_COUNTER_VALUE, tstream):
             self._initial_counter_value = Integer(
                 tag=Tags.INITIAL_COUNTER_VALUE
             )
-            self._initial_counter_value.read(tstream)
+            self._initial_counter_value.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self._block_cipher_mode:
-            self._block_cipher_mode.write(tstream)
+            self._block_cipher_mode.write(tstream, kmip_version=kmip_version)
         if self._padding_method:
-            self._padding_method.write(tstream)
+            self._padding_method.write(tstream, kmip_version=kmip_version)
         if self._hashing_algorithm:
-            self._hashing_algorithm.write(tstream)
+            self._hashing_algorithm.write(tstream, kmip_version=kmip_version)
         if self._key_role_type:
-            self._key_role_type.write(tstream)
+            self._key_role_type.write(tstream, kmip_version=kmip_version)
         if self._digital_signature_algorithm:
-            self._digital_signature_algorithm.write(tstream)
+            self._digital_signature_algorithm.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_algorithm:
-            self._cryptographic_algorithm.write(tstream)
+            self._cryptographic_algorithm.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self._random_iv:
-            self._random_iv.write(tstream)
+            self._random_iv.write(tstream, kmip_version=kmip_version)
         if self._iv_length:
-            self._iv_length.write(tstream)
+            self._iv_length.write(tstream, kmip_version=kmip_version)
         if self._tag_length:
-            self._tag_length.write(tstream)
+            self._tag_length.write(tstream, kmip_version=kmip_version)
         if self._fixed_field_length:
-            self._fixed_field_length.write(tstream)
+            self._fixed_field_length.write(tstream, kmip_version=kmip_version)
         if self._invocation_field_length:
-            self._invocation_field_length.write(tstream)
+            self._invocation_field_length.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self._counter_length:
-            self._counter_length.write(tstream)
+            self._counter_length.write(tstream, kmip_version=kmip_version)
         if self._initial_counter_value:
-            self._initial_counter_value.write(tstream)
+            self._initial_counter_value.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.length = tstream.length()
-        super(CryptographicParameters, self).write(ostream)
+        super(CryptographicParameters, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def __eq__(self, other):
@@ -866,7 +896,7 @@ class Digest(Struct):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Digest object and decode it into its
         constituent parts.
@@ -874,33 +904,39 @@ class Digest(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Digest, self).read(istream)
+        super(Digest, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
-        self.hashing_algorithm.read(tstream)
-        self.digest_value.read(tstream)
-        self.key_format_type.read(tstream)
+        self.hashing_algorithm.read(tstream, kmip_version=kmip_version)
+        self.digest_value.read(tstream, kmip_version=kmip_version)
+        self.key_format_type.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Digest object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
-        self.hashing_algorithm.write(tstream)
-        self.digest_value.write(tstream)
-        self.key_format_type.write(tstream)
+        self.hashing_algorithm.write(tstream, kmip_version=kmip_version)
+        self.digest_value.write(tstream, kmip_version=kmip_version)
+        self.key_format_type.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(Digest, self).write(ostream)
+        super(Digest, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -1115,7 +1151,7 @@ class ApplicationSpecificInformation(Struct):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ApplicationSpecificInformation object and
         decode it into its constituent parts.
@@ -1123,17 +1159,23 @@ class ApplicationSpecificInformation(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(ApplicationSpecificInformation, self).read(istream)
+        super(ApplicationSpecificInformation, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        self.application_namespace.read(tstream)
-        self.application_data.read(tstream)
+        self.application_namespace.read(tstream, kmip_version=kmip_version)
+        self.application_data.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ApplicationSpecificInformation object to a
         stream.
@@ -1141,14 +1183,20 @@ class ApplicationSpecificInformation(Struct):
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
-        self.application_namespace.write(tstream)
-        self.application_data.write(tstream)
+        self.application_namespace.write(tstream, kmip_version=kmip_version)
+        self.application_data.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(ApplicationSpecificInformation, self).write(ostream)
+        super(ApplicationSpecificInformation, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -1392,7 +1440,7 @@ class DerivationParameters(Struct):
         else:
             raise TypeError("iteration count must be an integer")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the DerivationParameters struct and decode it
         into its constituent parts.
@@ -1401,8 +1449,14 @@ class DerivationParameters(Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(DerivationParameters, self).read(input_stream)
+        super(DerivationParameters, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(
@@ -1410,29 +1464,35 @@ class DerivationParameters(Struct):
                 local_stream
         ):
             self._cryptographic_parameters = CryptographicParameters()
-            self._cryptographic_parameters.read(local_stream)
+            self._cryptographic_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.INITIALIZATION_VECTOR, local_stream):
             self._initialization_vector = ByteString(
                 tag=enums.Tags.INITIALIZATION_VECTOR
             )
-            self._initialization_vector.read(local_stream)
+            self._initialization_vector.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.DERIVATION_DATA, local_stream):
             self._derivation_data = ByteString(tag=enums.Tags.DERIVATION_DATA)
-            self._derivation_data.read(local_stream)
+            self._derivation_data.read(local_stream, kmip_version=kmip_version)
 
         if self.is_tag_next(enums.Tags.SALT, local_stream):
             self._salt = ByteString(tag=enums.Tags.SALT)
-            self._salt.read(local_stream)
+            self._salt.read(local_stream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.ITERATION_COUNT, local_stream):
             self._iteration_count = Integer(tag=Tags.ITERATION_COUNT)
-            self._iteration_count.read(local_stream)
+            self._iteration_count.read(local_stream, kmip_version=kmip_version)
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the DerivationParameters struct to a stream.
 
@@ -1440,22 +1500,43 @@ class DerivationParameters(Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         local_stream = BytearrayStream()
 
         if self._cryptographic_parameters:
-            self._cryptographic_parameters.write(local_stream)
+            self._cryptographic_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._initialization_vector:
-            self._initialization_vector.write(local_stream)
+            self._initialization_vector.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._derivation_data:
-            self._derivation_data.write(local_stream)
+            self._derivation_data.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._salt:
-            self._salt.write(local_stream)
+            self._salt.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._iteration_count:
-            self._iteration_count.write(local_stream)
+            self._iteration_count.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(DerivationParameters, self).write(output_stream)
+        super(DerivationParameters, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/messages.py
+++ b/kmip/core/messages/messages.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import Tags
 
 from kmip.core.messages import contents
@@ -48,70 +49,91 @@ class RequestHeader(Struct):
         self.time_stamp = time_stamp
         self.batch_count = batch_count
 
-    def read(self, istream):
-        super(RequestHeader, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestHeader, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.protocol_version = contents.ProtocolVersion()
-        self.protocol_version.read(tstream)
+        self.protocol_version.read(tstream, kmip_version=kmip_version)
 
         # Read the maximum response size if it is present
         if self.is_tag_next(Tags.MAXIMUM_RESPONSE_SIZE, tstream):
             self.maximum_response_size = contents.MaximumResponseSize()
-            self.maximum_response_size.read(tstream)
+            self.maximum_response_size.read(tstream, kmip_version=kmip_version)
 
         # Read the asynchronous indicator if it is present
         if self.is_tag_next(Tags.ASYNCHRONOUS_INDICATOR, tstream):
             self.asynchronous_indicator = contents.AsynchronousIndicator()
-            self.asynchronous_indicator.read(tstream)
+            self.asynchronous_indicator.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         # Read the authentication if it is present
         if self.is_tag_next(Tags.AUTHENTICATION, tstream):
             self.authentication = contents.Authentication()
-            self.authentication.read(tstream)
+            self.authentication.read(tstream, kmip_version=kmip_version)
 
         # Read the batch error continuation option if it is present
         if self.is_tag_next(Tags.BATCH_ERROR_CONTINUATION_OPTION, tstream):
             self.batch_error_cont_option = BatchErrorContinuationOption()
-            self.batch_error_cont_option.read(tstream)
+            self.batch_error_cont_option.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         # Read the batch order option if it is present
         if self.is_tag_next(Tags.BATCH_ORDER_OPTION, tstream):
             self.batch_order_option = contents.BatchOrderOption()
-            self.batch_order_option.read(tstream)
+            self.batch_order_option.read(tstream, kmip_version=kmip_version)
 
         # Read the time stamp if it is present
         if self.is_tag_next(Tags.TIME_STAMP, tstream):
             self.time_stamp = contents.TimeStamp()
-            self.time_stamp.read(tstream)
+            self.time_stamp.read(tstream, kmip_version=kmip_version)
 
         self.batch_count = contents.BatchCount()
-        self.batch_count.read(tstream)
+        self.batch_count.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of a request header to the stream
-        self.protocol_version.write(tstream)
+        self.protocol_version.write(tstream, kmip_version=kmip_version)
         if self.maximum_response_size is not None:
-            self.maximum_response_size.write(tstream)
+            self.maximum_response_size.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self.asynchronous_indicator is not None:
-            self.asynchronous_indicator.write(tstream)
+            self.asynchronous_indicator.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self.authentication is not None:
-            self.authentication.write(tstream)
+            self.authentication.write(tstream, kmip_version=kmip_version)
         if self.batch_error_cont_option is not None:
-            self.batch_error_cont_option.write(tstream)
+            self.batch_error_cont_option.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self.batch_order_option is not None:
-            self.batch_order_option.write(tstream)
+            self.batch_order_option.write(tstream, kmip_version=kmip_version)
         if self.time_stamp is not None:
-            self.time_stamp.write(tstream)
-        self.batch_count.write(tstream)
+            self.time_stamp.write(tstream, kmip_version=kmip_version)
+        self.batch_count.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request header
         self.length = tstream.length()
-        super(RequestHeader, self).write(ostream)
+        super(RequestHeader, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
 
@@ -127,33 +149,39 @@ class ResponseHeader(Struct):
         self.batch_count = batch_count
         self.validate()
 
-    def read(self, istream):
-        super(ResponseHeader, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseHeader, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.protocol_version = contents.ProtocolVersion()
-        self.protocol_version.read(tstream)
+        self.protocol_version.read(tstream, kmip_version=kmip_version)
 
         self.time_stamp = contents.TimeStamp()
-        self.time_stamp.read(tstream)
+        self.time_stamp.read(tstream, kmip_version=kmip_version)
 
         self.batch_count = contents.BatchCount()
-        self.batch_count.read(tstream)
+        self.batch_count.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of a response header to the stream
-        self.protocol_version.write(tstream)
-        self.time_stamp.write(tstream)
-        self.batch_count.write(tstream)
+        self.protocol_version.write(tstream, kmip_version=kmip_version)
+        self.time_stamp.write(tstream, kmip_version=kmip_version)
+        self.batch_count.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request header
         self.length = tstream.length()
-        super(ResponseHeader, self).write(ostream)
+        super(ResponseHeader, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -181,49 +209,55 @@ class RequestBatchItem(Struct):
         self.request_payload = request_payload
         self.message_extension = message_extension
 
-    def read(self, istream):
-        super(RequestBatchItem, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestBatchItem, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the batch item operation
         self.operation = contents.Operation()
-        self.operation.read(tstream)
+        self.operation.read(tstream, kmip_version=kmip_version)
 
         # Read the unique batch item ID if it is present
         if self.is_tag_next(Tags.UNIQUE_BATCH_ITEM_ID, tstream):
             self.unique_batch_item_id = contents.UniqueBatchItemID()
-            self.unique_batch_item_id.read(tstream)
+            self.unique_batch_item_id.read(tstream, kmip_version=kmip_version)
 
         # Dynamically create the response payload class that belongs to the
         # operation
         self.request_payload = self.payload_factory.create(
             self.operation.value)
-        self.request_payload.read(tstream)
+        self.request_payload.read(tstream, kmip_version=kmip_version)
 
         # Read the message extension if it is present
         if self.is_tag_next(Tags.MESSAGE_EXTENSION, tstream):
             self.message_extension = contents.MessageExtension()
-            self.message_extension.read(tstream)
+            self.message_extension.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of the batch item to the stream
-        self.operation.write(tstream)
+        self.operation.write(tstream, kmip_version=kmip_version)
 
         if self.unique_batch_item_id is not None:
-            self.unique_batch_item_id.write(tstream)
+            self.unique_batch_item_id.write(tstream, kmip_version=kmip_version)
 
-        self.request_payload.write(tstream)
+        self.request_payload.write(tstream, kmip_version=kmip_version)
 
         if self.message_extension is not None:
-            self.message_extension.write(tstream)
+            self.message_extension.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the batch item
         self.length = tstream.length()
-        super(RequestBatchItem, self).write(ostream)
+        super(RequestBatchItem, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
 
@@ -252,38 +286,44 @@ class ResponseBatchItem(Struct):
         self.message_extension = message_extension
         self.validate()
 
-    def read(self, istream):
-        super(ResponseBatchItem, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseBatchItem, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         # Read the batch item operation if it is present
         if self.is_tag_next(Tags.OPERATION, tstream):
             self.operation = contents.Operation()
-            self.operation.read(tstream)
+            self.operation.read(tstream, kmip_version=kmip_version)
 
         # Read the unique batch item ID if it is present
         if self.is_tag_next(Tags.UNIQUE_BATCH_ITEM_ID, tstream):
             self.unique_batch_item_id = contents.UniqueBatchItemID()
-            self.unique_batch_item_id.read(tstream)
+            self.unique_batch_item_id.read(tstream, kmip_version=kmip_version)
 
         # Read the batch item result status
         self.result_status = contents.ResultStatus()
-        self.result_status.read(tstream)
+        self.result_status.read(tstream, kmip_version=kmip_version)
 
         # Read the batch item result reason if it is present
         if self.is_tag_next(Tags.RESULT_REASON, tstream):
             self.result_reason = contents.ResultReason()
-            self.result_reason.read(tstream)
+            self.result_reason.read(tstream, kmip_version=kmip_version)
 
         # Read the batch item result message if it is present
         if self.is_tag_next(Tags.RESULT_MESSAGE, tstream):
             self.result_message = contents.ResultMessage()
-            self.result_message.read(tstream)
+            self.result_message.read(tstream, kmip_version=kmip_version)
 
         # Read the batch item asynchronous correlation value if it is present
         if self.is_tag_next(Tags.ASYNCHRONOUS_CORRELATION_VALUE, tstream):
             self.async_correlation_value = AsynchronousCorrelationValue()
-            self.async_correlation_value.read(tstream)
+            self.async_correlation_value.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if (self.operation is not None):
             # Dynamically create the response payload class that belongs to the
@@ -291,41 +331,47 @@ class ResponseBatchItem(Struct):
             expected = self.payload_factory.create(self.operation.value)
             if self.is_tag_next(expected.tag, tstream):
                 self.response_payload = expected
-                self.response_payload.read(tstream)
+                self.response_payload.read(tstream, kmip_version=kmip_version)
 
         # Read the message extension if it is present
         if self.is_tag_next(Tags.MESSAGE_EXTENSION, tstream):
             self.message_extension = contents.MessageExtension()
-            self.message_extension.read(tstream)
+            self.message_extension.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of the batch item to the stream
         if self.operation is not None:
-            self.operation.write(tstream)
+            self.operation.write(tstream, kmip_version=kmip_version)
         if self.unique_batch_item_id is not None:
-            self.unique_batch_item_id.write(tstream)
+            self.unique_batch_item_id.write(tstream, kmip_version=kmip_version)
 
-        self.result_status.write(tstream)
+        self.result_status.write(tstream, kmip_version=kmip_version)
 
         if self.result_reason is not None:
-            self.result_reason.write(tstream)
+            self.result_reason.write(tstream, kmip_version=kmip_version)
         if self.result_message is not None:
-            self.result_message.write(tstream)
+            self.result_message.write(tstream, kmip_version=kmip_version)
         if self.async_correlation_value is not None:
-            self.async_correlation_value.write(tstream)
+            self.async_correlation_value.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self.response_payload is not None:
-            self.response_payload.write(tstream)
+            self.response_payload.write(tstream, kmip_version=kmip_version)
         if self.message_extension is not None:
-            self.message_extension.write(tstream)
+            self.message_extension.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the batch item
         self.length = tstream.length()
-        super(ResponseBatchItem, self).write(ostream)
+        super(ResponseBatchItem, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -339,29 +385,35 @@ class RequestMessage(Struct):
         self.request_header = request_header
         self.batch_items = batch_items
 
-    def read(self, istream):
-        super(RequestMessage, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RequestMessage, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
 
         self.request_header = RequestHeader()
-        self.request_header.read(istream)
+        self.request_header.read(istream, kmip_version=kmip_version)
 
         self.batch_items = []
         for _ in range(self.request_header.batch_count.value):
             batch_item = RequestBatchItem()
-            batch_item.read(istream)
+            batch_item.read(istream, kmip_version=kmip_version)
             self.batch_items.append(batch_item)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the request header and all batch items
-        self.request_header.write(tstream)
+        self.request_header.write(tstream, kmip_version=kmip_version)
         for batch_item in self.batch_items:
-            batch_item.write(tstream)
+            batch_item.write(tstream, kmip_version=kmip_version)
 
         # Write the TTLV encoding of the request message
         self.length = tstream.length()
-        super(RequestMessage, self).write(ostream)
+        super(RequestMessage, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
 
@@ -373,30 +425,36 @@ class ResponseMessage(Struct):
         self.batch_items = batch_items
         self.validate()
 
-    def read(self, istream):
-        super(ResponseMessage, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ResponseMessage, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
 
         self.response_header = ResponseHeader()
-        self.response_header.read(istream)
+        self.response_header.read(istream, kmip_version=kmip_version)
 
         self.batch_items = []
         for _ in range(self.response_header.batch_count.value):
             batch_item = ResponseBatchItem()
-            batch_item.read(istream)
+            batch_item.read(istream, kmip_version=kmip_version)
             self.batch_items.append(batch_item)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the request header and all batch items
-        self.response_header.write(tstream)
+        self.response_header.write(tstream, kmip_version=kmip_version)
         for batch_item in self.batch_items:
-            batch_item.write(tstream)
+            batch_item.write(tstream, kmip_version=kmip_version)
 
         # Write the TTLV encoding of the request message
         self.length = tstream.length()
-        super(ResponseMessage, self).write(ostream)
+        super(ResponseMessage, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/activate.py
+++ b/kmip/core/messages/payloads/activate.py
@@ -45,39 +45,51 @@ class ActivateRequestPayload(Struct):
         self.unique_identifier = unique_identifier
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ActivateRequestPayload object and decode it
         into its constituent parts.
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(ActivateRequestPayload, self).read(istream)
+        super(ActivateRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ActivateRequestPayload object to a stream.
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         # Write the contents of the request payload
         if self.unique_identifier is not None:
-            self.unique_identifier.write(tstream)
+            self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(ActivateRequestPayload, self).write(ostream)
+        super(ActivateRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -118,7 +130,7 @@ class ActivateResponsePayload(Struct):
             self.unique_identifier = unique_identifier
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ActivateResponsePayload object and decode it
         into its constituent parts.
@@ -126,32 +138,44 @@ class ActivateResponsePayload(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(ActivateResponsePayload, self).read(istream)
+        super(ActivateResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ActivateResponsePayload object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         # Write the contents of the response payload
-        self.unique_identifier.write(tstream)
+        self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(ActivateResponsePayload, self).write(ostream)
+        super(ActivateResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/archive.py
+++ b/kmip/core/messages/payloads/archive.py
@@ -62,7 +62,7 @@ class ArchiveRequestPayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Archive request payload and decode it into
         its constituent parts.
@@ -71,23 +71,32 @@ class ArchiveRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(ArchiveRequestPayload, self).read(input_stream)
+        super(ArchiveRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Archive request payload to a stream.
 
@@ -95,6 +104,9 @@ class ArchiveRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -102,10 +114,16 @@ class ArchiveRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(ArchiveRequestPayload, self).write(output_stream)
+        super(ArchiveRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -175,7 +193,7 @@ class ArchiveResponsePayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Archive response payload and decode it
         into its constituent parts.
@@ -184,23 +202,32 @@ class ArchiveResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(ArchiveResponsePayload, self).read(input_stream)
+        super(ArchiveResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Archive response payload to a stream.
 
@@ -208,6 +235,9 @@ class ArchiveResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -215,10 +245,16 @@ class ArchiveResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(ArchiveResponsePayload, self).write(output_stream)
+        super(ArchiveResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/cancel.py
+++ b/kmip/core/messages/payloads/cancel.py
@@ -63,7 +63,7 @@ class CancelRequestPayload(primitives.Struct):
         else:
             raise TypeError("Asynchronous correlation value must be bytes.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Cancel request payload and decode it into
         its constituent parts.
@@ -72,12 +72,18 @@ class CancelRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(CancelRequestPayload, self).read(input_stream)
+        super(CancelRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(
@@ -87,11 +93,14 @@ class CancelRequestPayload(primitives.Struct):
             self._asynchronous_correlation_value = primitives.ByteString(
                 tag=enums.Tags.ASYNCHRONOUS_CORRELATION_VALUE
             )
-            self._asynchronous_correlation_value.read(local_stream)
+            self._asynchronous_correlation_value.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Cancel request payload to a stream.
 
@@ -99,6 +108,9 @@ class CancelRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -106,10 +118,16 @@ class CancelRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._asynchronous_correlation_value:
-            self._asynchronous_correlation_value.write(local_stream)
+            self._asynchronous_correlation_value.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(CancelRequestPayload, self).write(output_stream)
+        super(CancelRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -216,7 +234,7 @@ class CancelResponsePayload(primitives.Struct):
                 "Cancellation result must be a CancellationResult enumeration."
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Cancel response payload and decode it into
         its constituent parts.
@@ -225,12 +243,18 @@ class CancelResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(CancelResponsePayload, self).read(input_stream)
+        super(CancelResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(
@@ -240,17 +264,23 @@ class CancelResponsePayload(primitives.Struct):
             self._asynchronous_correlation_value = primitives.ByteString(
                 tag=enums.Tags.ASYNCHRONOUS_CORRELATION_VALUE
             )
-            self._asynchronous_correlation_value.read(local_stream)
+            self._asynchronous_correlation_value.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.CANCELLATION_RESULT, local_stream):
             self._cancellation_result = primitives.Enumeration(
                 enums.CancellationResult,
                 tag=enums.Tags.CANCELLATION_RESULT
             )
-            self._cancellation_result.read(local_stream)
+            self._cancellation_result.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Cancel response payload to a stream.
 
@@ -258,6 +288,9 @@ class CancelResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -265,12 +298,21 @@ class CancelResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._asynchronous_correlation_value:
-            self._asynchronous_correlation_value.write(local_stream)
+            self._asynchronous_correlation_value.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cancellation_result:
-            self._cancellation_result.write(local_stream)
+            self._cancellation_result.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(CancelResponsePayload, self).write(output_stream)
+        super(CancelResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/check.py
+++ b/kmip/core/messages/payloads/check.py
@@ -143,7 +143,7 @@ class CheckRequestPayload(primitives.Struct):
         else:
             raise TypeError("Lease time must be an integer.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Check request payload and decode it into
         its constituent parts.
@@ -152,38 +152,53 @@ class CheckRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(CheckRequestPayload, self).read(input_stream)
+        super(CheckRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.USAGE_LIMITS_COUNT, local_stream):
             self._usage_limits_count = primitives.LongInteger(
                 tag=enums.Tags.USAGE_LIMITS_COUNT
             )
-            self._usage_limits_count.read(local_stream)
+            self._usage_limits_count.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.CRYPTOGRAPHIC_USAGE_MASK, local_stream):
             self._cryptographic_usage_mask = primitives.Integer(
                 tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
             )
-            self._cryptographic_usage_mask.read(local_stream)
+            self._cryptographic_usage_mask.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.LEASE_TIME, local_stream):
             self._lease_time = primitives.Interval(
                 tag=enums.Tags.LEASE_TIME
             )
-            self._lease_time.read(local_stream)
+            self._lease_time.read(local_stream, kmip_version=kmip_version)
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Check request payload to a stream.
 
@@ -191,6 +206,9 @@ class CheckRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -198,16 +216,31 @@ class CheckRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._usage_limits_count:
-            self._usage_limits_count.write(local_stream)
+            self._usage_limits_count.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_usage_mask:
-            self._cryptographic_usage_mask.write(local_stream)
+            self._cryptographic_usage_mask.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._lease_time:
-            self._lease_time.write(local_stream)
+            self._lease_time.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(CheckRequestPayload, self).write(output_stream)
+        super(CheckRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -375,7 +408,7 @@ class CheckResponsePayload(primitives.Struct):
         else:
             raise TypeError("Lease time must be an integer.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Check response payload and decode it into
         its constituent parts.
@@ -384,38 +417,56 @@ class CheckResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(CheckResponsePayload, self).read(input_stream)
+        super(CheckResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.USAGE_LIMITS_COUNT, local_stream):
             self._usage_limits_count = primitives.LongInteger(
                 tag=enums.Tags.USAGE_LIMITS_COUNT
             )
-            self._usage_limits_count.read(local_stream)
+            self._usage_limits_count.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.CRYPTOGRAPHIC_USAGE_MASK, local_stream):
             self._cryptographic_usage_mask = primitives.Integer(
                 tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
             )
-            self._cryptographic_usage_mask.read(local_stream)
+            self._cryptographic_usage_mask.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.LEASE_TIME, local_stream):
             self._lease_time = primitives.Interval(
                 tag=enums.Tags.LEASE_TIME
             )
-            self._lease_time.read(local_stream)
+            self._lease_time.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Check response payload to a stream.
 
@@ -423,6 +474,9 @@ class CheckResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -430,16 +484,31 @@ class CheckResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._usage_limits_count:
-            self._usage_limits_count.write(local_stream)
+            self._usage_limits_count.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_usage_mask:
-            self._cryptographic_usage_mask.write(local_stream)
+            self._cryptographic_usage_mask.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._lease_time:
-            self._lease_time.write(local_stream)
+            self._lease_time.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(CheckResponsePayload, self).write(output_stream)
+        super(CheckResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/create.py
+++ b/kmip/core/messages/payloads/create.py
@@ -35,29 +35,35 @@ class CreateRequestPayload(Struct):
         self.template_attribute = template_attribute
         self.validate()
 
-    def read(self, istream):
-        super(CreateRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CreateRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
         self.template_attribute = TemplateAttribute()
 
-        self.object_type.read(tstream)
-        self.template_attribute.read(tstream)
+        self.object_type.read(tstream, kmip_version=kmip_version)
+        self.template_attribute.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the object type and template attribute of the request payload
-        self.object_type.write(tstream)
-        self.template_attribute.write(tstream)
+        self.object_type.write(tstream, kmip_version=kmip_version)
+        self.template_attribute.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(CreateRequestPayload, self).write(ostream)
+        super(CreateRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -78,36 +84,42 @@ class CreateResponsePayload(Struct):
         self.template_attribute = template_attribute
         self.validate()
 
-    def read(self, istream):
-        super(CreateResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CreateResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
         self.unique_identifier = attributes.UniqueIdentifier()
 
-        self.object_type.read(tstream)
-        self.unique_identifier.read(tstream)
+        self.object_type.read(tstream, kmip_version=kmip_version)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.TEMPLATE_ATTRIBUTE, tstream):
             self.template_attribute = TemplateAttribute()
-            self.template_attribute.read(tstream)
+            self.template_attribute.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of the request payload
-        self.object_type.write(tstream)
-        self.unique_identifier.write(tstream)
+        self.object_type.write(tstream, kmip_version=kmip_version)
+        self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         if self.template_attribute is not None:
-            self.template_attribute.write(tstream)
+            self.template_attribute.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(CreateResponsePayload, self).write(ostream)
+        super(CreateResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/create_key_pair.py
+++ b/kmip/core/messages/payloads/create_key_pair.py
@@ -16,7 +16,7 @@
 from kmip.core import attributes
 from kmip.core import objects
 
-from kmip.core.enums import Tags
+from kmip.core import enums
 
 from kmip.core.primitives import Struct
 
@@ -29,7 +29,9 @@ class CreateKeyPairRequestPayload(Struct):
                  common_template_attribute=None,
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
-        super(CreateKeyPairRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(CreateKeyPairRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD
+        )
 
         self.common_template_attribute = common_template_attribute
         self.private_key_template_attribute = private_key_template_attribute
@@ -37,41 +39,66 @@ class CreateKeyPairRequestPayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(CreateKeyPairRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CreateKeyPairRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        if self.is_tag_next(Tags.COMMON_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.COMMON_TEMPLATE_ATTRIBUTE, tstream):
             self.common_template_attribute = objects.CommonTemplateAttribute()
-            self.common_template_attribute.read(tstream)
+            self.common_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+                            tstream):
             self.private_key_template_attribute = \
                 objects.PrivateKeyTemplateAttribute()
-            self.private_key_template_attribute.read(tstream)
+            self.private_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
             self.public_key_template_attribute = \
                 objects.PublicKeyTemplateAttribute()
-            self.public_key_template_attribute.read(tstream)
+            self.public_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self.common_template_attribute is not None:
-            self.common_template_attribute.write(tstream)
+            self.common_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.private_key_template_attribute is not None:
-            self.private_key_template_attribute.write(tstream)
+            self.private_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.public_key_template_attribute is not None:
-            self.public_key_template_attribute.write(tstream)
+            self.public_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.length = tstream.length()
-        super(CreateKeyPairRequestPayload, self).write(ostream)
+        super(CreateKeyPairRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -114,7 +141,8 @@ class CreateKeyPairResponsePayload(Struct):
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
         super(CreateKeyPairResponsePayload, self).__init__(
-            Tags.RESPONSE_PAYLOAD)
+            enums.Tags.RESPONSE_PAYLOAD
+        )
 
         # Private and public UUIDs are required so make defaults as backup
         if private_key_uuid is None:
@@ -132,40 +160,60 @@ class CreateKeyPairResponsePayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(CreateKeyPairResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(CreateKeyPairResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        self.private_key_uuid.read(tstream)
-        self.public_key_uuid.read(tstream)
+        self.private_key_uuid.read(tstream, kmip_version=kmip_version)
+        self.public_key_uuid.read(tstream, kmip_version=kmip_version)
 
-        if self.is_tag_next(Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+                            tstream):
             self.private_key_template_attribute = \
                 objects.PrivateKeyTemplateAttribute()
-            self.private_key_template_attribute.read(tstream)
+            self.private_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE,
+                            tstream):
             self.public_key_template_attribute = \
                 objects.PublicKeyTemplateAttribute()
-            self.public_key_template_attribute.read(tstream)
+            self.public_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.private_key_uuid.write(tstream)
-        self.public_key_uuid.write(tstream)
+        self.private_key_uuid.write(tstream, kmip_version=kmip_version)
+        self.public_key_uuid.write(tstream, kmip_version=kmip_version)
 
         if self.private_key_template_attribute is not None:
-            self.private_key_template_attribute.write(tstream)
+            self.private_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.public_key_template_attribute is not None:
-            self.public_key_template_attribute.write(tstream)
+            self.public_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.length = tstream.length()
-        super(CreateKeyPairResponsePayload, self).write(ostream)
+        super(CreateKeyPairResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/decrypt.py
+++ b/kmip/core/messages/payloads/decrypt.py
@@ -144,7 +144,7 @@ class DecryptRequestPayload(primitives.Struct):
         else:
             raise TypeError("IV/counter/nonce must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Decrypt request payload and decode it
         into its constituent parts.
@@ -153,19 +153,28 @@ class DecryptRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(DecryptRequestPayload, self).read(input_stream)
+        super(DecryptRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(
                 enums.Tags.CRYPTOGRAPHIC_PARAMETERS,
@@ -173,11 +182,14 @@ class DecryptRequestPayload(primitives.Struct):
         ):
             self._cryptographic_parameters = \
                 attributes.CryptographicParameters()
-            self._cryptographic_parameters.read(local_stream)
+            self._cryptographic_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
@@ -185,11 +197,14 @@ class DecryptRequestPayload(primitives.Struct):
             self._iv_counter_nonce = primitives.ByteString(
                 tag=enums.Tags.IV_COUNTER_NONCE
             )
-            self._iv_counter_nonce.read(local_stream)
+            self._iv_counter_nonce.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Decrypt request payload to a stream.
 
@@ -197,6 +212,9 @@ class DecryptRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -204,20 +222,32 @@ class DecryptRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_parameters:
-            self._cryptographic_parameters.write(local_stream)
+            self._cryptographic_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         if self._iv_counter_nonce:
-            self._iv_counter_nonce.write(local_stream)
+            self._iv_counter_nonce.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(DecryptRequestPayload, self).write(output_stream)
+        super(DecryptRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -333,7 +363,7 @@ class DecryptResponsePayload(primitives.Struct):
         else:
             raise TypeError("data must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Decrypt response payload and decode it
         into its constituent parts.
@@ -342,19 +372,28 @@ class DecryptResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique_identifier or data attributes
                 are missing from the encoded payload.
         """
-        super(DecryptResponsePayload, self).read(input_stream)
+        super(DecryptResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
@@ -362,13 +401,13 @@ class DecryptResponsePayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Decrypt response payload to a stream.
 
@@ -376,6 +415,9 @@ class DecryptResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique_identifier or data attributes
@@ -384,19 +426,25 @@ class DecryptResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
             )
 
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         self.length = local_stream.length()
-        super(DecryptResponsePayload, self).write(output_stream)
+        super(DecryptResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/derive_key.py
+++ b/kmip/core/messages/payloads/derive_key.py
@@ -195,7 +195,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
                 "template attribute must be a TemplateAttribute struct"
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the DeriveKey request payload and decode it
         into its constituent parts.
@@ -204,12 +204,18 @@ class DeriveKeyRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(DeriveKeyRequestPayload, self).read(input_stream)
+        super(DeriveKeyRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.OBJECT_TYPE, local_stream):
@@ -217,7 +223,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
                 enums.ObjectType,
                 tag=enums.Tags.OBJECT_TYPE
             )
-            self._object_type.read(local_stream)
+            self._object_type.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError(
                 "invalid payload missing object type"
@@ -228,7 +234,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
             unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            unique_identifier.read(local_stream)
+            unique_identifier.read(local_stream, kmip_version=kmip_version)
             unique_identifiers.append(unique_identifier)
         if not unique_identifiers:
             raise ValueError("invalid payload missing unique identifiers")
@@ -240,7 +246,10 @@ class DeriveKeyRequestPayload(primitives.Struct):
                 enums.DerivationMethod,
                 tag=enums.Tags.DERIVATION_METHOD
             )
-            self._derivation_method.read(local_stream)
+            self._derivation_method.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing derivation method"
@@ -248,7 +257,10 @@ class DeriveKeyRequestPayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.DERIVATION_PARAMETERS, local_stream):
             self._derivation_parameters = attributes.DerivationParameters()
-            self._derivation_parameters.read(local_stream)
+            self._derivation_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing derivation parameters"
@@ -256,7 +268,10 @@ class DeriveKeyRequestPayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_stream):
             self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(local_stream)
+            self._template_attribute.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing template attribute"
@@ -264,7 +279,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the DeriveKey request payload to a stream.
 
@@ -272,6 +287,9 @@ class DeriveKeyRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -279,33 +297,48 @@ class DeriveKeyRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._object_type:
-            self._object_type.write(local_stream)
+            self._object_type.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing object type")
 
         if self._unique_identifiers:
             for unique_identifier in self._unique_identifiers:
-                unique_identifier.write(local_stream)
+                unique_identifier.write(
+                    local_stream,
+                    kmip_version=kmip_version
+                )
         else:
             raise ValueError("invalid payload missing unique identifiers")
 
         if self._derivation_method:
-            self._derivation_method.write(local_stream)
+            self._derivation_method.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError("invalid payload missing derivation method")
 
         if self._derivation_parameters:
-            self._derivation_parameters.write(local_stream)
+            self._derivation_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError("invalid payload missing derivation parameters")
 
         if self._template_attribute:
-            self._template_attribute.write(local_stream)
+            self._template_attribute.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError("invalid payload missing template attributes")
 
         self.length = local_stream.length()
-        super(DeriveKeyRequestPayload, self).write(output_stream)
+        super(DeriveKeyRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -427,7 +460,7 @@ class DeriveKeyResponsePayload(primitives.Struct):
                 "template attribute must be a TemplateAttribute struct"
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the DeriveKey response payload and decode it
         into its constituent parts.
@@ -436,19 +469,28 @@ class DeriveKeyResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(DeriveKeyResponsePayload, self).read(input_stream)
+        super(DeriveKeyResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing unique identifier"
@@ -456,11 +498,14 @@ class DeriveKeyResponsePayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_stream):
             self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(local_stream)
+            self._template_attribute.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the DeriveKey response payload to a stream.
 
@@ -468,6 +513,9 @@ class DeriveKeyResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -475,17 +523,26 @@ class DeriveKeyResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing unique identifier"
             )
 
         if self._template_attribute:
-            self._template_attribute.write(local_stream)
+            self._template_attribute.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(DeriveKeyResponsePayload, self).write(output_stream)
+        super(DeriveKeyResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/destroy.py
+++ b/kmip/core/messages/payloads/destroy.py
@@ -31,26 +31,32 @@ class DestroyRequestPayload(Struct):
         self.unique_identifier = unique_identifier
         self.validate()
 
-    def read(self, istream):
-        super(DestroyRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(DestroyRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
             self.unique_identifier = attributes.UniqueIdentifier()
-            self.unique_identifier.read(tstream)
+            self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self.unique_identifier is not None:
-            self.unique_identifier.write(tstream)
+            self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(DestroyRequestPayload, self).write(ostream)
+        super(DestroyRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -70,24 +76,30 @@ class DestroyResponsePayload(Struct):
         self.unique_identifier = unique_identifier
         self.validate()
 
-    def read(self, istream):
-        super(DestroyResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(DestroyResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.unique_identifier.write(tstream)
+        self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(DestroyResponsePayload, self).write(ostream)
+        super(DestroyResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/discover_versions.py
+++ b/kmip/core/messages/payloads/discover_versions.py
@@ -15,7 +15,7 @@
 
 from six.moves import xrange
 
-from kmip.core.enums import Tags
+from kmip.core import enums
 
 from kmip.core.messages.contents import ProtocolVersion
 
@@ -28,7 +28,8 @@ class DiscoverVersionsRequestPayload(Struct):
 
     def __init__(self, protocol_versions=None):
         super(DiscoverVersionsRequestPayload, self).__init__(
-            Tags.REQUEST_PAYLOAD)
+            enums.Tags.REQUEST_PAYLOAD
+        )
 
         if protocol_versions is None:
             self.protocol_versions = list()
@@ -37,26 +38,32 @@ class DiscoverVersionsRequestPayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(DiscoverVersionsRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(DiscoverVersionsRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        while(self.is_tag_next(Tags.PROTOCOL_VERSION, tstream)):
+        while(self.is_tag_next(enums.Tags.PROTOCOL_VERSION, tstream)):
             protocol_version = ProtocolVersion()
-            protocol_version.read(tstream)
+            protocol_version.read(tstream, kmip_version=kmip_version)
             self.protocol_versions.append(protocol_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         for protocol_version in self.protocol_versions:
-            protocol_version.write(tstream)
+            protocol_version.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(DiscoverVersionsRequestPayload, self).write(ostream)
+        super(DiscoverVersionsRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -82,7 +89,8 @@ class DiscoverVersionsResponsePayload(Struct):
 
     def __init__(self, protocol_versions=None):
         super(DiscoverVersionsResponsePayload, self).__init__(
-            Tags.RESPONSE_PAYLOAD)
+            enums.Tags.RESPONSE_PAYLOAD
+        )
 
         if protocol_versions is None:
             self.protocol_versions = list()
@@ -91,26 +99,32 @@ class DiscoverVersionsResponsePayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(DiscoverVersionsResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(DiscoverVersionsResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        while(self.is_tag_next(Tags.PROTOCOL_VERSION, tstream)):
+        while(self.is_tag_next(enums.Tags.PROTOCOL_VERSION, tstream)):
             protocol_version = ProtocolVersion()
-            protocol_version.read(tstream)
+            protocol_version.read(tstream, kmip_version=kmip_version)
             self.protocol_versions.append(protocol_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         for protocol_version in self.protocol_versions:
-            protocol_version.write(tstream)
+            protocol_version.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(DiscoverVersionsResponsePayload, self).write(ostream)
+        super(DiscoverVersionsResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/encrypt.py
+++ b/kmip/core/messages/payloads/encrypt.py
@@ -144,7 +144,7 @@ class EncryptRequestPayload(primitives.Struct):
         else:
             raise TypeError("IV/counter/nonce must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Encrypt request payload and decode it
         into its constituent parts.
@@ -153,19 +153,28 @@ class EncryptRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(EncryptRequestPayload, self).read(input_stream)
+        super(EncryptRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(
                 enums.Tags.CRYPTOGRAPHIC_PARAMETERS,
@@ -173,11 +182,14 @@ class EncryptRequestPayload(primitives.Struct):
         ):
             self._cryptographic_parameters = \
                 attributes.CryptographicParameters()
-            self._cryptographic_parameters.read(local_stream)
+            self._cryptographic_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
@@ -185,11 +197,14 @@ class EncryptRequestPayload(primitives.Struct):
             self._iv_counter_nonce = primitives.ByteString(
                 tag=enums.Tags.IV_COUNTER_NONCE
             )
-            self._iv_counter_nonce.read(local_stream)
+            self._iv_counter_nonce.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Encrypt request payload to a stream.
 
@@ -197,6 +212,9 @@ class EncryptRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -204,20 +222,32 @@ class EncryptRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_parameters:
-            self._cryptographic_parameters.write(local_stream)
+            self._cryptographic_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         if self._iv_counter_nonce:
-            self._iv_counter_nonce.write(local_stream)
+            self._iv_counter_nonce.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(EncryptRequestPayload, self).write(output_stream)
+        super(EncryptRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -361,7 +391,7 @@ class EncryptResponsePayload(primitives.Struct):
         else:
             raise TypeError("IV/counter/nonce must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Encrypt response payload and decode it
         into its constituent parts.
@@ -370,19 +400,28 @@ class EncryptResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique_identifier or data attributes
                 are missing from the encoded payload.
         """
-        super(EncryptResponsePayload, self).read(input_stream)
+        super(EncryptResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
@@ -390,7 +429,10 @@ class EncryptResponsePayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError("invalid payload missing the data attribute")
 
@@ -398,11 +440,14 @@ class EncryptResponsePayload(primitives.Struct):
             self._iv_counter_nonce = primitives.ByteString(
                 tag=enums.Tags.IV_COUNTER_NONCE
             )
-            self._iv_counter_nonce.read(local_stream)
+            self._iv_counter_nonce.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Encrypt response payload to a stream.
 
@@ -410,6 +455,9 @@ class EncryptResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique_identifier or data attributes
@@ -418,22 +466,31 @@ class EncryptResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
             )
 
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         if self._iv_counter_nonce:
-            self._iv_counter_nonce.write(local_stream)
+            self._iv_counter_nonce.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(EncryptResponsePayload, self).write(output_stream)
+        super(EncryptResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/get.py
+++ b/kmip/core/messages/payloads/get.py
@@ -156,7 +156,7 @@ class GetRequestPayload(primitives.Struct):
                 "KeyWrappingSpecification struct."
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Get request payload and decode it into its
         constituent parts.
@@ -165,29 +165,44 @@ class GetRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(GetRequestPayload, self).read(input_stream)
+        super(GetRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.KEY_FORMAT_TYPE, local_stream):
             self._key_format_type = primitives.Enumeration(
                 enum=enums.KeyFormatType,
                 tag=enums.Tags.KEY_FORMAT_TYPE
             )
-            self._key_format_type.read(local_stream)
+            self._key_format_type.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.KEY_COMPRESSION_TYPE, local_stream):
             self._key_compression_type = primitives.Enumeration(
                 enum=enums.KeyCompressionType,
                 tag=enums.Tags.KEY_COMPRESSION_TYPE
             )
-            self._key_compression_type.read(local_stream)
+            self._key_compression_type.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(
                 enums.Tags.KEY_WRAPPING_SPECIFICATION,
@@ -195,11 +210,14 @@ class GetRequestPayload(primitives.Struct):
         ):
             self._key_wrapping_specification = \
                 objects.KeyWrappingSpecification()
-            self._key_wrapping_specification.read(local_stream)
+            self._key_wrapping_specification.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Get request payload to a stream.
 
@@ -207,20 +225,38 @@ class GetRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier is not None:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._key_format_type is not None:
-            self._key_format_type.write(local_stream)
+            self._key_format_type.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._key_compression_type is not None:
-            self._key_compression_type.write(local_stream)
+            self._key_compression_type.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._key_wrapping_specification is not None:
-            self._key_wrapping_specification.write(local_stream)
+            self._key_wrapping_specification.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(GetRequestPayload, self).write(output_stream)
+        super(GetRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -375,7 +411,7 @@ class GetResponsePayload(primitives.Struct):
                 "SymmetricKey, Template"
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Get response payload and decode it
         into its constituent parts.
@@ -384,12 +420,18 @@ class GetResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the object type, unique identifier, or
                 secret attributes are missing from the encoded payload.
         """
-        super(GetResponsePayload, self).read(input_stream)
+        super(GetResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.OBJECT_TYPE, local_stream):
@@ -397,7 +439,7 @@ class GetResponsePayload(primitives.Struct):
                 enum=enums.ObjectType,
                 tag=enums.Tags.OBJECT_TYPE
             )
-            self._object_type.read(local_stream)
+            self._object_type.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError(
                 "Parsed payload encoding is missing the object type field."
@@ -407,7 +449,10 @@ class GetResponsePayload(primitives.Struct):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Parsed payload encoding is missing the unique identifier "
@@ -416,7 +461,7 @@ class GetResponsePayload(primitives.Struct):
 
         self.secret = self.secret_factory.create(self.object_type)
         if self.is_tag_next(self._secret.tag, local_stream):
-            self._secret.read(local_stream)
+            self._secret.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError(
                 "Parsed payload encoding is missing the secret field."
@@ -424,7 +469,7 @@ class GetResponsePayload(primitives.Struct):
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Get response payload to a stream.
 
@@ -432,6 +477,9 @@ class GetResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the object type, unique identifier, or
@@ -440,24 +488,30 @@ class GetResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self.object_type:
-            self._object_type.write(local_stream)
+            self._object_type.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("Payload is missing the object type field.")
 
         if self.unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Payload is missing the unique identifier field."
             )
 
         if self.secret:
-            self._secret.write(local_stream)
+            self._secret.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("Payload is missing the secret field.")
 
         self.length = local_stream.length()
-        super(GetResponsePayload, self).write(output_stream)
+        super(GetResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/get_attribute_list.py
+++ b/kmip/core/messages/payloads/get_attribute_list.py
@@ -68,7 +68,7 @@ class GetAttributeListRequestPayload(primitives.Struct):
         else:
             raise TypeError("unique identifier must be a string")
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributeList request payload and decode
         it into its constituent parts.
@@ -76,21 +76,27 @@ class GetAttributeListRequestPayload(primitives.Struct):
         Args:
             istream (stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(GetAttributeListRequestPayload, self).read(istream)
+        super(GetAttributeListRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(tstream)
+            self._unique_identifier.read(tstream, kmip_version=kmip_version)
         else:
             self._unique_identifier = None
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributeList request payload to a
         stream.
@@ -98,14 +104,20 @@ class GetAttributeListRequestPayload(primitives.Struct):
         Args:
             ostream (stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(GetAttributeListRequestPayload, self).write(ostream)
+        super(GetAttributeListRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def __repr__(self):
@@ -225,7 +237,7 @@ class GetAttributeListResponsePayload(primitives.Struct):
         else:
             raise TypeError("attribute_names must be a list of strings")
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributeList response payload and
         decode it into its constituent parts.
@@ -233,28 +245,34 @@ class GetAttributeListResponsePayload(primitives.Struct):
         Args:
             istream (stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(GetAttributeListResponsePayload, self).read(istream)
+        super(GetAttributeListResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(tstream)
+            self._unique_identifier.read(tstream, kmip_version=kmip_version)
         else:
             self._unique_identifier = None
 
         names = list()
         while self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, tstream):
             name = primitives.TextString(tag=enums.Tags.ATTRIBUTE_NAME)
-            name.read(tstream)
+            name.read(tstream, kmip_version=kmip_version)
             names.append(name)
         self._attribute_names = names
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributeList response payload to a
         stream.
@@ -262,17 +280,23 @@ class GetAttributeListResponsePayload(primitives.Struct):
         Args:
             ostream (stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
 
         for attribute_name in self._attribute_names:
-            attribute_name.write(tstream)
+            attribute_name.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(GetAttributeListResponsePayload, self).write(ostream)
+        super(GetAttributeListResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def __repr__(self):

--- a/kmip/core/messages/payloads/get_attributes.py
+++ b/kmip/core/messages/payloads/get_attributes.py
@@ -112,7 +112,7 @@ class GetAttributesRequestPayload(primitives.Struct):
         else:
             raise TypeError("attribute_names must be a list of strings")
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributes request payload and decode
         it into its constituent parts.
@@ -120,28 +120,34 @@ class GetAttributesRequestPayload(primitives.Struct):
         Args:
             istream (stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(GetAttributesRequestPayload, self).read(istream)
+        super(GetAttributesRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(tstream)
+            self._unique_identifier.read(tstream, kmip_version=kmip_version)
         else:
             self._unique_identifier = None
 
         names = list()
         while self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, tstream):
             name = primitives.TextString(tag=enums.Tags.ATTRIBUTE_NAME)
-            name.read(tstream)
+            name.read(tstream, kmip_version=kmip_version)
             names.append(name)
         self._attribute_names = names
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributes request payload to a
         stream.
@@ -149,17 +155,23 @@ class GetAttributesRequestPayload(primitives.Struct):
         Args:
             ostream (stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
 
         for attribute_name in self._attribute_names:
-            attribute_name.write(tstream)
+            attribute_name.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(GetAttributesRequestPayload, self).write(ostream)
+        super(GetAttributesRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def __repr__(self):
@@ -270,7 +282,7 @@ class GetAttributesResponsePayload(primitives.Struct):
         else:
             raise TypeError("attributes must be a list of attribute objects")
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributes response payload and decode
         it into its constituent parts.
@@ -278,15 +290,21 @@ class GetAttributesResponsePayload(primitives.Struct):
         Args:
             istream (stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(GetAttributesResponsePayload, self).read(istream)
+        super(GetAttributesResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = utils.BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
             unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            unique_identifier.read(tstream)
+            unique_identifier.read(tstream, kmip_version=kmip_version)
             self.unique_identifier = unique_identifier.value
         else:
             raise exceptions.InvalidKmipEncoding(
@@ -296,12 +314,12 @@ class GetAttributesResponsePayload(primitives.Struct):
         self._attributes = list()
         while self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
             attribute = objects.Attribute()
-            attribute.read(tstream)
+            attribute.read(tstream, kmip_version=kmip_version)
             self._attributes.append(attribute)
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributes response payload to a
         stream.
@@ -309,21 +327,27 @@ class GetAttributesResponsePayload(primitives.Struct):
         Args:
             ostream (stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidField(
                 "The GetAttributes response unique identifier is required."
             )
 
         for attribute in self._attributes:
-            attribute.write(tstream)
+            attribute.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(GetAttributesResponsePayload, self).write(ostream)
+        super(GetAttributesResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def __repr__(self):

--- a/kmip/core/messages/payloads/get_usage_allocation.py
+++ b/kmip/core/messages/payloads/get_usage_allocation.py
@@ -90,7 +90,7 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
         else:
             raise TypeError("Usage limits count must be an integer.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetUsageAllocation request payload and
         decode it into its constituent parts.
@@ -99,28 +99,40 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(GetUsageAllocationRequestPayload, self).read(input_stream)
+        super(GetUsageAllocationRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.USAGE_LIMITS_COUNT, local_stream):
             self._usage_limits_count = primitives.LongInteger(
                 tag=enums.Tags.USAGE_LIMITS_COUNT
             )
-            self._usage_limits_count.read(local_stream)
+            self._usage_limits_count.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetUsageAllocation request payload to a
         stream.
@@ -129,6 +141,9 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -136,12 +151,21 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._usage_limits_count:
-            self._usage_limits_count.write(local_stream)
+            self._usage_limits_count.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(GetUsageAllocationRequestPayload, self).write(output_stream)
+        super(GetUsageAllocationRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -217,7 +241,7 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetUsageAllocation response payload and
         decode it into its constituent parts.
@@ -226,23 +250,32 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(GetUsageAllocationResponsePayload, self).read(input_stream)
+        super(GetUsageAllocationResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetUsageAllocation response payload to a
         stream.
@@ -251,6 +284,9 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -258,10 +294,16 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(GetUsageAllocationResponsePayload, self).write(output_stream)
+        super(GetUsageAllocationResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/locate.py
+++ b/kmip/core/messages/payloads/locate.py
@@ -56,40 +56,46 @@ class LocateRequestPayload(Struct):
         self.attributes = attributes or []
         self.validate()
 
-    def read(self, istream):
-        super(LocateRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(LocateRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
         if self.is_tag_next(Tags.MAXIMUM_ITEMS, tstream):
             self.maximum_items = LocateRequestPayload.MaximumItems()
-            self.maximum_items.read(tstream)
+            self.maximum_items.read(tstream, kmip_version=kmip_version)
         if self.is_tag_next(Tags.STORAGE_STATUS_MASK, tstream):
             self.storage_status_mask = LocateRequestPayload.StorageStatusMask()
-            self.storage_status_mask.read(tstream)
+            self.storage_status_mask.read(tstream, kmip_version=kmip_version)
         if self.is_tag_next(Tags.OBJECT_GROUP_MEMBER, tstream):
             self.object_group_member = LocateRequestPayload.ObjectGroupMember()
-            self.object_group_member.read(tstream)
+            self.object_group_member.read(tstream, kmip_version=kmip_version)
         while self.is_tag_next(Tags.ATTRIBUTE, tstream):
             attr = Attribute()
-            attr.read(tstream)
+            attr.read(tstream, kmip_version=kmip_version)
             self.attributes.append(attr)
 
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
         if self.maximum_items is not None:
-            self.maximum_items.write(tstream)
+            self.maximum_items.write(tstream, kmip_version=kmip_version)
         if self.storage_status_mask is not None:
-            self.storage_status_mask.write(tstream)
+            self.storage_status_mask.write(tstream, kmip_version=kmip_version)
         if self.object_group_member is not None:
-            self.object_group_member.write(tstream)
+            self.object_group_member.write(tstream, kmip_version=kmip_version)
         if self.attributes is not None:
             for a in self.attributes:
-                a.write(tstream)
+                a.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(LocateRequestPayload, self).write(ostream)
+        super(LocateRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -108,27 +114,33 @@ class LocateResponsePayload(Struct):
         self.unique_identifiers = unique_identifiers or []
         self.validate()
 
-    def read(self, istream):
-        super(LocateResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(LocateResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         while self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
             ui = attributes.UniqueIdentifier()
-            ui.read(tstream)
+            ui.read(tstream, kmip_version=kmip_version)
             self.unique_identifiers.append(ui)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         for ui in self.unique_identifiers:
-            ui.write(tstream)
+            ui.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(LocateResponsePayload, self).write(ostream)
+        super(LocateResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/mac.py
+++ b/kmip/core/messages/payloads/mac.py
@@ -83,22 +83,28 @@ class MACRequestPayload(Struct):
         else:
             raise TypeError("data must be Data type")
 
-    def read(self, istream):
-        super(MACRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(MACRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
             self.unique_identifier = attributes.UniqueIdentifier()
-            self.unique_identifier.read(tstream)
+            self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.CRYPTOGRAPHIC_PARAMETERS, tstream):
             self.cryptographic_parameters = \
                 attributes.CryptographicParameters()
-            self.cryptographic_parameters.read(tstream)
+            self.cryptographic_parameters.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(Tags.DATA, tstream):
             self.data = Data()
-            self.data.read(tstream)
+            self.data.read(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidKmipEncoding(
                 "expected mac request data not found"
@@ -106,22 +112,28 @@ class MACRequestPayload(Struct):
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self._unique_identifier is not None:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
         if self._cryptographic_parameters is not None:
-            self._cryptographic_parameters.write(tstream)
+            self._cryptographic_parameters.write(
+                tstream,
+                kmip_version=kmip_version
+            )
         if self._data is not None:
-            self.data.write(tstream)
+            self.data.write(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidField(
                 "The mac request data is required"
             )
 
         self.length = tstream.length()
-        super(MACRequestPayload, self).write(ostream)
+        super(MACRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
 
@@ -165,13 +177,16 @@ class MACResponsePayload(Struct):
         else:
             raise TypeError("mac_data must be MACData type")
 
-    def read(self, istream):
-        super(MACResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(MACResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         if self.is_tag_next(Tags.UNIQUE_IDENTIFIER, tstream):
             self._unique_identifier = attributes.UniqueIdentifier()
-            self._unique_identifier.read(tstream)
+            self._unique_identifier.read(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidKmipEncoding(
                 "expected mac response unique identifier not found"
@@ -179,7 +194,7 @@ class MACResponsePayload(Struct):
 
         if self.is_tag_next(Tags.MAC_DATA, tstream):
             self._mac_data = MACData()
-            self._mac_data.read(tstream)
+            self._mac_data.read(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidKmipEncoding(
                 "expected mac response mac data not found"
@@ -187,21 +202,24 @@ class MACResponsePayload(Struct):
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self._unique_identifier is not None:
-            self._unique_identifier.write(tstream)
+            self._unique_identifier.write(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidField(
                 "The mac response unique identifier is required"
             )
         if self._mac_data is not None:
-            self._mac_data.write(tstream)
+            self._mac_data.write(tstream, kmip_version=kmip_version)
         else:
             raise exceptions.InvalidField(
                 "The mac response mac data is required"
             )
         self.length = tstream.length()
-        super(MACResponsePayload, self).write(ostream)
+        super(MACResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)

--- a/kmip/core/messages/payloads/obtain_lease.py
+++ b/kmip/core/messages/payloads/obtain_lease.py
@@ -63,7 +63,7 @@ class ObtainLeaseRequestPayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ObtainLease request payload and decode it
         into its constituent parts.
@@ -72,23 +72,32 @@ class ObtainLeaseRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(ObtainLeaseRequestPayload, self).read(input_stream)
+        super(ObtainLeaseRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ObtainLease request payload to a stream.
 
@@ -96,6 +105,9 @@ class ObtainLeaseRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -103,10 +115,16 @@ class ObtainLeaseRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(ObtainLeaseRequestPayload, self).write(output_stream)
+        super(ObtainLeaseRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -233,7 +251,7 @@ class ObtainLeaseResponsePayload(primitives.Struct):
         else:
             raise TypeError("Last change date must be an integer.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ObtainLease response payload and decode it
         into its constituent parts.
@@ -242,33 +260,45 @@ class ObtainLeaseResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(ObtainLeaseResponsePayload, self).read(input_stream)
+        super(ObtainLeaseResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.LEASE_TIME, local_stream):
             self._lease_time = primitives.Interval(
                 tag=enums.Tags.LEASE_TIME
             )
-            self._lease_time.read(local_stream)
+            self._lease_time.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.LAST_CHANGE_DATE, local_stream):
             self._last_change_date = primitives.DateTime(
                 tag=enums.Tags.LAST_CHANGE_DATE
             )
-            self._last_change_date.read(local_stream)
+            self._last_change_date.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ObtainLease response payload to a stream.
 
@@ -276,6 +306,9 @@ class ObtainLeaseResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -283,14 +316,26 @@ class ObtainLeaseResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._lease_time:
-            self._lease_time.write(local_stream)
+            self._lease_time.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._last_change_date:
-            self._last_change_date.write(local_stream)
+            self._last_change_date.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(ObtainLeaseResponsePayload, self).write(output_stream)
+        super(ObtainLeaseResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/poll.py
+++ b/kmip/core/messages/payloads/poll.py
@@ -64,7 +64,7 @@ class PollRequestPayload(primitives.Struct):
         else:
             raise TypeError("Asynchronous correlation value must be bytes.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Poll request payload and decode it into
         its constituent parts.
@@ -73,12 +73,18 @@ class PollRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(PollRequestPayload, self).read(input_stream)
+        super(PollRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(
@@ -88,11 +94,14 @@ class PollRequestPayload(primitives.Struct):
             self._asynchronous_correlation_value = primitives.ByteString(
                 tag=enums.Tags.ASYNCHRONOUS_CORRELATION_VALUE
             )
-            self._asynchronous_correlation_value.read(local_stream)
+            self._asynchronous_correlation_value.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Poll request payload to a stream.
 
@@ -100,6 +109,9 @@ class PollRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -107,10 +119,16 @@ class PollRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._asynchronous_correlation_value:
-            self._asynchronous_correlation_value.write(local_stream)
+            self._asynchronous_correlation_value.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(PollRequestPayload, self).write(output_stream)
+        super(PollRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/query.py
+++ b/kmip/core/messages/payloads/query.py
@@ -18,7 +18,7 @@ from six.moves import xrange
 from kmip.core.attributes import ApplicationNamespace
 from kmip.core.attributes import ObjectType
 
-from kmip.core.enums import Tags
+from kmip.core import enums
 from kmip.core.messages.contents import Operation
 
 from kmip.core.misc import QueryFunction
@@ -48,7 +48,7 @@ class QueryRequestPayload(Struct):
         Args:
             query_functions (list): A list of QueryFunction enumerations.
         """
-        super(QueryRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(QueryRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
 
         if query_functions is None:
             self.query_functions = list()
@@ -57,7 +57,7 @@ class QueryRequestPayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the QueryRequestPayload object and decode it
         into its constituent parts.
@@ -65,33 +65,45 @@ class QueryRequestPayload(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(QueryRequestPayload, self).read(istream)
+        super(QueryRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        while(self.is_tag_next(Tags.QUERY_FUNCTION, tstream)):
+        while(self.is_tag_next(enums.Tags.QUERY_FUNCTION, tstream)):
             query_function = QueryFunction()
-            query_function.read(tstream)
+            query_function.read(tstream, kmip_version=kmip_version)
             self.query_functions.append(query_function)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the QueryRequestPayload object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         for query_function in self.query_functions:
-            query_function.write(tstream)
+            query_function.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(QueryRequestPayload, self).write(ostream)
+        super(QueryRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -155,7 +167,9 @@ class QueryResponsePayload(Struct):
                 objects detailing Objects supported by the server with ItemTag
                 values in the Extensions range.
         """
-        super(QueryResponsePayload, self).__init__(Tags.RESPONSE_PAYLOAD)
+        super(QueryResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD
+        )
 
         if operations is None:
             self.operations = list()
@@ -182,7 +196,7 @@ class QueryResponsePayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the QueryResponsePayload object and decode it
         into its constituent parts.
@@ -190,71 +204,89 @@ class QueryResponsePayload(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(QueryResponsePayload, self).read(istream)
+        super(QueryResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        while(self.is_tag_next(Tags.OPERATION, tstream)):
+        while(self.is_tag_next(enums.Tags.OPERATION, tstream)):
             operation = Operation()
-            operation.read(tstream)
+            operation.read(tstream, kmip_version=kmip_version)
             self.operations.append(operation)
 
-        while(self.is_tag_next(Tags.OBJECT_TYPE, tstream)):
+        while(self.is_tag_next(enums.Tags.OBJECT_TYPE, tstream)):
             object_type = ObjectType()
-            object_type.read(tstream)
+            object_type.read(tstream, kmip_version=kmip_version)
             self.object_types.append(object_type)
 
-        if self.is_tag_next(Tags.VENDOR_IDENTIFICATION, tstream):
+        if self.is_tag_next(enums.Tags.VENDOR_IDENTIFICATION, tstream):
             self.vendor_identification = VendorIdentification()
-            self.vendor_identification.read(tstream)
+            self.vendor_identification.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.SERVER_INFORMATION, tstream):
+        if self.is_tag_next(enums.Tags.SERVER_INFORMATION, tstream):
             self.server_information = ServerInformation()
-            self.server_information.read(tstream)
+            self.server_information.read(tstream, kmip_version=kmip_version)
 
-        while(self.is_tag_next(Tags.APPLICATION_NAMESPACE, tstream)):
+        while(self.is_tag_next(enums.Tags.APPLICATION_NAMESPACE, tstream)):
             application_namespace = ApplicationNamespace()
-            application_namespace.read(tstream)
+            application_namespace.read(tstream, kmip_version=kmip_version)
             self.application_namespaces.append(application_namespace)
 
-        while(self.is_tag_next(Tags.EXTENSION_INFORMATION, tstream)):
+        while(self.is_tag_next(enums.Tags.EXTENSION_INFORMATION, tstream)):
             extension_information = ExtensionInformation()
-            extension_information.read(tstream)
+            extension_information.read(tstream, kmip_version=kmip_version)
             self.extension_information.append(extension_information)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the QueryResponsePayload object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         for operation in self.operations:
-            operation.write(tstream)
+            operation.write(tstream, kmip_version=kmip_version)
 
         for object_type in self.object_types:
-            object_type.write(tstream)
+            object_type.write(tstream, kmip_version=kmip_version)
 
         if self.vendor_identification is not None:
-            self.vendor_identification.write(tstream)
+            self.vendor_identification.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.server_information is not None:
-            self.server_information.write(tstream)
+            self.server_information.write(tstream, kmip_version=kmip_version)
 
         for application_namespace in self.application_namespaces:
-            application_namespace.write(tstream)
+            application_namespace.write(tstream, kmip_version=kmip_version)
 
         for extension_information in self.extension_information:
-            extension_information.write(tstream)
+            extension_information.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(QueryResponsePayload, self).write(ostream)
+        super(QueryResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/recover.py
+++ b/kmip/core/messages/payloads/recover.py
@@ -62,7 +62,7 @@ class RecoverRequestPayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Recover request payload and decode it into
         its constituent parts.
@@ -71,23 +71,32 @@ class RecoverRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(RecoverRequestPayload, self).read(input_stream)
+        super(RecoverRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Recover request payload to a stream.
 
@@ -95,6 +104,9 @@ class RecoverRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -102,10 +114,16 @@ class RecoverRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(RecoverRequestPayload, self).write(output_stream)
+        super(RecoverRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -175,7 +193,7 @@ class RecoverResponsePayload(primitives.Struct):
         else:
             raise TypeError("Unique identifier must be a string.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Recover response payload and decode it
         into its constituent parts.
@@ -184,23 +202,32 @@ class RecoverResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(RecoverResponsePayload, self).read(input_stream)
+        super(RecoverResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Recover response payload to a stream.
 
@@ -208,6 +235,9 @@ class RecoverResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -215,10 +245,16 @@ class RecoverResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(RecoverResponsePayload, self).write(output_stream)
+        super(RecoverResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -16,7 +16,7 @@
 from kmip.core.factories.secrets import SecretFactory
 
 from kmip.core import attributes
-from kmip.core.enums import Tags
+from kmip.core import enums
 
 from kmip.core.objects import TemplateAttribute
 
@@ -32,7 +32,9 @@ class RegisterRequestPayload(Struct):
                  object_type=None,
                  template_attribute=None,
                  secret=None):
-        super(RegisterRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(RegisterRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD
+        )
 
         self.secret_factory = SecretFactory()
         self.object_type = object_type
@@ -41,39 +43,45 @@ class RegisterRequestPayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(RegisterRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RegisterRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.object_type = attributes.ObjectType()
         self.template_attribute = TemplateAttribute()
 
-        self.object_type.read(tstream)
-        self.template_attribute.read(tstream)
+        self.object_type.read(tstream, kmip_version=kmip_version)
+        self.template_attribute.read(tstream, kmip_version=kmip_version)
 
         secret_type = self.object_type.value
         secret = self.secret_factory.create(secret_type)
 
         if self.is_tag_next(secret.tag, tstream):
             self.secret = secret
-            self.secret.read(tstream)
+            self.secret.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of the request payload
-        self.object_type.write(tstream)
-        self.template_attribute.write(tstream)
+        self.object_type.write(tstream, kmip_version=kmip_version)
+        self.template_attribute.write(tstream, kmip_version=kmip_version)
 
         if self.secret is not None:
-            self.secret.write(tstream)
+            self.secret.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(RegisterRequestPayload, self).write(ostream)
+        super(RegisterRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -89,39 +97,47 @@ class RegisterResponsePayload(Struct):
     def __init__(self,
                  unique_identifier=None,
                  template_attribute=None):
-        super(RegisterResponsePayload, self).__init__(Tags.RESPONSE_PAYLOAD)
+        super(RegisterResponsePayload, self).__init__(
+            enums.Tags.RESPONSE_PAYLOAD
+        )
 
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute
 
         self.validate()
 
-    def read(self, istream):
-        super(RegisterResponsePayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RegisterResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
-        if self.is_tag_next(Tags.TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, tstream):
             self.template_attribute = TemplateAttribute()
-            self.template_attribute.read(tstream)
+            self.template_attribute.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         # Write the contents of the request payload
-        self.unique_identifier.write(tstream)
+        self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         if self.template_attribute is not None:
-            self.template_attribute.write(tstream)
+            self.template_attribute.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(RegisterResponsePayload, self).write(ostream)
+        super(RegisterResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/rekey.py
+++ b/kmip/core/messages/payloads/rekey.py
@@ -115,7 +115,7 @@ class RekeyRequestPayload(primitives.Struct):
                 "Template attribute must be a TemplateAttribute struct."
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Rekey request payload and decode it into
         its constituent parts.
@@ -124,29 +124,41 @@ class RekeyRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(RekeyRequestPayload, self).read(input_stream)
+        super(RekeyRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.OFFSET, local_stream):
             self._offset = primitives.Interval(
                 tag=enums.Tags.OFFSET
             )
-            self._offset.read(local_stream)
+            self._offset.read(local_stream, kmip_version=kmip_version)
 
         if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_stream):
             self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(local_stream)
+            self._template_attribute.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Rekey request payload to a stream.
 
@@ -154,18 +166,30 @@ class RekeyRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier is not None:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._offset is not None:
-            self._offset.write(local_stream)
+            self._offset.write(local_stream, kmip_version=kmip_version)
         if self._template_attribute is not None:
-            self._template_attribute.write(local_stream)
+            self._template_attribute.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(RekeyRequestPayload, self).write(output_stream)
+        super(RekeyRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -273,7 +297,7 @@ class RekeyResponsePayload(primitives.Struct):
                 "Template attribute must be a TemplateAttribute struct."
             )
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Rekey response payload and decode it into
         its constituent parts.
@@ -282,19 +306,28 @@ class RekeyResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique identifier attribute is missing
                 from the encoded payload.
         """
-        super(RekeyResponsePayload, self).read(input_stream)
+        super(RekeyResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "The Rekey response payload encoding is missing the unique "
@@ -303,11 +336,14 @@ class RekeyResponsePayload(primitives.Struct):
 
         if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_stream):
             self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(local_stream)
+            self._template_attribute.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Rekey request payload to a stream.
 
@@ -315,6 +351,9 @@ class RekeyResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the payload is missing the unique identifier.
@@ -322,16 +361,25 @@ class RekeyResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier is not None:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "The Rekey response payload is missing the unique identifier."
             )
         if self._template_attribute is not None:
-            self._template_attribute.write(local_stream)
+            self._template_attribute.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(RekeyResponsePayload, self).write(output_stream)
+        super(RekeyResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/rekey_key_pair.py
+++ b/kmip/core/messages/payloads/rekey_key_pair.py
@@ -17,7 +17,7 @@ from kmip.core import attributes
 from kmip.core import misc
 from kmip.core import objects
 
-from kmip.core.enums import Tags
+from kmip.core import enums
 from kmip.core.messages.payloads.create_key_pair import \
     CreateKeyPairResponsePayload
 from kmip.core.primitives import Struct
@@ -32,7 +32,9 @@ class RekeyKeyPairRequestPayload(Struct):
                  common_template_attribute=None,
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
-        super(RekeyKeyPairRequestPayload, self).__init__(Tags.REQUEST_PAYLOAD)
+        super(RekeyKeyPairRequestPayload, self).__init__(
+            enums.Tags.REQUEST_PAYLOAD
+        )
 
         self.private_key_uuid = private_key_uuid
         self.offset = offset
@@ -42,55 +44,80 @@ class RekeyKeyPairRequestPayload(Struct):
 
         self.validate()
 
-    def read(self, istream):
-        super(RekeyKeyPairRequestPayload, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(RekeyKeyPairRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
-        if self.is_tag_next(Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER, tstream):
+        if self.is_tag_next(enums.Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER, tstream):
             self.private_key_uuid = attributes.PrivateKeyUniqueIdentifier()
-            self.private_key_uuid.read(tstream)
+            self.private_key_uuid.read(tstream, kmip_version=kmip_version)
 
-        if self.is_tag_next(Tags.OFFSET, tstream):
+        if self.is_tag_next(enums.Tags.OFFSET, tstream):
             self.offset = misc.Offset()
-            self.offset.read(tstream)
+            self.offset.read(tstream, kmip_version=kmip_version)
 
-        if self.is_tag_next(Tags.COMMON_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.COMMON_TEMPLATE_ATTRIBUTE, tstream):
             self.common_template_attribute = objects.CommonTemplateAttribute()
-            self.common_template_attribute.read(tstream)
+            self.common_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+                            tstream):
             self.private_key_template_attribute = \
                 objects.PrivateKeyTemplateAttribute()
-            self.private_key_template_attribute.read(tstream)
+            self.private_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
-        if self.is_tag_next(Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
+        if self.is_tag_next(enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
             self.public_key_template_attribute = \
                 objects.PublicKeyTemplateAttribute()
-            self.public_key_template_attribute.read(tstream)
+            self.public_key_template_attribute.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         if self.private_key_uuid is not None:
-            self.private_key_uuid.write(tstream)
+            self.private_key_uuid.write(tstream, kmip_version=kmip_version)
 
         if self.offset is not None:
-            self.offset.write(tstream)
+            self.offset.write(tstream, kmip_version=kmip_version)
 
         if self.common_template_attribute is not None:
-            self.common_template_attribute.write(tstream)
+            self.common_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.private_key_template_attribute is not None:
-            self.private_key_template_attribute.write(tstream)
+            self.private_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         if self.public_key_template_attribute is not None:
-            self.public_key_template_attribute.write(tstream)
+            self.public_key_template_attribute.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.length = tstream.length()
-        super(RekeyKeyPairRequestPayload, self).write(ostream)
+        super(RekeyKeyPairRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/revoke.py
+++ b/kmip/core/messages/payloads/revoke.py
@@ -60,52 +60,70 @@ class RevokeRequestPayload(Struct):
             self.revocation_reason = objects.RevocationReason()
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the RevokeRequestPayload object and decode it
         into its constituent parts.
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(RevokeRequestPayload, self).read(istream)
+        super(RevokeRequestPayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.revocation_reason = objects.RevocationReason()
-        self.revocation_reason.read(tstream)
+        self.revocation_reason.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(enums.Tags.COMPROMISE_OCCURRENCE_DATE, tstream):
             self.compromise_occurrence_date = primitives.DateTime(
                 tag=enums.Tags.COMPROMISE_OCCURRENCE_DATE)
-            self.compromise_occurrence_date.read(tstream)
+            self.compromise_occurrence_date.read(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the RevokeRequestPayload object to a stream.
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         # Write the contents of the request payload
         if self.unique_identifier is not None:
-            self.unique_identifier.write(tstream)
+            self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
-        self.revocation_reason.write(tstream)
+        self.revocation_reason.write(tstream, kmip_version=kmip_version)
 
         if self.compromise_occurrence_date is not None:
-            self.compromise_occurrence_date.write(tstream)
+            self.compromise_occurrence_date.write(
+                tstream,
+                kmip_version=kmip_version
+            )
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(RevokeRequestPayload, self).write(ostream)
+        super(RevokeRequestPayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -151,38 +169,50 @@ class RevokeResponsePayload(Struct):
             self.unique_identifier = unique_identifier
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the RevokeResponsePayload object and decode it
         into its constituent parts.
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(RevokeResponsePayload, self).read(istream)
+        super(RevokeResponsePayload, self).read(
+            istream,
+            kmip_version=kmip_version
+        )
         tstream = BytearrayStream(istream.read(self.length))
 
         self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream)
+        self.unique_identifier.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the RevokeResponsePayload object to a stream.
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
         # Write the contents of the response payload
-        self.unique_identifier.write(tstream)
+        self.unique_identifier.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the request payload
         self.length = tstream.length()
-        super(RevokeResponsePayload, self).write(ostream)
+        super(RevokeResponsePayload, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/messages/payloads/sign.py
+++ b/kmip/core/messages/payloads/sign.py
@@ -117,7 +117,7 @@ class SignRequestPayload(primitives.Struct):
         else:
             raise TypeError("data must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Sign request payload and decode it
         into its parts
@@ -125,12 +125,18 @@ class SignRequestPayload(primitives.Struct):
         Args:
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(SignRequestPayload, self).read(input_stream)
+        super(SignRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
@@ -138,7 +144,10 @@ class SignRequestPayload(primitives.Struct):
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
 
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(
                enums.Tags.CRYPTOGRAPHIC_PARAMETERS,
@@ -146,18 +155,21 @@ class SignRequestPayload(primitives.Struct):
         ):
             self._cryptographic_parameters = \
                 attributes.CryptographicParameters()
-            self._cryptographic_parameters.read(local_stream)
+            self._cryptographic_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
 
         else:
             raise ValueError(
                 "invalid payload missing the data attribute"
             )
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Sign request payload to a stream.
 
@@ -165,6 +177,9 @@ class SignRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -172,17 +187,26 @@ class SignRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_parameters:
-            self._cryptographic_parameters.write(local_stream)
+            self._cryptographic_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError("invalid payload missing the data attribute")
 
         self.length = local_stream.length()
-        super(SignRequestPayload, self).write(output_stream)
+        super(SignRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -284,7 +308,7 @@ class SignResponsePayload(primitives.Struct):
         else:
             raise TypeError("signature data must be bytes")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Sign response payload and decode it.
 
@@ -292,20 +316,29 @@ class SignResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the unique_identifier or signature attributes
                 are missing from the encoded payload.
         """
 
-        super(SignResponsePayload, self).read(input_stream)
+        super(SignResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
@@ -315,13 +348,13 @@ class SignResponsePayload(primitives.Struct):
             self._signature_data = primitives.ByteString(
                 tag=enums.Tags.SIGNATURE_DATA
             )
-            self._signature_data.read(local_stream)
+            self._signature_data.read(local_stream, kmip_version=kmip_version)
         else:
             raise ValueError(
                 "invalid payload missing the signature data attribute"
             )
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Sign response to a stream.
 
@@ -338,21 +371,30 @@ class SignResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the unique identifier attribute"
             )
 
         if self._signature_data:
-            self._signature_data.write(local_stream)
+            self._signature_data.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "invalid payload missing the signature attribute"
             )
 
         self.length = local_stream.length()
-        super(SignResponsePayload, self).write(output_stream)
+        super(SignResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/messages/payloads/signature_verify.py
+++ b/kmip/core/messages/payloads/signature_verify.py
@@ -248,7 +248,7 @@ class SignatureVerifyRequestPayload(primitives.Struct):
         else:
             raise TypeError("Final indicator must be a boolean.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the SignatureVerify request payload and decode
         it into its constituent parts.
@@ -257,55 +257,70 @@ class SignatureVerifyRequestPayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(SignatureVerifyRequestPayload, self).read(input_stream)
+        super(SignatureVerifyRequestPayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.CRYPTOGRAPHIC_PARAMETERS, local_stream):
             self._cryptographic_parameters = \
                 attributes.CryptographicParameters()
-            self._cryptographic_parameters.read(local_stream)
+            self._cryptographic_parameters.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.DIGESTED_DATA, local_stream):
             self._digested_data = primitives.ByteString(
                 tag=enums.Tags.DIGESTED_DATA
             )
-            self._digested_data.read(local_stream)
+            self._digested_data.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.SIGNATURE_DATA, local_stream):
             self._signature_data = primitives.ByteString(
                 tag=enums.Tags.SIGNATURE_DATA
             )
-            self._signature_data.read(local_stream)
+            self._signature_data.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.CORRELATION_VALUE, local_stream):
             self._correlation_value = primitives.ByteString(
                 tag=enums.Tags.CORRELATION_VALUE
             )
-            self._correlation_value.read(local_stream)
+            self._correlation_value.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self.is_tag_next(enums.Tags.INIT_INDICATOR, local_stream):
             self._init_indicator = primitives.Boolean(
                 tag=enums.Tags.INIT_INDICATOR
             )
-            self._init_indicator.read(local_stream)
+            self._init_indicator.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.FINAL_INDICATOR, local_stream):
             self._final_indicator = primitives.Boolean(
                 tag=enums.Tags.FINAL_INDICATOR
             )
-            self._final_indicator.read(local_stream)
+            self._final_indicator.read(local_stream, kmip_version=kmip_version)
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the SignatureVerify request payload to a
         stream.
@@ -314,6 +329,9 @@ class SignatureVerifyRequestPayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -321,24 +339,45 @@ class SignatureVerifyRequestPayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._cryptographic_parameters:
-            self._cryptographic_parameters.write(local_stream)
+            self._cryptographic_parameters.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         if self._digested_data:
-            self._digested_data.write(local_stream)
+            self._digested_data.write(local_stream, kmip_version=kmip_version)
         if self._signature_data:
-            self._signature_data.write(local_stream)
+            self._signature_data.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._correlation_value:
-            self._correlation_value.write(local_stream)
+            self._correlation_value.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._init_indicator:
-            self._init_indicator.write(local_stream)
+            self._init_indicator.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         if self._final_indicator:
-            self._final_indicator.write(local_stream)
+            self._final_indicator.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(SignatureVerifyRequestPayload, self).write(output_stream)
+        super(SignatureVerifyRequestPayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):
@@ -526,7 +565,7 @@ class SignatureVerifyResponsePayload(primitives.Struct):
         else:
             raise TypeError("Correlation value must be bytes.")
 
-    def read(self, input_stream):
+    def read(self, input_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the SignatureVerify response payload and decode
         it into its constituent parts.
@@ -535,19 +574,28 @@ class SignatureVerifyResponsePayload(primitives.Struct):
             input_stream (stream): A data stream containing encoded object
                 data, supporting a read method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is missing from the
                 encoded payload.
         """
-        super(SignatureVerifyResponsePayload, self).read(input_stream)
+        super(SignatureVerifyResponsePayload, self).read(
+            input_stream,
+            kmip_version=kmip_version
+        )
         local_stream = utils.BytearrayStream(input_stream.read(self.length))
 
         if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_stream):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(local_stream)
+            self._unique_identifier.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Parsed payload encoding is missing the unique identifier "
@@ -558,7 +606,10 @@ class SignatureVerifyResponsePayload(primitives.Struct):
                 enums.ValidityIndicator,
                 tag=enums.Tags.VALIDITY_INDICATOR
             )
-            self._validity_indicator.read(local_stream)
+            self._validity_indicator.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Parsed payload encoding is missing the validity indicator "
@@ -566,16 +617,19 @@ class SignatureVerifyResponsePayload(primitives.Struct):
             )
         if self.is_tag_next(enums.Tags.DATA, local_stream):
             self._data = primitives.ByteString(tag=enums.Tags.DATA)
-            self._data.read(local_stream)
+            self._data.read(local_stream, kmip_version=kmip_version)
         if self.is_tag_next(enums.Tags.CORRELATION_VALUE, local_stream):
             self._correlation_value = primitives.ByteString(
                 tag=enums.Tags.CORRELATION_VALUE
             )
-            self._correlation_value.read(local_stream)
+            self._correlation_value.read(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.is_oversized(local_stream)
 
-    def write(self, output_stream):
+    def write(self, output_stream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the SignatureVerify response payload to a
         stream.
@@ -584,6 +638,9 @@ class SignatureVerifyResponsePayload(primitives.Struct):
             output_stream (stream): A data stream in which to encode object
                 data, supporting a write method; usually a BytearrayStream
                 object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: Raised if the data attribute is not defined.
@@ -591,24 +648,36 @@ class SignatureVerifyResponsePayload(primitives.Struct):
         local_stream = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(local_stream)
+            self._unique_identifier.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Payload is missing the unique identifier field."
             )
         if self._validity_indicator:
-            self._validity_indicator.write(local_stream)
+            self._validity_indicator.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
         else:
             raise ValueError(
                 "Payload is missing the validity indicator field."
             )
         if self._data:
-            self._data.write(local_stream)
+            self._data.write(local_stream, kmip_version=kmip_version)
         if self._correlation_value:
-            self._correlation_value.write(local_stream)
+            self._correlation_value.write(
+                local_stream,
+                kmip_version=kmip_version
+            )
 
         self.length = local_stream.length()
-        super(SignatureVerifyResponsePayload, self).write(output_stream)
+        super(SignatureVerifyResponsePayload, self).write(
+            output_stream,
+            kmip_version=kmip_version
+        )
         output_stream.write(local_stream.buffer)
 
     def __eq__(self, other):

--- a/kmip/core/misc.py
+++ b/kmip/core/misc.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from kmip.core import enums
 from kmip.core.enums import KeyFormatType as KeyFormatTypeEnum
 from kmip.core.enums import Tags
 from kmip.core.enums import QueryFunction as QueryFunctionEnum
@@ -140,7 +141,7 @@ class ServerInformation(Struct):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the ServerInformation object and decode it into
         its constituent parts.
@@ -148,8 +149,11 @@ class ServerInformation(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(ServerInformation, self).read(istream)
+        super(ServerInformation, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.data = BytearrayStream(tstream.read())
@@ -157,19 +161,25 @@ class ServerInformation(Struct):
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the ServerInformation object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
         tstream.write(self.data.buffer)
 
         self.length = tstream.length()
-        super(ServerInformation, self).write(ostream)
+        super(ServerInformation, self).write(
+            ostream,
+            kmip_version=kmip_version
+        )
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/core/primitives.py
+++ b/kmip/core/primitives.py
@@ -101,7 +101,7 @@ class Base(object):
     def read_value(self, istream):
         raise NotImplementedError()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         self.read_tag(istream)
         self.read_type(istream)
         self.read_length(istream)
@@ -135,7 +135,7 @@ class Base(object):
     def write_value(self, ostream):
         raise NotImplementedError()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         self.write_tag(ostream)
         self.write_type(ostream)
         self.write_length(ostream)
@@ -224,17 +224,17 @@ class Integer(Base):
             )
         self.validate()
 
-    def read(self, istream):
-        super(Integer, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Integer, self).read(istream, kmip_version=kmip_version)
         self.read_value(istream)
 
-    def write_value(self, ostream):
+    def write_value(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         ostream.write(pack(self.pack_string, self.value))
         ostream.write(pack(self.pack_string, 0))
 
-    def write(self, ostream):
-        super(Integer, self).write(ostream)
-        self.write_value(ostream)
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Integer, self).write(ostream, kmip_version=kmip_version)
+        self.write_value(ostream, kmip_version=kmip_version)
 
     def validate(self):
         """
@@ -328,19 +328,22 @@ class LongInteger(Base):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the encoding of the LongInteger from the input stream.
 
         Args:
             istream (stream): A buffer containing the encoded bytes of a
                 LongInteger. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             InvalidPrimitiveLength: if the long integer encoding read in has
                 an invalid encoded length.
         """
-        super(LongInteger, self).read(istream)
+        super(LongInteger, self).read(istream, kmip_version=kmip_version)
 
         if self.length is not LongInteger.LENGTH:
             raise exceptions.InvalidPrimitiveLength(
@@ -351,15 +354,18 @@ class LongInteger(Base):
         self.value = unpack('!q', istream.read(self.length))[0]
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the encoding of the LongInteger to the output stream.
 
         Args:
             ostream (stream): A buffer to contain the encoded bytes of a
                 LongInteger. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(LongInteger, self).write(ostream)
+        super(LongInteger, self).write(ostream, kmip_version=kmip_version)
         ostream.write(pack('!q', self.value))
 
     def validate(self):
@@ -420,7 +426,7 @@ class BigInteger(Base):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the encoding of the BigInteger from the input stream.
 
@@ -428,12 +434,15 @@ class BigInteger(Base):
             istream (stream): A buffer containing the encoded bytes of the
                 value of a BigInteger. Usually a BytearrayStream object.
                 Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             InvalidPrimitiveLength: if the big integer encoding read in has
                 an invalid encoded length.
         """
-        super(BigInteger, self).read(istream)
+        super(BigInteger, self).read(istream, kmip_version=kmip_version)
 
         # Check for a valid length before even trying to parse the value.
         if self.length % 8:
@@ -467,7 +476,7 @@ class BigInteger(Base):
         # Convert the value back to an integer and reapply the sign.
         self.value = int(binary, 2) * sign
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the encoding of the BigInteger to the output stream.
 
@@ -475,6 +484,9 @@ class BigInteger(Base):
             ostream (Stream): A buffer to contain the encoded bytes of a
                 BigInteger object. Usually a BytearrayStream object.
                 Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         # Convert the value to binary and pad it as needed.
         binary = "{0:b}".format(abs(self.value))
@@ -497,7 +509,7 @@ class BigInteger(Base):
             hexadecimal += struct.pack('!B', byte)
 
         self.length = len(hexadecimal)
-        super(BigInteger, self).write(ostream)
+        super(BigInteger, self).write(ostream, kmip_version=kmip_version)
         ostream.write(hexadecimal)
 
     def validate(self):
@@ -568,13 +580,16 @@ class Enumeration(Base):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the encoding of the Enumeration from the input stream.
 
         Args:
             istream (stream): A buffer containing the encoded bytes of an
                 Enumeration. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             InvalidPrimitiveLength: if the Enumeration encoding read in has an
@@ -582,7 +597,7 @@ class Enumeration(Base):
             InvalidPaddingBytes: if the Enumeration encoding read in does not
                 use zeroes for its padding bytes.
         """
-        super(Enumeration, self).read(istream)
+        super(Enumeration, self).read(istream, kmip_version=kmip_version)
 
         # Check for a valid length before even trying to parse the value.
         if self.length != Enumeration.LENGTH:
@@ -600,15 +615,18 @@ class Enumeration(Base):
 
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the encoding of the Enumeration to the output stream.
 
         Args:
             ostream (stream): A buffer to contain the encoded bytes of an
                 Enumeration. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Enumeration, self).write(ostream)
+        super(Enumeration, self).write(ostream, kmip_version=kmip_version)
         ostream.write(pack('!I', self.value.value))
         ostream.write(pack('!I', 0))
 
@@ -689,7 +707,7 @@ class Boolean(Base):
 
         self.validate()
 
-    def read_value(self, istream):
+    def read_value(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the value of the Boolean object from the input stream.
 
@@ -697,6 +715,9 @@ class Boolean(Base):
             istream (Stream): A buffer containing the encoded bytes of the
                 value of a Boolean object. Usually a BytearrayStream object.
                 Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             ValueError: if the read boolean value is not a 0 or 1.
@@ -716,18 +737,21 @@ class Boolean(Base):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the encoding of the Boolean object from the input stream.
 
         Args:
             istream (Stream): A buffer containing the encoded bytes of a
                 Boolean object. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Boolean, self).read(istream)
-        self.read_value(istream)
+        super(Boolean, self).read(istream, kmip_version=kmip_version)
+        self.read_value(istream, kmip_version=kmip_version)
 
-    def write_value(self, ostream):
+    def write_value(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the value of the Boolean object to the output stream.
 
@@ -735,6 +759,9 @@ class Boolean(Base):
             ostream (Stream): A buffer to contain the encoded bytes of the
                 value of a Boolean object. Usually a BytearrayStream object.
                 Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         try:
             ostream.write(pack('!Q', self.value))
@@ -742,16 +769,19 @@ class Boolean(Base):
             self.logger.error("Error writing boolean value to buffer")
             raise
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the encoding of the Boolean object to the output stream.
 
         Args:
             ostream (Stream): A buffer to contain the encoded bytes of a
                 Boolean object. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Boolean, self).write(ostream)
-        self.write_value(ostream)
+        super(Boolean, self).write(ostream, kmip_version=kmip_version)
+        self.write_value(ostream, kmip_version=kmip_version)
 
     def validate(self):
         """
@@ -808,7 +838,7 @@ class TextString(Base):
             self.length = None
             self.padding_length = None
 
-    def read_value(self, istream):
+    def read_value(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         # Read string text
         self.value = ''
         for _ in range(self.length):
@@ -831,12 +861,12 @@ class TextString(Base):
                         pad
                     )
 
-    def read(self, istream):
-        super(TextString, self).read(istream)
-        self.read_value(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(TextString, self).read(istream, kmip_version=kmip_version)
+        self.read_value(istream, kmip_version=kmip_version)
         self.validate()
 
-    def write_value(self, ostream):
+    def write_value(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         # Write string to stream
         for char in self.value:
             ostream.write(pack(self.BYTE_FORMAT, char.encode()))
@@ -845,9 +875,9 @@ class TextString(Base):
         for _ in range(self.padding_length):
             ostream.write(pack('!B', 0))
 
-    def write(self, ostream):
-        super(TextString, self).write(ostream)
-        self.write_value(ostream)
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(TextString, self).write(ostream, kmip_version=kmip_version)
+        self.write_value(ostream, kmip_version=kmip_version)
 
     def validate(self):
         self.__validate()
@@ -902,7 +932,7 @@ class ByteString(Base):
             self.length = None
             self.padding_length = None
 
-    def read_value(self, istream):
+    def read_value(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         # Read bytes into bytearray
         data = bytearray()
         for _ in range(self.length):
@@ -926,11 +956,11 @@ class ByteString(Base):
                         pad
                     )
 
-    def read(self, istream):
-        super(ByteString, self).read(istream)
-        self.read_value(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ByteString, self).read(istream, kmip_version=kmip_version)
+        self.read_value(istream, kmip_version=kmip_version)
 
-    def write_value(self, ostream):
+    def write_value(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         # Write bytes to stream
         data = bytearray(self.value)
         for byte in data:
@@ -940,9 +970,9 @@ class ByteString(Base):
         for _ in range(self.padding_length):
             ostream.write(pack('!B', 0))
 
-    def write(self, ostream):
-        super(ByteString, self).write(ostream)
-        self.write_value(ostream)
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(ByteString, self).write(ostream, kmip_version=kmip_version)
+        self.write_value(ostream, kmip_version=kmip_version)
 
     def validate(self):
         self.__validate()
@@ -1031,7 +1061,7 @@ class Interval(Base):
 
         self.validate()
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the encoding of the Interval from the input stream.
 
@@ -1039,6 +1069,9 @@ class Interval(Base):
             istream (stream): A buffer containing the encoded bytes of the
                 value of an Interval. Usually a BytearrayStream object.
                 Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
 
         Raises:
             InvalidPrimitiveLength: if the Interval encoding read in has an
@@ -1046,7 +1079,7 @@ class Interval(Base):
             InvalidPaddingBytes: if the Interval encoding read in does not use
                 zeroes for its padding bytes.
         """
-        super(Interval, self).read(istream)
+        super(Interval, self).read(istream, kmip_version=kmip_version)
 
         # Check for a valid length before even trying to parse the value.
         if self.length != Interval.LENGTH:
@@ -1063,15 +1096,18 @@ class Interval(Base):
 
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the encoding of the Interval to the output stream.
 
         Args:
             ostream (stream): A buffer to contain the encoded bytes of an
                 Interval. Usually a BytearrayStream object. Required.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Interval, self).write(ostream)
+        super(Interval, self).write(ostream, kmip_version=kmip_version)
         ostream.write(pack('!I', self.value))
         ostream.write(pack('!I', 0))
 

--- a/kmip/core/secrets.py
+++ b/kmip/core/secrets.py
@@ -69,7 +69,7 @@ class Certificate(Struct):
         else:
             self.certificate_value = CertificateValue(certificate_value)
 
-    def read(self, istream):
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the Certificate object and decode it into its
         constituent parts.
@@ -77,33 +77,39 @@ class Certificate(Struct):
         Args:
             istream (Stream): A data stream containing encoded object data,
                 supporting a read method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
         """
-        super(Certificate, self).read(istream)
+        super(Certificate, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.certificate_type = CertificateType()
         self.certificate_value = CertificateValue()
 
-        self.certificate_type.read(tstream)
-        self.certificate_value.read(tstream)
+        self.certificate_type.read(tstream, kmip_version=kmip_version)
+        self.certificate_value.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the Certificate object to a stream.
 
         Args:
             ostream (Stream): A data stream in which to encode object data,
                 supporting a write method; usually a BytearrayStream object.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
         """
         tstream = BytearrayStream()
 
-        self.certificate_type.write(tstream)
-        self.certificate_value.write(tstream)
+        self.certificate_type.write(tstream, kmip_version=kmip_version)
+        self.certificate_value.write(tstream, kmip_version=kmip_version)
 
         self.length = tstream.length()
-        super(Certificate, self).write(ostream)
+        super(Certificate, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def __eq__(self, other):
@@ -141,24 +147,24 @@ class KeyBlockKey(Struct):
         self.key_block = key_block
         self.validate()
 
-    def read(self, istream):
-        super(KeyBlockKey, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(KeyBlockKey, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.key_block = KeyBlock()
-        self.key_block.read(tstream)
+        self.key_block.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.key_block.write(tstream)
+        self.key_block.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(KeyBlockKey, self).write(ostream)
+        super(KeyBlockKey, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -262,45 +268,45 @@ class SplitKey(Struct):
         self.key_block = key_block
         self.validate()
 
-    def read(self, istream):
-        super(SplitKey, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(SplitKey, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.split_key_parts = SplitKey.SplitKeyParts()
-        self.split_key_parts.read(tstream)
+        self.split_key_parts.read(tstream, kmip_version=kmip_version)
 
         self.key_part_identifier = SplitKey.KeyPartIdentifier()
-        self.key_part_identifier.read(tstream)
+        self.key_part_identifier.read(tstream, kmip_version=kmip_version)
 
         self.split_key_threshold = SplitKey.SplitKeyThreshold()
-        self.split_key_threshold.read(tstream)
+        self.split_key_threshold.read(tstream, kmip_version=kmip_version)
 
         if self.is_tag_next(Tags.PRIME_FIELD_SIZE, tstream):
             self.prime_field_size = SplitKey.PrimeFieldSize()
-            self.prime_field_size.read(tstream)
+            self.prime_field_size.read(tstream, kmip_version=kmip_version)
 
         self.key_block = KeyBlock()
-        self.key_block.read(tstream)
+        self.key_block.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.split_key_parts.write(tstream)
-        self.key_part_identifier.write(tstream)
-        self.split_key_threshold.write(tstream)
-        self.split_key_method.write(tstream)
+        self.split_key_parts.write(tstream, kmip_version=kmip_version)
+        self.key_part_identifier.write(tstream, kmip_version=kmip_version)
+        self.split_key_threshold.write(tstream, kmip_version=kmip_version)
+        self.split_key_method.write(tstream, kmip_version=kmip_version)
 
         if self.prime_field_size is not None:
-            self.prime_field_size.write(tstream)
+            self.prime_field_size.write(tstream, kmip_version=kmip_version)
 
-        self.key_block.write(tstream)
+        self.key_block.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(SplitKey, self).write(ostream)
+        super(SplitKey, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -319,33 +325,33 @@ class Template(Struct):
         self.attributes = attributes
         self.validate()
 
-    def read(self, istream):
-        super(Template, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(Template, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.attributes = list()
 
         attribute = Attribute()
-        attribute.read(tstream)
+        attribute.read(tstream, kmip_version=kmip_version)
         self.attributes.append(attribute)
 
         while self.is_tag_next(Tags.ATTRIBUTE, tstream):
             attribute = Attribute()
-            attribute.read(tstream)
+            attribute.read(tstream, kmip_version=kmip_version)
             self.attributes.append(attribute)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
         for attribute in self.attributes:
-            attribute.write(tstream)
+            attribute.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(Template, self).write(ostream)
+        super(Template, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -373,28 +379,28 @@ class SecretData(Struct):
         self.key_block = key_block
         self.validate()
 
-    def read(self, istream):
-        super(SecretData, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(SecretData, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.secret_data_type = SecretData.SecretDataType()
         self.key_block = KeyBlock()
 
-        self.secret_data_type.read(tstream)
-        self.key_block.read(tstream)
+        self.secret_data_type.read(tstream, kmip_version=kmip_version)
+        self.key_block.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.secret_data_type.write(tstream)
-        self.key_block.write(tstream)
+        self.secret_data_type.write(tstream, kmip_version=kmip_version)
+        self.key_block.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(SecretData, self).write(ostream)
+        super(SecretData, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):
@@ -428,28 +434,28 @@ class OpaqueObject(Struct):
         self.opaque_data_value = opaque_data_value
         self.validate()
 
-    def read(self, istream):
-        super(OpaqueObject, self).read(istream)
+    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        super(OpaqueObject, self).read(istream, kmip_version=kmip_version)
         tstream = BytearrayStream(istream.read(self.length))
 
         self.opaque_data_type = OpaqueObject.OpaqueDataType()
         self.opaque_data_value = OpaqueObject.OpaqueDataValue()
 
-        self.opaque_data_type.read(tstream)
-        self.opaque_data_value.read(tstream)
+        self.opaque_data_type.read(tstream, kmip_version=kmip_version)
+        self.opaque_data_value.read(tstream, kmip_version=kmip_version)
 
         self.is_oversized(tstream)
         self.validate()
 
-    def write(self, ostream):
+    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
         tstream = BytearrayStream()
 
-        self.opaque_data_type.write(tstream)
-        self.opaque_data_value.write(tstream)
+        self.opaque_data_type.write(tstream, kmip_version=kmip_version)
+        self.opaque_data_value.write(tstream, kmip_version=kmip_version)
 
         # Write the length and value of the template attribute
         self.length = tstream.length()
-        super(OpaqueObject, self).write(ostream)
+        super(OpaqueObject, self).write(ostream, kmip_version=kmip_version)
         ostream.write(tstream.buffer)
 
     def validate(self):

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -1061,7 +1061,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1313,7 +1313,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1350,7 +1350,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1383,7 +1383,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1421,7 +1421,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1458,7 +1458,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1508,7 +1508,7 @@ class KMIPProxy(object):
         message = messages.ResponseMessage()
         data = self._receive_message()
 
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1542,7 +1542,7 @@ class KMIPProxy(object):
         self._send_message(message)
         message = messages.ResponseMessage()
         data = self._receive_message()
-        message.read(data)
+        message.read(data, self.kmip_version)
         batch_items = message.batch_items
         batch_item = batch_items[0]
         payload = batch_item.response_payload
@@ -1610,7 +1610,7 @@ class KMIPProxy(object):
 
     def _send_message(self, message):
         stream = BytearrayStream()
-        message.write(stream)
+        message.write(stream, self.kmip_version)
         self.protocol.write(stream.buffer)
 
     def _receive_message(self):
@@ -1620,7 +1620,7 @@ class KMIPProxy(object):
         self._send_message(request)
         response = messages.ResponseMessage()
         data = self._receive_message()
-        response.read(data)
+        response.read(data, self.kmip_version)
         return response
 
     def _set_variables(self, host, port, keyfile, certfile,

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -116,6 +116,7 @@ class KmipEngine(object):
             contents.ProtocolVersion(1, 0)
         ]
 
+        self.default_protocol_version = self._protocol_versions[2]
         self._protocol_version = self._protocol_versions[2]
 
         self._object_map = {
@@ -308,7 +309,7 @@ class KmipEngine(object):
             response_batch
         )
 
-        return response, max_response_size
+        return response, max_response_size, header.protocol_version
 
     def _build_response(self, version, batch_items):
         header = messages.ResponseHeader(

--- a/kmip/tests/unit/core/messages/contents/test_protocol_version.py
+++ b/kmip/tests/unit/core/messages/contents/test_protocol_version.py
@@ -15,6 +15,7 @@
 
 import testtools
 
+from kmip.core import enums
 from kmip.core.messages import contents
 from kmip.core import utils
 
@@ -347,3 +348,75 @@ class TestProtocolVersion(testtools.TestCase):
         struct = contents.ProtocolVersion(1, 0)
 
         self.assertEqual("1.0", str(struct))
+
+
+class TestContents(testtools.TestCase):
+
+    def setUp(self):
+        super(TestContents, self).setUp()
+
+    def tearDown(self):
+        super(TestContents, self).tearDown()
+
+    def test_protocol_version_to_kmip_version_kmip_1_0(self):
+        """
+        Test the conversion from ProtocolVersion(1, 0) to KMIPVersion.KMIP_1_0.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 0)
+        )
+        self.assertEqual(result, enums.KMIPVersion.KMIP_1_0)
+
+    def test_protocol_version_to_kmip_version_kmip_1_1(self):
+        """
+        Test the conversion from ProtocolVersion(1, 1) to KMIPVersion.KMIP_1_1.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 1)
+        )
+        self.assertEqual(result, enums.KMIPVersion.KMIP_1_1)
+
+    def test_protocol_version_to_kmip_version_kmip_1_2(self):
+        """
+        Test the conversion from ProtocolVersion(1, 2) to KMIPVersion.KMIP_1_2.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 2)
+        )
+        self.assertEqual(result, enums.KMIPVersion.KMIP_1_2)
+
+    def test_protocol_version_to_kmip_version_kmip_1_3(self):
+        """
+        Test the conversion from ProtocolVersion(1, 3) to KMIPVersion.KMIP_1_3.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 3)
+        )
+        self.assertEqual(result, enums.KMIPVersion.KMIP_1_3)
+
+    def test_protocol_version_to_kmip_version_kmip_1_4(self):
+        """
+        Test the conversion from ProtocolVersion(1, 4) to KMIPVersion.KMIP_1_4.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 4)
+        )
+        self.assertEqual(result, enums.KMIPVersion.KMIP_1_4)
+
+    def test_protocol_version_to_kmip_version_invalid_minor(self):
+        """
+        Test the conversion from invalid ProtocolVersion minor value to None.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(1, 5)
+        )
+        self.assertIsNone(result)
+
+    def test_protocol_version_to_kmip_version_invalid_major(self):
+        """
+        Test the conversion from invalid ProtocolVersion major value to None.
+        """
+        result = contents.protocol_version_to_kmip_version(
+            contents.ProtocolVersion(9, 5)
+        )
+        self.assertIsNone(result)

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -213,7 +213,7 @@ class TestKmipEngine(testtools.TestCase):
             batch_items=batch
         )
 
-        response, max_size = e.process_request(request)
+        response, max_size, protocol_version = e.process_request(request)
 
         e._logger.info.assert_any_call(
             MockRegexString("Received request at time:")

--- a/kmip/tests/unit/services/server/test_session.py
+++ b/kmip/tests/unit/services/server/test_session.py
@@ -233,7 +233,11 @@ class TestKmipSession(testtools.TestCase):
             ['group A', 'group B']
         )
         kmip_session._engine.process_request = mock.MagicMock(
-            return_value=(message, kmip_session._max_response_size)
+            return_value=(
+                message,
+                kmip_session._max_response_size,
+                contents.ProtocolVersion(1, 2)
+            )
         )
         kmip_session._logger = mock.MagicMock()
         kmip_session._connection = mock.MagicMock()
@@ -424,6 +428,8 @@ class TestKmipSession(testtools.TestCase):
             "Authentication failed."
         )
         kmip_session._engine = mock.MagicMock()
+        kmip_session._engine.default_protocol_version = \
+            kmip_engine.default_protocol_version
         kmip_session._logger = mock.MagicMock()
         kmip_session._connection = mock.MagicMock()
         kmip_session._receive_request = mock.MagicMock(return_value=data)
@@ -450,7 +456,10 @@ class TestKmipSession(testtools.TestCase):
         kmip_session._handle_message_loop()
 
         kmip_session._receive_request.assert_called_once_with()
-        fake_request.read.assert_called_once_with(data)
+        fake_request.read.assert_called_once_with(
+            data,
+            kmip_version=enums.KMIPVersion.KMIP_1_2
+        )
         kmip_session.authenticate.assert_called_once_with(
             "test_certificate",
             fake_request


### PR DESCRIPTION
This change updates the PyKMIP object hierarchy's read/write method signatures to support propagation of the KMIP version. The introduction of KMIP 2.0 introduces future KMIP message encodings that break backwards compatibility; to support this, PyKMIP must know what KMIP version is being used when encoding or decoding an object; the KMIP version residing in the client or server alone is now insufficient. Prior versions of KMIP, namely 1.0 - 1.4, have been backwards compatible, obviating the need for the KMIP version at encode/decode time. Going forward, this is no longer true.

The PyKMIP client and server have been updated to include the KMIP version when making calls to read/write, as have the associated test cases covering this functionality.