### PR TITLE
Block Attributes encoding and decoding on non KMIP 2.0 calls

### DIFF
--- a/kmip/core/exceptions.py
+++ b/kmip/core/exceptions.py
@@ -324,6 +324,12 @@ class ShutdownError(Exception):
     """
 
 
+class VersionNotSupported(Exception):
+    """
+    An error generated when an unsupported KMIP version is referenced.
+    """
+
+
 class StreamNotEmptyError(Exception):
     def __init__(self, cls, extra):
         super(StreamNotEmptyError, self).__init__()

--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -258,7 +258,16 @@ class Attributes(primitives.Struct):
         Raises:
             AttributeNotSupported: Raised if an unsupported attribute is
                 encountered while decoding.
+            VersionNotSupported: Raised when a KMIP version is provided that
+                does not support the Attributes object.
         """
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            raise exceptions.VersionNotSupported(
+                "KMIP {} does not support the Attributes object.".format(
+                    kmip_version.value
+                )
+            )
+
         super(Attributes, self).read(input_stream, kmip_version=kmip_version)
         local_stream = BytearrayStream(input_stream.read(self.length))
 
@@ -297,7 +306,16 @@ class Attributes(primitives.Struct):
         Raises:
             AttributeNotSupported: Raised if an unsupported attribute is
                 found in the attribute list while encoding.
+            VersionNotSupported: Raised when a KMIP version is provided that
+                does not support the Attributes object.
         """
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            raise exceptions.VersionNotSupported(
+                "KMIP {} does not support the Attributes object.".format(
+                    kmip_version.value
+                )
+            )
+
         local_stream = BytearrayStream()
 
         for attribute in self._attributes:

--- a/kmip/tests/unit/core/objects/test_objects.py
+++ b/kmip/tests/unit/core/objects/test_objects.py
@@ -400,6 +400,24 @@ class TestAttributes(TestCase):
         self.assertIsInstance(attr_2, primitives.Integer)
         self.assertEqual(128, attr_2.value)
 
+    def test_read_version_not_supported(self):
+        """
+        Test that a VersionNotSupported error is raised when an unsupported
+        KMIP version is provided while reading in an Attributes structure from
+        a data stream. The Attributes structure is only supported in KMIP 2.0+.
+        """
+        attrs = objects.Attributes()
+
+        args = (self.full_encoding, )
+        kwargs = {"kmip_version": enums.KMIPVersion.KMIP_1_2}
+        self.assertRaisesRegex(
+            exceptions.VersionNotSupported,
+            "KMIP 1.2 does not support the Attributes object.",
+            attrs.read,
+            *args,
+            **kwargs
+        )
+
     def test_write(self):
         """
         Test that an Attributes structure can be correctly written to a data
@@ -488,6 +506,30 @@ class TestAttributes(TestCase):
 
         self.assertEqual(len(self.alt_encoding), len(stream))
         self.assertEqual(str(self.alt_encoding), str(stream))
+
+    def test_write_version_not_supported(self):
+        """
+        Test that a VersionNotSupported error is raised when an unsupported
+        KMIP version is provided while writing an Attributes structure to a
+        data stream. The Attributes structure is only supported in KMIP 2.0+.
+        """
+        attrs = objects.Attributes(attributes=[
+            primitives.TextString(
+                "default",
+                tag=enums.Tags.OPERATION_POLICY_NAME
+            )
+        ])
+
+        stream = utils.BytearrayStream()
+        args = (stream, )
+        kwargs = {"kmip_version": enums.KMIPVersion.KMIP_1_1}
+        self.assertRaisesRegex(
+            exceptions.VersionNotSupported,
+            "KMIP 1.1 does not support the Attributes object.",
+            attrs.write,
+            *args,
+            **kwargs
+        )
 
     def test_repr(self):
         """


### PR DESCRIPTION
This change adds a check to the read and write methods of the new Attributes object that raises a new VersionNotSupported exception if KMIP 2.0 is not the version used for encoding and decoding. The Attributes object is not defined for older versions of KMIP and therefore cannot be correctly encoded or decoded in those use cases.