### PR TITLE
Add KMIP 2.0-style attribute handling

### DIFF
--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -16,6 +16,7 @@
 # In case of new content, remove the following line to enable flake8 tests
 # flake8: noqa
 
+import copy
 import enum
 
 
@@ -473,11 +474,12 @@ class KeyWrapType(enum.Enum):
 
 
 class KMIPVersion(enum.Enum):
-    KMIP_1_0 = "KMIP 1.0"
-    KMIP_1_1 = "KMIP 1.1"
-    KMIP_1_2 = "KMIP 1.2"
-    KMIP_1_3 = "KMIP 1.3"
-    KMIP_1_4 = "KMIP 1.4"
+    KMIP_1_0 = 1.0
+    KMIP_1_1 = 1.1
+    KMIP_1_2 = 1.2
+    KMIP_1_3 = 1.3
+    KMIP_1_4 = 1.4
+    KMIP_2_0 = 2.0
 
 
 class LinkType(enum.Enum):
@@ -1304,7 +1306,7 @@ class Tags(enum.Enum):
     ISSUER_DISTINGUISHED_NAME                = 0x4200B2
     SUBJECT_ALTERNATIVE_NAME                 = 0x4200B3
     SUBJECT_DISTINGUISHED_NAME               = 0x4200B4
-    X_509_CERTIFICATE_IDENTIFER              = 0x4200B5
+    X_509_CERTIFICATE_IDENTIFIER             = 0x4200B5
     X_509_CERTIFICATE_ISSUER                 = 0x4200B6
     X_509_CERTIFICATE_SUBJECT                = 0x4200B7
     KEY_VALUE_LOCATION                       = 0x4200B8
@@ -1558,3 +1560,168 @@ class WrappingMethod(enum.Enum):
     ENCRYPT_THEN_MAC_SIGN = 0x00000003
     MAC_SIGN_THEN_ENCRYPT = 0x00000004
     TR_31                 = 0x00000005
