### PR TITLE
Update the Create payloads to support KMIP 2.0

### DIFF
--- a/kmip/core/messages/payloads/create.py
+++ b/kmip/core/messages/payloads/create.py
@@ -126,17 +126,37 @@ class CreateRequestPayload(primitives.Struct):
                 "type."
             )
 
-        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
-            self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(
-                local_buffer,
-                kmip_version=kmip_version
-            )
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
+                self._template_attribute = objects.TemplateAttribute()
+                self._template_attribute.read(
+                    local_buffer,
+                    kmip_version=kmip_version
+                )
+            else:
+                raise exceptions.InvalidKmipEncoding(
+                    "The Create request payload encoding is missing the "
+                    "template attribute."
+                )
         else:
-            raise exceptions.InvalidKmipEncoding(
-                "The Create request payload encoding is missing the template "
-                "attribute."
-            )
+            # NOTE (ph) For now, leave attributes natively in TemplateAttribute
+            # form and just convert to the KMIP 2.0 Attributes form as needed
+            # for encoding/decoding purposes. Changing the payload to require
+            # the new Attributes structure will trigger a bunch of second-order
+            # effects across the client and server codebases that is beyond
+            # the scope of updating the Create payloads to support KMIP 2.0.
+            if self.is_tag_next(enums.Tags.ATTRIBUTES, local_buffer):
+                attributes = objects.Attributes()
+                attributes.read(local_buffer, kmip_version=kmip_version)
+                value = objects.convert_attributes_to_template_attribute(
+                    attributes
+                )
+                self._template_attribute = value
+            else:
+                raise exceptions.InvalidKmipEncoding(
+                    "The Create request payload encoding is missing the "
+                    "attributes structure."
+                )
 
         self.is_oversized(local_buffer)
 
@@ -164,16 +184,34 @@ class CreateRequestPayload(primitives.Struct):
                 "The Create request payload is missing the object type field."
             )
 
-        if self._template_attribute:
-            self._template_attribute.write(
-                local_buffer,
-                kmip_version=kmip_version
-            )
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            if self._template_attribute:
+                self._template_attribute.write(
+                    local_buffer,
+                    kmip_version=kmip_version
+                )
+            else:
+                raise exceptions.InvalidField(
+                    "The Create request payload is missing the template "
+                    "attribute field."
+                )
         else:
-            raise exceptions.InvalidField(
-                "The Create request payload is missing the template attribute "
-                "field."
-            )
+            # NOTE (ph) For now, leave attributes natively in TemplateAttribute
+            # form and just convert to the KMIP 2.0 Attributes form as needed
+            # for encoding/decoding purposes. Changing the payload to require
+            # the new Attributes structure will trigger a bunch of second-order
+            # effects across the client and server codebases that is beyond
+            # the scope of updating the Create payloads to support KMIP 2.0.
+            if self._template_attribute:
+                attributes = objects.convert_template_attribute_to_attributes(
+                    self._template_attribute
+                )
+                attributes.write(local_buffer, kmip_version=kmip_version)
+            else:
+                raise exceptions.InvalidField(
+                    "The Create request payload is missing the template "
+                    "attribute field."
+                )
 
         self.length = local_buffer.length()
         super(CreateRequestPayload, self).write(
@@ -360,12 +398,13 @@ class CreateResponsePayload(primitives.Struct):
                 "identifier."
             )
 
-        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
-            self._template_attribute = objects.TemplateAttribute()
-            self._template_attribute.read(
-                local_buffer,
-                kmip_version=kmip_version
-            )
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
+                self._template_attribute = objects.TemplateAttribute()
+                self._template_attribute.read(
+                    local_buffer,
+                    kmip_version=kmip_version
+                )
 
         self.is_oversized(local_buffer)
 
@@ -404,11 +443,12 @@ class CreateResponsePayload(primitives.Struct):
                 "field."
             )
 
-        if self._template_attribute:
-            self._template_attribute.write(
-                local_buffer,
-                kmip_version=kmip_version
-            )
+        if kmip_version < enums.KMIPVersion.KMIP_2_0:
+            if self._template_attribute:
+                self._template_attribute.write(
+                    local_buffer,
+                    kmip_version=kmip_version
+                )
 
         self.length = local_buffer.length()
         super(CreateResponsePayload, self).write(


### PR DESCRIPTION
This change updates the Create payloads to support KMIP 2.0 features, including swapping out TemplateAttributes for the new Attributes structure in the request payload and removing all attribute-related encodings from the response payload. Unit tests have been added to cover these changes.