### PR TITLE
Provision CA extension in CA cert

### DIFF
--- a/bin/create_certificates.py
+++ b/bin/create_certificates.py
@@ -31,6 +31,8 @@ def create_self_signed_certificate(subject_name, private_key, days_valid=365):
         private_key.public_key()
     ).serial_number(
         x509.random_serial_number()
+    ).add_extension(
+        x509.BasicConstraints(ca=True, path_length=None), critical=True
     ).not_valid_before(
         datetime.datetime.utcnow()
     ).not_valid_after(


### PR DESCRIPTION
Without that, on modern OpenSSL libs this gives an error:

```
verify error:num=24:invalid CA certificate
```