+
+
+def is_enum_value(enum_class, potential_value):
+    """
+    A utility function that checks if the enumeration class contains the
+    provided value.
+
+    Args:
+        enum_class (class): One of the enumeration classes found in this file.
+        potential_value (int, string): A potential value of the enumeration
+            class.
+
+    Returns:
+        True: if the potential value is a valid value of the enumeration class
+        False: otherwise
+    """
+    try:
+        enum_class(potential_value)
+    except ValueError:
+        return False
+
+    return True
+
+
+def is_attribute(tag, kmip_version=None):
+    """
+    A utility function that checks if the tag is a valid attribute tag.
+
+    Args:
+        tag (enum): A Tags enumeration that may or may not correspond to a
+            KMIP attribute type.
+        kmip_version (enum): The KMIPVersion enumeration that should be used
+            when checking if the tag is a valid attribute tag. Optional,
+            defaults to None. If None, the tag is compared with all possible
+            attribute tags across all KMIP versions. Otherwise, only the
+            attribute tags for a specific KMIP version are checked.
+
+    Returns:
+        True: if the tag is a valid attribute tag
+        False: otherwise
+    """
+    kmip_1_0_attribute_tags = [
+        Tags.UNIQUE_IDENTIFIER,
+        Tags.NAME,
+        Tags.OBJECT_TYPE,
+        Tags.CRYPTOGRAPHIC_ALGORITHM,
+        Tags.CRYPTOGRAPHIC_LENGTH,
+        Tags.CRYPTOGRAPHIC_PARAMETERS,
+        Tags.CRYPTOGRAPHIC_DOMAIN_PARAMETERS,
+        Tags.CERTIFICATE_TYPE,
+        Tags.CERTIFICATE_IDENTIFIER,
+        Tags.CERTIFICATE_SUBJECT,
+        Tags.CERTIFICATE_ISSUER,
+        Tags.DIGEST,
+        Tags.OPERATION_POLICY_NAME,
+        Tags.CRYPTOGRAPHIC_USAGE_MASK,
+        Tags.LEASE_TIME,
+        Tags.USAGE_LIMITS,
+        Tags.STATE,
+        Tags.INITIAL_DATE,
+        Tags.ACTIVATION_DATE,
+        Tags.PROCESS_START_DATE,
+        Tags.PROTECT_STOP_DATE,
+        Tags.DEACTIVATION_DATE,
+        Tags.DESTROY_DATE,
+        Tags.COMPROMISE_OCCURRENCE_DATE,
+        Tags.COMPROMISE_DATE,
+        Tags.REVOCATION_REASON,
+        Tags.ARCHIVE_DATE,
+        Tags.OBJECT_GROUP,
+        Tags.LINK,
+        Tags.APPLICATION_SPECIFIC_INFORMATION,
+        Tags.CONTACT_INFORMATION,
+        Tags.LAST_CHANGE_DATE,
+        Tags.CUSTOM_ATTRIBUTE
+    ]
+    kmip_1_1_attribute_tags = copy.deepcopy(kmip_1_0_attribute_tags) + [
+        Tags.CERTIFICATE_LENGTH,
+        Tags.X_509_CERTIFICATE_IDENTIFIER,
+        Tags.X_509_CERTIFICATE_SUBJECT,
+        Tags.X_509_CERTIFICATE_ISSUER,
+        Tags.DIGITAL_SIGNATURE_ALGORITHM,
+        Tags.FRESH
+    ]
+    kmip_1_2_attribute_tags = copy.deepcopy(kmip_1_1_attribute_tags) + [
+        Tags.ALTERNATIVE_NAME,
+        Tags.KEY_VALUE_PRESENT,
+        Tags.KEY_VALUE_LOCATION,
+        Tags.ORIGINAL_CREATION_DATE
+    ]
+    kmip_1_3_attribute_tags = copy.deepcopy(kmip_1_2_attribute_tags) + [
+        Tags.RANDOM_NUMBER_GENERATOR
+    ]
+    kmip_1_4_attribute_tags = copy.deepcopy(kmip_1_3_attribute_tags) + [
+        Tags.PKCS12_FRIENDLY_NAME,
+        Tags.DESCRIPTION,
+        Tags.COMMENT,
+        Tags.SENSITIVE,
+        Tags.ALWAYS_SENSITIVE,
+        Tags.EXTRACTABLE,
+        Tags.NEVER_EXTRACTABLE
+    ]
+    kmip_2_0_attribute_tags = copy.deepcopy(kmip_1_4_attribute_tags) + [
+        Tags.CERTIFICATE_SUBJECT_CN,
+        Tags.CERTIFICATE_SUBJECT_O,
+        Tags.CERTIFICATE_SUBJECT_OU,
+        Tags.CERTIFICATE_SUBJECT_EMAIL,
+        Tags.CERTIFICATE_SUBJECT_C,
+        Tags.CERTIFICATE_SUBJECT_ST,
+        Tags.CERTIFICATE_SUBJECT_L,
+        Tags.CERTIFICATE_SUBJECT_UID,
+        Tags.CERTIFICATE_SUBJECT_SERIAL_NUMBER,
+        Tags.CERTIFICATE_SUBJECT_TITLE,
+        Tags.CERTIFICATE_SUBJECT_DC,
+        Tags.CERTIFICATE_SUBJECT_DN_QUALIFIER,
+        Tags.CERTIFICATE_ISSUER_CN,
+        Tags.CERTIFICATE_ISSUER_O,
+        Tags.CERTIFICATE_ISSUER_OU,
+        Tags.CERTIFICATE_ISSUER_EMAIL,
+        Tags.CERTIFICATE_ISSUER_C,
+        Tags.CERTIFICATE_ISSUER_ST,
+        Tags.CERTIFICATE_ISSUER_L,
+        Tags.CERTIFICATE_ISSUER_UID,
+        Tags.CERTIFICATE_ISSUER_SERIAL_NUMBER,
+        Tags.CERTIFICATE_ISSUER_TITLE,
+        Tags.CERTIFICATE_ISSUER_DC,
+        Tags.CERTIFICATE_ISSUER_DN_QUALIFIER,
+        Tags.KEY_FORMAT_TYPE,
+        Tags.NIST_KEY_TYPE,
+        Tags.OPAQUE_DATA_TYPE,
+        Tags.PROTECTION_LEVEL,
+        Tags.PROTECTION_PERIOD,
+        Tags.PROTECTION_STORAGE_MASK,
+        Tags.QUANTUM_SAFE,
+        Tags.SHORT_UNIQUE_IDENTIFIER,
+        Tags.ATTRIBUTE
+    ]
+    kmip_2_0_attribute_tags.remove(Tags.CERTIFICATE_IDENTIFIER)
+    kmip_2_0_attribute_tags.remove(Tags.CERTIFICATE_SUBJECT)
+    kmip_2_0_attribute_tags.remove(Tags.CERTIFICATE_ISSUER)
+    kmip_2_0_attribute_tags.remove(Tags.OPERATION_POLICY_NAME)
+    kmip_2_0_attribute_tags.remove(Tags.CUSTOM_ATTRIBUTE)
+
+    if kmip_version == KMIPVersion.KMIP_1_0:
+        return tag in kmip_1_0_attribute_tags
+    elif kmip_version == KMIPVersion.KMIP_1_1:
+        return tag in kmip_1_1_attribute_tags
+    elif kmip_version == KMIPVersion.KMIP_1_2:
+        return tag in kmip_1_2_attribute_tags
+    elif kmip_version == KMIPVersion.KMIP_1_3:
+        return tag in kmip_1_3_attribute_tags
+    elif kmip_version == KMIPVersion.KMIP_1_4:
+        return tag in kmip_1_4_attribute_tags
+    elif kmip_version == KMIPVersion.KMIP_2_0:
+        return tag in kmip_2_0_attribute_tags
+    else:
+        all_attribute_tags = set(
+            kmip_1_0_attribute_tags +
+            kmip_1_1_attribute_tags +
+            kmip_1_2_attribute_tags +
+            kmip_1_3_attribute_tags +
+            kmip_1_4_attribute_tags +
+            kmip_2_0_attribute_tags
+        )
+        return tag in all_attribute_tags

--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -264,6 +264,13 @@ class PermissionDenied(KmipError):
         )
 
 
+class AttributeNotSupported(Exception):
+    """
+    An error generated when an unsupported attribute is processed.
+    """
+    pass
+
+
 class ConfigurationError(Exception):
     """
     An error generated when a problem occurs with a client or server

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -110,6 +110,90 @@ class AttributeValueFactory(object):
                 # Custom attribute indicated
                 return attributes.CustomAttribute(value)
 
+    def create_attribute_value_by_enum(self, enum, value):
+        # Switch on the name of the attribute
+        if enum is enums.Tags.UNIQUE_IDENTIFIER:
+            return attributes.UniqueIdentifier(value)
+        elif enum is enums.Tags.NAME:
+            return self._create_name(value)
+        elif enum is enums.Tags.OBJECT_TYPE:
+            return attributes.ObjectType(value)
+        elif enum is enums.Tags.CRYPTOGRAPHIC_ALGORITHM:
+            return attributes.CryptographicAlgorithm(value)
+        elif enum is enums.Tags.CRYPTOGRAPHIC_LENGTH:
+            return self._create_cryptographic_length(value)
+        elif enum is enums.Tags.CRYPTOGRAPHIC_PARAMETERS:
+            return self._create_cryptographic_parameters(value)
+        elif enum is enums.Tags.CRYPTOGRAPHIC_DOMAIN_PARAMETERS:
+            raise NotImplementedError()
+        elif enum is enums.Tags.CERTIFICATE_TYPE:
+            raise NotImplementedError()
+        elif enum is enums.Tags.CERTIFICATE_LENGTH:
+            return primitives.Integer(value, enums.Tags.CERTIFICATE_LENGTH)
+        elif enum is enums.Tags.X_509_CERTIFICATE_IDENTIFIER:
+            raise NotImplementedError()
+        elif enum is enums.Tags.X_509_CERTIFICATE_SUBJECT:
+            raise NotImplementedError()
+        elif enum is enums.Tags.X_509_CERTIFICATE_ISSUER:
+            raise NotImplementedError()
+        elif enum is enums.Tags.CERTIFICATE_IDENTIFIER:
+            raise NotImplementedError()
+        elif enum is enums.Tags.CERTIFICATE_SUBJECT:
+            raise NotImplementedError()
+        elif enum is enums.Tags.CERTIFICATE_ISSUER:
+            raise NotImplementedError()
+        elif enum is enums.Tags.DIGITAL_SIGNATURE_ALGORITHM:
+            raise NotImplementedError()
+        elif enum is enums.Tags.DIGEST:
+            return attributes.Digest()
+        elif enum is enums.Tags.OPERATION_POLICY_NAME:
+            return attributes.OperationPolicyName(value)
+        elif enum is enums.Tags.CRYPTOGRAPHIC_USAGE_MASK:
+            return self._create_cryptographic_usage_mask(value)
+        elif enum is enums.Tags.LEASE_TIME:
+            return primitives.Interval(value, enums.Tags.LEASE_TIME)
+        elif enum is enums.Tags.USAGE_LIMITS:
+            raise NotImplementedError()
+        elif enum is enums.Tags.STATE:
+            return attributes.State(value)
+        elif enum is enums.Tags.INITIAL_DATE:
+            return primitives.DateTime(value, enums.Tags.INITIAL_DATE)
+        elif enum is enums.Tags.ACTIVATION_DATE:
+            return primitives.DateTime(value, enums.Tags.ACTIVATION_DATE)
+        elif enum is enums.Tags.PROCESS_START_DATE:
+            return primitives.DateTime(value, enums.Tags.PROCESS_START_DATE)
+        elif enum is enums.Tags.PROTECT_STOP_DATE:
+            return primitives.DateTime(value, enums.Tags.PROTECT_STOP_DATE)
+        elif enum is enums.Tags.DEACTIVATION_DATE:
+            return primitives.DateTime(value, enums.Tags.DEACTIVATION_DATE)
+        elif enum is enums.Tags.DESTROY_DATE:
+            return primitives.DateTime(value, enums.Tags.DESTROY_DATE)
+        elif enum is enums.Tags.COMPROMISE_OCCURRENCE_DATE:
+            return primitives.DateTime(
+                value, enums.Tags.COMPROMISE_OCCURRENCE_DATE)
+        elif enum is enums.Tags.COMPROMISE_DATE:
+            return primitives.DateTime(value, enums.Tags.COMPROMISE_DATE)
+        elif enum is enums.Tags.REVOCATION_REASON:
+            raise NotImplementedError()
+        elif enum is enums.Tags.ARCHIVE_DATE:
+            return primitives.DateTime(value, enums.Tags.ARCHIVE_DATE)
+        elif enum is enums.Tags.OBJECT_GROUP:
+            return self._create_object_group(value)
+        elif enum is enums.Tags.FRESH:
+            return primitives.Boolean(value, enums.Tags.FRESH)
+        elif enum is enums.Tags.LINK:
+            raise NotImplementedError()
+        elif enum is enums.Tags.APPLICATION_SPECIFIC_INFORMATION:
+            return self._create_application_specific_information(value)
+        elif enum is enums.Tags.CONTACT_INFORMATION:
+            return self._create_contact_information(value)
+        elif enum is enums.Tags.LAST_CHANGE_DATE:
+            return primitives.DateTime(value, enums.Tags.LAST_CHANGE_DATE)
+        elif enum is enums.Tags.CUSTOM_ATTRIBUTE:
+            return attributes.CustomAttribute(value)
+        else:
+            raise ValueError("Unrecognized attribute type: {}".format(enum))
+
     def _create_name(self, name):
         if name is not None:
             if isinstance(name, attributes.Name):

--- a/kmip/tests/unit/core/test_enums.py
+++ b/kmip/tests/unit/core/test_enums.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import testtools
+
+from kmip.core import enums
+
+
+class TestEnumUtilityFunctions(testtools.TestCase):
+
+    def setUp(self):
+        super(TestEnumUtilityFunctions, self).setUp()
+
+    def tearDown(self):
+        super(TestEnumUtilityFunctions, self).tearDown()
+
+    def test_is_enum_value(self):
+        result = enums.is_enum_value(
+            enums.CryptographicAlgorithm,
+            enums.CryptographicAlgorithm.AES
+        )
+        self.assertTrue(result)
+
+        result = enums.is_enum_value(
+            enums.WrappingMethod,
+            'invalid'
+        )
+        self.assertFalse(result)
+
+    def test_is_attribute(self):
+        # Test an attribute introduced in KMIP 1.0
+        result = enums.is_attribute(enums.Tags.UNIQUE_IDENTIFIER)
+        self.assertTrue(result)
+
+        # Test an attribute introduced in KMIP 1.1
+        result = enums.is_attribute(enums.Tags.FRESH)
+        self.assertTrue(result)
+
+        # Test an attribute introduced in KMIP 1.2
+        result = enums.is_attribute(enums.Tags.KEY_VALUE_PRESENT)
+        self.assertTrue(result)
+
+        # Test an attribute introduced in KMIP 1.3
+        result = enums.is_attribute(enums.Tags.RANDOM_NUMBER_GENERATOR)
+        self.assertTrue(result)
+
+        # Test an attribute introduced in KMIP 1.4
+        result = enums.is_attribute(enums.Tags.COMMENT)
+        self.assertTrue(result)
+
+        # Test an attribute introduced in KMIP 2.0
+        result = enums.is_attribute(enums.Tags.QUANTUM_SAFE)
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_1_0(self):
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.UNIQUE_IDENTIFIER,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_1_1(self):
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.FRESH,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_1_2(self):
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.KEY_VALUE_PRESENT,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_1_3(self):
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.RANDOM_NUMBER_GENERATOR,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_1_4(self):
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.COMMENT,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_added_in_kmip_2_0(self):
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertFalse(result)
+
+        result = enums.is_attribute(
+            enums.Tags.QUANTUM_SAFE,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertTrue(result)
+
+    def test_is_attribute_removed_in_kmip_2_0(self):
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_1_0
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_1_1
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_1_2
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_1_3
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_1_4
+        )
+        self.assertTrue(result)
+
+        result = enums.is_attribute(
+            enums.Tags.CUSTOM_ATTRIBUTE,
+            enums.KMIPVersion.KMIP_2_0
+        )
+        self.assertFalse(result)


### PR DESCRIPTION
This change adds a new Attributes object to the object hierarchy, which replaces TemplateAttributes in KMIP 2.0. The old attribute components, like the AttributeName and AttributeIndex, are no longer used and are instead replaced with the KMIP TTLV tag for the attributes in question. This brings the attribute encoding process in line with the rest of the KMIP specification.

To support this change, additional attribute and enumeration utility functions have been added to simply attribute building and attribute/enumeration validity checking. New test cases covering this new functionality are also included.