### PR TITLE
Update the Register payloads

### DIFF
--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -13,136 +13,462 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core.factories.secrets import SecretFactory
+import six
 
-from kmip.core import attributes
 from kmip.core import enums
+from kmip.core import exceptions
+from kmip.core import objects
+from kmip.core import primitives
+from kmip.core import secrets
+from kmip.core import utils
 
-from kmip.core.objects import TemplateAttribute
-
-from kmip.core.primitives import Struct
-
-from kmip.core.utils import BytearrayStream
+from kmip.core.factories import secrets as secret_factory
 
 
-# 4.3
-class RegisterRequestPayload(Struct):
+class RegisterRequestPayload(primitives.Struct):
+    """
+    A request payload for the Register operation.
+
+    Attributes:
+        object_type: The type of the object to register.
+        template_attribute: A group of attributes to set on the new object.
+        managed_object: The object to register.
+    """
 
     def __init__(self,
                  object_type=None,
                  template_attribute=None,
-                 secret=None):
+                 managed_object=None):
+        """
+        Construct a Register request payload structure.
+
+        Args:
+            object_type (enum): An ObjectType enumeration specifying the type
+                of object to register. Optional, defaults to None. Required for
+                read/write.
+            template_attribute (TemplateAttribute): A TemplateAttribute
+                structure containing a set of attributes to set on the new
+                object. Optional, defaults to None. Required for read/write.
+            managed_object (Struct): A managed object structure representing
+                the object to register. Must be one of:
+                    * secrets.Certificate
+                    * secrets.OpaqueObject
+                    * secrets.PrivateKey
+                    * secrets.PublicKey
+                    * secrets.SecretData
+                    * secrets.SplitKey
+                    * secrets.SymmetricKey
+                    * secrets.Template
+                Optional, defaults to None. Required for read/write.
+        """
+
         super(RegisterRequestPayload, self).__init__(
             enums.Tags.REQUEST_PAYLOAD
         )
 
-        self.secret_factory = SecretFactory()
+        self.secret_factory = secret_factory.SecretFactory()
+
+        self._object_type = None
+        self._template_attribute = None
+        self._secret = None
+
         self.object_type = object_type
         self.template_attribute = template_attribute
-        self.secret = secret
+        self.managed_object = managed_object
 
-        self.validate()
+    @property
+    def object_type(self):
+        if self._object_type:
+            return self._object_type.value
+        else:
+            return None
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    @object_type.setter
+    def object_type(self, value):
+        if value is None:
+            self._object_type = None
+        elif isinstance(value, enums.ObjectType):
+            self._object_type = primitives.Enumeration(
+                enums.ObjectType,
+                value=value,
+                tag=enums.Tags.OBJECT_TYPE
+            )
+        else:
+            raise TypeError(
+                "Object type must be an ObjectType enumeration."
+            )
+
+    @property
+    def template_attribute(self):
+        return self._template_attribute
+
+    @template_attribute.setter
+    def template_attribute(self, value):
+        if value is None:
+            self._template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            self._template_attribute = value
+        else:
+            raise TypeError(
+                "Template attribute must be a TemplateAttribute structure."
+            )
+
+    @property
+    def managed_object(self):
+        return self._managed_object
+
+    @managed_object.setter
+    def managed_object(self, value):
+        if value is None:
+            self._managed_object = None
+        elif isinstance(
+                value,
+                (
+                    secrets.Certificate,
+                    secrets.OpaqueObject,
+                    secrets.PrivateKey,
+                    secrets.PublicKey,
+                    secrets.SecretData,
+                    secrets.SplitKey,
+                    secrets.SymmetricKey,
+                    secrets.Template
+                )
+        ):
+            self._managed_object = value
+        else:
+            raise TypeError(
+                "Managed object must be a supported managed object structure."
+            )
+
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Read the data encoding the Register request payload and decode it into
+        its constituent parts.
+
+        Args:
+            input_buffer (stream): A data buffer containing encoded object
+                data, supporting a read method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
+
+        Raises:
+            InvalidKmipEncoding: Raised if the object type, template attribute,
+                or managed object is missing from the encoded payload.
+        """
         super(RegisterRequestPayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        self.object_type = attributes.ObjectType()
-        self.template_attribute = TemplateAttribute()
+        if self.is_tag_next(enums.Tags.OBJECT_TYPE, local_buffer):
+            self._object_type = primitives.Enumeration(
+                enums.ObjectType,
+                tag=enums.Tags.OBJECT_TYPE
+            )
+            self._object_type.read(local_buffer, kmip_version=kmip_version)
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Register request payload encoding is missing the object "
+                "type."
+            )
 
-        self.object_type.read(tstream, kmip_version=kmip_version)
-        self.template_attribute.read(tstream, kmip_version=kmip_version)
+        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
+            self._template_attribute = objects.TemplateAttribute()
+            self._template_attribute.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Register request payload encoding is missing the "
+                "template attribute."
+            )
 
-        secret_type = self.object_type.value
-        secret = self.secret_factory.create(secret_type)
+        managed_object = self.secret_factory.create(self.object_type)
 
-        if self.is_tag_next(secret.tag, tstream):
-            self.secret = secret
-            self.secret.read(tstream, kmip_version=kmip_version)
+        if self.is_tag_next(managed_object.tag, local_buffer):
+            self._managed_object = managed_object
+            self._managed_object.read(local_buffer, kmip_version=kmip_version)
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Register request payload encoding is missing the managed "
+                "object."
+            )
 
-        self.is_oversized(tstream)
-        self.validate()
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
-        tstream = BytearrayStream()
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Write the data encoding the Register request payload to a buffer.
 
-        # Write the contents of the request payload
-        self.object_type.write(tstream, kmip_version=kmip_version)
-        self.template_attribute.write(tstream, kmip_version=kmip_version)
+        Args:
+            output_buffer (stream): A data buffer in which to encode object
+                data, supporting a write method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
-        if self.secret is not None:
-            self.secret.write(tstream, kmip_version=kmip_version)
+        Raises:
+            InvalidField: Raised if the object type attribute, template
+                attribute, or managed object is not defined.
+        """
+        local_buffer = utils.BytearrayStream()
 
-        # Write the length and value of the request payload
-        self.length = tstream.length()
+        if self._object_type:
+            self._object_type.write(local_buffer, kmip_version=kmip_version)
+        else:
+            raise exceptions.InvalidField(
+                "The Register request payload is missing the object type "
+                "field."
+            )
+
+        if self._template_attribute:
+            self._template_attribute.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The Register request payload is missing the template "
+                "attribute field."
+            )
+
+        if self._managed_object:
+            self._managed_object.write(local_buffer, kmip_version=kmip_version)
+        else:
+            raise exceptions.InvalidField(
+                "The Register request payload is missing the managed object "
+                "field."
+            )
+
+        self.length = local_buffer.length()
         super(RegisterRequestPayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
-    def validate(self):
-        self.__validate()
+    def __eq__(self, other):
+        if isinstance(other, RegisterRequestPayload):
+            if self.object_type != other.object_type:
+                return False
+            elif self.template_attribute != other.template_attribute:
+                return False
+            elif self.managed_object != other.managed_object:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
 
-    def __validate(self):
-        # TODO (peter-hamilton) Finish implementation.
-        pass
+    def __ne__(self, other):
+        if isinstance(other, RegisterRequestPayload):
+            return not (self == other)
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        args = ", ".join([
+            "object_type={}".format(self.object_type),
+            "template_attribute={}".format(repr(self.template_attribute)),
+            "managed_object={}".format(repr(self.managed_object))
+        ])
+        return "RegisterRequestPayload({})".format(args)
+
+    def __str__(self):
+        value = ", ".join(
+            [
+                '"object_type": {}'.format(self.object_type),
+                '"template_attribute": {}'.format(self.template_attribute),
+                '"managed_object": {}'.format(self.managed_object)
+            ]
+        )
+        return '{' + value + '}'
 
 
-class RegisterResponsePayload(Struct):
+class RegisterResponsePayload(primitives.Struct):
+    """
+    A response payload for the Register operation.
+
+    Attributes:
+        unique_identifier: The unique ID of the new object.
+        template_attribute: A group of attributes that were set on the new
+            object.
+    """
 
     def __init__(self,
                  unique_identifier=None,
                  template_attribute=None):
+        """
+        Construct a Register response payload structure.
+
+        Args:
+            unique_identifier (string): The ID of the new object. Optional,
+                defaults to None. Required for read/write.
+            template_attribute (TemplateAttribute): A TemplateAttribute
+                structure containing a set of attributes that were set on the
+                new object. Optional, defaults to None.
+        """
         super(RegisterResponsePayload, self).__init__(
             enums.Tags.RESPONSE_PAYLOAD
         )
 
+        self._unique_identifier = None
+        self._template_attribute = None
+
         self.unique_identifier = unique_identifier
         self.template_attribute = template_attribute
 
-        self.validate()
+    @property
+    def unique_identifier(self):
+        if self._unique_identifier:
+            return self._unique_identifier.value
+        else:
+            return None
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    @unique_identifier.setter
+    def unique_identifier(self, value):
+        if value is None:
+            self._unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Unique identifier must be a string.")
+
+    @property
+    def template_attribute(self):
+        return self._template_attribute
+
+    @template_attribute.setter
+    def template_attribute(self, value):
+        if value is None:
+            self._template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            self._template_attribute = value
+        else:
+            raise TypeError(
+                "Template attribute must be a TemplateAttribute structure."
+            )
+
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Read the data encoding the Register response payload and decode it
+        into its constituent parts.
+
+        Args:
+            input_buffer (stream): A data buffer containing encoded object
+                data, supporting a read method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
+
+        Raises:
+            InvalidKmipEncoding: Raised if the unique identifier is missing
+                from the encoded payload.
+        """
         super(RegisterResponsePayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        self.unique_identifier = attributes.UniqueIdentifier()
-        self.unique_identifier.read(tstream, kmip_version=kmip_version)
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_buffer):
+            self._unique_identifier = primitives.TextString(
+                tag=enums.Tags.UNIQUE_IDENTIFIER
+            )
+            self._unique_identifier.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The Register response payload encoding is missing the unique "
+                "identifier."
+            )
 
-        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, tstream):
-            self.template_attribute = TemplateAttribute()
-            self.template_attribute.read(tstream, kmip_version=kmip_version)
+        if self.is_tag_next(enums.Tags.TEMPLATE_ATTRIBUTE, local_buffer):
+            self._template_attribute = objects.TemplateAttribute()
+            self._template_attribute.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
 
-        self.is_oversized(tstream)
-        self.validate()
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
-        tstream = BytearrayStream()
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Write the data encoding the Register response payload to a buffer.
 
-        # Write the contents of the request payload
-        self.unique_identifier.write(tstream, kmip_version=kmip_version)
+        Args:
+            output_buffer (stream): A data buffer in which to encode object
+                data, supporting a write method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
-        if self.template_attribute is not None:
-            self.template_attribute.write(tstream, kmip_version=kmip_version)
+        Raises:
+            InvalidField: Raised if the unique identifier is not defined.
+        """
+        local_buffer = utils.BytearrayStream()
 
-        # Write the length and value of the request payload
-        self.length = tstream.length()
+        if self._unique_identifier:
+            self._unique_identifier.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The Register response payload is missing the unique "
+                "identifier field."
+            )
+
+        if self._template_attribute:
+            self._template_attribute.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+
+        self.length = local_buffer.length()
         super(RegisterResponsePayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
-    def validate(self):
-        self.__validate()
+    def __eq__(self, other):
+        if isinstance(other, RegisterResponsePayload):
+            if self.unique_identifier != other.unique_identifier:
+                return False
+            elif self.template_attribute != other.template_attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
 
-    def __validate(self):
-        # TODO (peter-hamilton) Finish implementation.
-        pass
+    def __ne__(self, other):
+        if isinstance(other, RegisterResponsePayload):
+            return not (self == other)
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        args = ", ".join([
+            "unique_identifier='{}'".format(self.unique_identifier),
+            "template_attribute={}".format(repr(self.template_attribute))
+        ])
+        return "RegisterResponsePayload({})".format(args)
+
+    def __str__(self):
+        value = ", ".join(
+            [
+                '"unique_identifier": "{}"'.format(self.unique_identifier),
+                '"template_attribute": {}'.format(self.template_attribute)
+            ]
+        )
+        return '{' + value + '}'

--- a/kmip/demos/units/register.py
+++ b/kmip/demos/units/register.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         result.result_status.value))
 
     if result.result_status.value == ResultStatus.SUCCESS:
-        logger.info('registered UUID: {0}'.format(result.uuid.value))
+        logger.info('registered UUID: {0}'.format(result.uuid))
         logger.info('registered template attribute: {0}'.
                     format(result.template_attribute))
     else:

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -426,8 +426,7 @@ class ProxyKmipClient(object):
 
         status = result.result_status.value
         if status == enums.ResultStatus.SUCCESS:
-            uid = result.uuid.value
-            return uid
+            return result.uuid
         else:
             reason = result.result_reason.value
             message = result.result_message.value

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -672,7 +672,6 @@ class KMIPProxy(object):
 
     def register(self, object_type, template_attribute, secret,
                  credential=None):
-        object_type = attr.ObjectType(object_type)
         return self._register(object_type=object_type,
                               template_attribute=template_attribute,
                               secret=secret,
@@ -1449,7 +1448,7 @@ class KMIPProxy(object):
         req_pl = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
-            secret=secret)
+            managed_object=secret)
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=req_pl)
 

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1285,7 +1285,7 @@ class KmipEngine(object):
     def _process_register(self, payload):
         self._logger.info("Processing operation: Register")
 
-        object_type = payload.object_type.value
+        object_type = payload.object_type
         template_attribute = payload.template_attribute
 
         if self._object_map.get(object_type) is None:
@@ -1298,8 +1298,8 @@ class KmipEngine(object):
                 )
             )
 
-        if payload.secret:
-            secret = payload.secret
+        if payload.managed_object:
+            secret = payload.managed_object
         else:
             # TODO (peterhamilton) It is possible to register 'empty' secrets
             # like Private Keys. For now, that feature is not supported.
@@ -1340,9 +1340,7 @@ class KmipEngine(object):
         )
 
         response_payload = payloads.RegisterResponsePayload(
-            unique_identifier=attributes.UniqueIdentifier(
-                str(managed_object.unique_identifier)
-            )
+            unique_identifier=str(managed_object.unique_identifier)
         )
 
         self._id_placeholder = str(managed_object.unique_identifier)

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -427,10 +427,10 @@ class TestIntegration(TestCase):
                                       credential=None)
 
         self._check_result_status(result, ResultStatus, ResultStatus.SUCCESS)
-        self._check_uuid(result.uuid.value, str)
+        self._check_uuid(result.uuid, str)
 
         # Check that the returned key bytes match what was provided
-        uuid = result.uuid.value
+        uuid = result.uuid
         result = self.client.get(uuid=uuid, credential=None)
 
         self._check_result_status(result, ResultStatus, ResultStatus.SUCCESS)
@@ -654,10 +654,10 @@ class TestIntegration(TestCase):
         self._check_result_status(priv_key_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 
-        self._check_uuid(priv_key_result.uuid.value, str)
+        self._check_uuid(priv_key_result.uuid, str)
 
         # Check that the returned key bytes match what was provided
-        priv_uuid = priv_key_result.uuid.value
+        priv_uuid = priv_key_result.uuid
 
         priv_key_result = self.client.get(uuid=priv_uuid, credential=None)
 
@@ -766,7 +766,7 @@ class TestIntegration(TestCase):
         self._check_result_status(pub_key_result, ResultStatus,
                                   ResultStatus.SUCCESS)
         # Check that the returned key bytes match what was provided
-        pub_uuid = pub_key_result.uuid.value
+        pub_uuid = pub_key_result.uuid
         pub_key_result = self.client.get(uuid=pub_uuid, credential=None)
         self._check_result_status(pub_key_result, ResultStatus,
                                   ResultStatus.SUCCESS)
@@ -901,10 +901,10 @@ class TestIntegration(TestCase):
         self._check_result_status(cert_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 
-        self._check_uuid(cert_result.uuid.value, str)
+        self._check_uuid(cert_result.uuid, str)
 
         # Check that the returned key bytes match what was provided
-        cert_uuid = cert_result.uuid.value
+        cert_uuid = cert_result.uuid
 
         cert_result = self.client.get(uuid=cert_uuid, credential=None)
 
@@ -1008,10 +1008,10 @@ class TestIntegration(TestCase):
         self._check_result_status(pass_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 
-        self._check_uuid(pass_result.uuid.value, str)
+        self._check_uuid(pass_result.uuid, str)
 
         # Check that the returned key bytes match what was provided
-        pass_uuid = pass_result.uuid.value
+        pass_uuid = pass_result.uuid
 
         pass_result = self.client.get(uuid=pass_uuid, credential=None)
 
@@ -1102,10 +1102,10 @@ class TestIntegration(TestCase):
         self._check_result_status(opaque_obj_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 
-        self._check_uuid(opaque_obj_result.uuid.value, str)
+        self._check_uuid(opaque_obj_result.uuid, str)
 
         # Check that the returned key bytes match what was provided
-        opaque_obj_uuid = opaque_obj_result.uuid.value
+        opaque_obj_uuid = opaque_obj_result.uuid
 
         opaque_obj_result = self.client.get(uuid=opaque_obj_uuid,
                                             credential=None)

--- a/kmip/tests/integration/services/test_kmip_client.py
+++ b/kmip/tests/integration/services/test_kmip_client.py
@@ -230,7 +230,7 @@ class TestKMIPClientIntegration(TestCase):
 
         self._check_result_status(result.result_status.value, ResultStatus,
                                   ResultStatus.SUCCESS)
-        self._check_uuid(result.uuid.value, str)
+        self._check_uuid(result.uuid, str)
 
         # Check the template attribute type
         self._check_template_attribute(result.template_attribute,
@@ -238,7 +238,7 @@ class TestKMIPClientIntegration(TestCase):
                                        [[str, 'Unique Identifier', str,
                                          None]])
         # Check that the returned key bytes match what was provided
-        uuid = result.uuid.value
+        uuid = result.uuid
         result = self.client.get(uuid=uuid, credential=credential)
 
         self._check_result_status(result.result_status.value, ResultStatus,

--- a/kmip/tests/unit/core/messages/payloads/test_register.py
+++ b/kmip/tests/unit/core/messages/payloads/test_register.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 The Johns Hopkins University/Applied Physics Laboratory
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -12,3 +12,1405 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+
+import testtools
+
+from kmip.core import enums
+from kmip.core import exceptions
+from kmip.core import objects
+from kmip.core import primitives
+from kmip.core import secrets
+from kmip.core import utils
+
+from kmip.core.messages import payloads
+
+
+class TestRegisterRequestPayload(testtools.TestCase):
+
+    def setUp(self):
+        super(TestRegisterRequestPayload, self).setUp()
+
+        self.certificate_value = (
+            b'\x30\x82\x03\x12\x30\x82\x01\xFA\xA0\x03\x02\x01\x02\x02\x01\x01'
+            b'\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x05\x05\x00\x30'
+            b'\x3B\x31\x0B\x30\x09\x06\x03\x55\x04\x06\x13\x02\x55\x53\x31\x0D'
+            b'\x30\x0B\x06\x03\x55\x04\x0A\x13\x04\x54\x45\x53\x54\x31\x0E\x30'
+            b'\x0C\x06\x03\x55\x04\x0B\x13\x05\x4F\x41\x53\x49\x53\x31\x0D\x30'
+            b'\x0B\x06\x03\x55\x04\x03\x13\x04\x4B\x4D\x49\x50\x30\x1E\x17\x0D'
+            b'\x31\x30\x31\x31\x30\x31\x32\x33\x35\x39\x35\x39\x5A\x17\x0D\x32'
+            b'\x30\x31\x31\x30\x31\x32\x33\x35\x39\x35\x39\x5A\x30\x3B\x31\x0B'
+            b'\x30\x09\x06\x03\x55\x04\x06\x13\x02\x55\x53\x31\x0D\x30\x0B\x06'
+            b'\x03\x55\x04\x0A\x13\x04\x54\x45\x53\x54\x31\x0E\x30\x0C\x06\x03'
+            b'\x55\x04\x0B\x13\x05\x4F\x41\x53\x49\x53\x31\x0D\x30\x0B\x06\x03'
+            b'\x55\x04\x03\x13\x04\x4B\x4D\x49\x50\x30\x82\x01\x22\x30\x0D\x06'
+            b'\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x01\x05\x00\x03\x82\x01\x0F'
+            b'\x00\x30\x82\x01\x0A\x02\x82\x01\x01\x00\xAB\x7F\x16\x1C\x00\x42'
+            b'\x49\x6C\xCD\x6C\x6D\x4D\xAD\xB9\x19\x97\x34\x35\x35\x77\x76\x00'
+            b'\x3A\xCF\x54\xB7\xAF\x1E\x44\x0A\xFB\x80\xB6\x4A\x87\x55\xF8\x00'
+            b'\x2C\xFE\xBA\x6B\x18\x45\x40\xA2\xD6\x60\x86\xD7\x46\x48\x34\x6D'
+            b'\x75\xB8\xD7\x18\x12\xB2\x05\x38\x7C\x0F\x65\x83\xBC\x4D\x7D\xC7'
+            b'\xEC\x11\x4F\x3B\x17\x6B\x79\x57\xC4\x22\xE7\xD0\x3F\xC6\x26\x7F'
+            b'\xA2\xA6\xF8\x9B\x9B\xEE\x9E\x60\xA1\xD7\xC2\xD8\x33\xE5\xA5\xF4'
+            b'\xBB\x0B\x14\x34\xF4\xE7\x95\xA4\x11\x00\xF8\xAA\x21\x49\x00\xDF'
+            b'\x8B\x65\x08\x9F\x98\x13\x5B\x1C\x67\xB7\x01\x67\x5A\xBD\xBC\x7D'
+            b'\x57\x21\xAA\xC9\xD1\x4A\x7F\x08\x1F\xCE\xC8\x0B\x64\xE8\xA0\xEC'
+            b'\xC8\x29\x53\x53\xC7\x95\x32\x8A\xBF\x70\xE1\xB4\x2E\x7B\xB8\xB7'
+            b'\xF4\xE8\xAC\x8C\x81\x0C\xDB\x66\xE3\xD2\x11\x26\xEB\xA8\xDA\x7D'
+            b'\x0C\xA3\x41\x42\xCB\x76\xF9\x1F\x01\x3D\xA8\x09\xE9\xC1\xB7\xAE'
+            b'\x64\xC5\x41\x30\xFB\xC2\x1D\x80\xE9\xC2\xCB\x06\xC5\xC8\xD7\xCC'
+            b'\xE8\x94\x6A\x9A\xC9\x9B\x1C\x28\x15\xC3\x61\x2A\x29\xA8\x2D\x73'
+            b'\xA1\xF9\x93\x74\xFE\x30\xE5\x49\x51\x66\x2A\x6E\xDA\x29\xC6\xFC'
+            b'\x41\x13\x35\xD5\xDC\x74\x26\xB0\xF6\x05\x02\x03\x01\x00\x01\xA3'
+            b'\x21\x30\x1F\x30\x1D\x06\x03\x55\x1D\x0E\x04\x16\x04\x14\x04\xE5'
+            b'\x7B\xD2\xC4\x31\xB2\xE8\x16\xE1\x80\xA1\x98\x23\xFA\xC8\x58\x27'
+            b'\x3F\x6B\x30\x0D\x06\x09\x2A\x86\x48\x86\xF7\x0D\x01\x01\x05\x05'
+            b'\x00\x03\x82\x01\x01\x00\xA8\x76\xAD\xBC\x6C\x8E\x0F\xF0\x17\x21'
+            b'\x6E\x19\x5F\xEA\x76\xBF\xF6\x1A\x56\x7C\x9A\x13\xDC\x50\xD1\x3F'
+            b'\xEC\x12\xA4\x27\x3C\x44\x15\x47\xCF\xAB\xCB\x5D\x61\xD9\x91\xE9'
+            b'\x66\x31\x9D\xF7\x2C\x0D\x41\xBA\x82\x6A\x45\x11\x2F\xF2\x60\x89'
+            b'\xA2\x34\x4F\x4D\x71\xCF\x7C\x92\x1B\x4B\xDF\xAE\xF1\x60\x0D\x1B'
+            b'\xAA\xA1\x53\x36\x05\x7E\x01\x4B\x8B\x49\x6D\x4F\xAE\x9E\x8A\x6C'
+            b'\x1D\xA9\xAE\xB6\xCB\xC9\x60\xCB\xF2\xFA\xE7\x7F\x58\x7E\xC4\xBB'
+            b'\x28\x20\x45\x33\x88\x45\xB8\x8D\xD9\xAE\xEA\x53\xE4\x82\xA3\x6E'
+            b'\x73\x4E\x4F\x5F\x03\xB9\xD0\xDF\xC4\xCA\xFC\x6B\xB3\x4E\xA9\x05'
+            b'\x3E\x52\xBD\x60\x9E\xE0\x1E\x86\xD9\xB0\x9F\xB5\x11\x20\xC1\x98'
+            b'\x34\xA9\x97\xB0\x9C\xE0\x8D\x79\xE8\x13\x11\x76\x2F\x97\x4B\xB1'
+            b'\xC8\xC0\x91\x86\xC4\xD7\x89\x33\xE0\xDB\x38\xE9\x05\x08\x48\x77'
+            b'\xE1\x47\xC7\x8A\xF5\x2F\xAE\x07\x19\x2F\xF1\x66\xD1\x9F\xA9\x4A'
+            b'\x11\xCC\x11\xB2\x7E\xD0\x50\xF7\xA2\x7F\xAE\x13\xB2\x05\xA5\x74'
+            b'\xC4\xEE\x00\xAA\x8B\xD6\x5D\x0D\x70\x57\xC9\x85\xC8\x39\xEF\x33'
+            b'\x6A\x44\x1E\xD5\x3A\x53\xC6\xB6\xB6\x96\xF1\xBD\xEB\x5F\x7E\xA8'
+            b'\x11\xEB\xB2\x5A\x7F\x86'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        # Modified to exclude the Link attribute.
+        #
+        # TODO (ph) Add the Link attribute back in once Links are supported.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Object Type - Certificate
+        #     Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign | Verify
+        #     Certificate
+        #         Certificate Type - X.509
+        #         Certificate Value -
+        #             0x30820312308201FAA003020102020101300D06092A864886F70D01
+        #             01050500303B310B3009060355040613025553310D300B060355040A
+        #             130454455354310E300C060355040B13054F41534953310D300B0603
+        #             55040313044B4D4950301E170D3130313130313233353935395A170D
+        #             3230313130313233353935395A303B310B3009060355040613025553
+        #             310D300B060355040A130454455354310E300C060355040B13054F41
+        #             534953310D300B060355040313044B4D495030820122300D06092A86
+        #             4886F70D01010105000382010F003082010A0282010100AB7F161C00
+        #             42496CCD6C6D4DADB919973435357776003ACF54B7AF1E440AFB80B6
+        #             4A8755F8002CFEBA6B184540A2D66086D74648346D75B8D71812B205
+        #             387C0F6583BC4D7DC7EC114F3B176B7957C422E7D03FC6267FA2A6F8
+        #             9B9BEE9E60A1D7C2D833E5A5F4BB0B1434F4E795A41100F8AA214900
+        #             DF8B65089F98135B1C67B701675ABDBC7D5721AAC9D14A7F081FCEC8
+        #             0B64E8A0ECC8295353C795328ABF70E1B42E7BB8B7F4E8AC8C810CDB
+        #             66E3D21126EBA8DA7D0CA34142CB76F91F013DA809E9C1B7AE64C541
+        #             30FBC21D80E9C2CB06C5C8D7CCE8946A9AC99B1C2815C3612A29A82D
+        #             73A1F99374FE30E54951662A6EDA29C6FC411335D5DC7426B0F60502
+        #             03010001A321301F301D0603551D0E0416041404E57BD2C431B2E816
+        #             E180A19823FAC858273F6B300D06092A864886F70D01010505000382
+        #             010100A876ADBC6C8E0FF017216E195FEA76BFF61A567C9A13DC50D1
+        #             3FEC12A4273C441547CFABCB5D61D991E966319DF72C0D41BA826A45
+        #             112FF26089A2344F4D71CF7C921B4BDFAEF1600D1BAAA15336057E01
+        #             4B8B496D4FAE9E8A6C1DA9AEB6CBC960CBF2FAE77F587EC4BB282045
+        #             338845B88DD9AEEA53E482A36E734E4F5F03B9D0DFC4CAFC6BB34EA9
+        #             053E52BD609EE01E86D9B09FB51120C19834A997B09CE08D79E81311
+        #             762F974BB1C8C09186C4D78933E0DB38E905084877E147C78AF52FAE
+        #             07192FF166D19FA94A11CC11B27ED050F7A27FAE13B205A574C4EE00
+        #             AA8BD65D0D7057C985C839EF336A441ED53A53C6B6B696F1BDEB5F7E
+        #             A811EBB25A7F86
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x03\x88'
+            b'\x42\x00\x57\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x91\x01\x00\x00\x00\x38'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\x13\x01\x00\x00\x03\x30'
+            b'\x42\x00\x1D\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x1E\x08\x00\x00\x03\x16' + self.certificate_value +
+            b'\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        # Modified to exclude the Link attribute.
+        #
+        # TODO (ph) Add the Link attribute back in once Links are supported.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign | Verify
+        #     Certificate
+        #         Certificate Type - X.509
+        #         Certificate Value - See comment for the full encoding.
+        self.no_object_type_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x03\x78'
+            b'\x42\x00\x91\x01\x00\x00\x00\x38'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+            b'\x42\x00\x13\x01\x00\x00\x03\x30'
+            b'\x42\x00\x1D\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x1E\x08\x00\x00\x03\x16' + self.certificate_value +
+            b'\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Object Type - Certificate
+        #     Certificate
+        #         Certificate Type - X.509
+        #         Certificate Value - See comment for the full encoding.
+        self.no_template_attribute_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x03\x48'
+            b'\x42\x00\x57\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x13\x01\x00\x00\x03\x30'
+            b'\x42\x00\x1D\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x1E\x08\x00\x00\x03\x16' + self.certificate_value +
+            b'\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        # Modified to exclude the Link attribute.
+        #
+        # TODO (ph) Add the Link attribute back in once Links are supported.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Object Type - Certificate
+        #     Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign | Verify
+        self.no_managed_object_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x00\x50'
+            b'\x42\x00\x57\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x91\x01\x00\x00\x00\x38'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x00'
+        )
+
+    def tearDown(self):
+        super(TestRegisterRequestPayload, self).tearDown()
+
+    def test_invalid_object_type(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the object type of a Register request payload.
+        """
+        kwargs = {'object_type': 'invalid'}
+        self.assertRaisesRegex(
+            TypeError,
+            "Object type must be an ObjectType enumeration.",
+            payloads.RegisterRequestPayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.RegisterRequestPayload(),
+            'object_type',
+            'invalid'
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Object type must be an ObjectType enumeration.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the template attribute of a Register request payload.
+        """
+        kwargs = {'template_attribute': 'invalid'}
+        self.assertRaisesRegex(
+            TypeError,
+            "Template attribute must be a TemplateAttribute structure.",
+            payloads.RegisterRequestPayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.RegisterRequestPayload(),
+            'template_attribute',
+            'invalid'
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Template attribute must be a TemplateAttribute structure.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_managed_object(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the managed object of a Register request payload.
+        """
+        kwargs = {'managed_object': 'invalid'}
+        self.assertRaisesRegex(
+            TypeError,
+            "Managed object must be a supported managed object structure.",
+            payloads.RegisterRequestPayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.RegisterRequestPayload(),
+            'managed_object',
+            'invalid'
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Managed object must be a supported managed object structure.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a Register request payload can be read from a data stream.
+        """
+        payload = payloads.RegisterRequestPayload()
+
+        self.assertIsNone(payload.object_type)
+        self.assertIsNone(payload.template_attribute)
+        self.assertIsNone(payload.managed_object)
+
+        payload.read(self.full_encoding)
+
+        self.assertEqual(enums.ObjectType.CERTIFICATE, payload.object_type)
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            payload.template_attribute
+        )
+        self.assertEqual(
+            secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            ),
+            payload.managed_object
+        )
+
+    def test_read_missing_object_type(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a Register request payload when the object type is missing from the
+        encoding.
+        """
+        payload = payloads.RegisterRequestPayload()
+
+        args = (self.no_object_type_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The Register request payload encoding is missing the object "
+            "type.",
+            payload.read,
+            *args
+        )
+
+    def test_read_missing_template_attribute(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a Register request payload when the template attribute is missing
+        from the encoding.
+        """
+        payload = payloads.RegisterRequestPayload()
+
+        args = (self.no_template_attribute_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The Register request payload encoding is missing the template "
+            "attribute.",
+            payload.read,
+            *args
+        )
+
+    def test_read_missing_managed_object(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a Register request payload when the managed object is missing from
+        the encoding.
+        """
+        payload = payloads.RegisterRequestPayload()
+
+        args = (self.no_managed_object_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The Register request payload encoding is missing the managed "
+            "object.",
+            payload.read,
+            *args
+        )
+
+    def test_write(self):
+        """
+        Test that a Register request payload can be written to a data stream.
+        """
+        payload = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_missing_object_type(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        Register request payload when the payload is missing the object type.
+        """
+        payload = payloads.RegisterRequestPayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        args = (utils.BytearrayStream(), )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The Register request payload is missing the object type field.",
+            payload.write,
+            *args
+        )
+
+    def test_write_missing_template_attribute(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        Register request payload when the payload is missing the template
+        attribute.
+        """
+        payload = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        args = (utils.BytearrayStream(), )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The Register request payload is missing the template attribute "
+            "field.",
+            payload.write,
+            *args
+        )
+
+    def test_write_missing_managed_object(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        Register request payload when the payload is missing the managed
+        object.
+        """
+        payload = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SECRET_DATA,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            )
+        )
+
+        args = (utils.BytearrayStream(), )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The Register request payload is missing the managed object "
+            "field.",
+            payload.write,
+            *args
+        )
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a Register request payload structure.
+        """
+        payload = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SECRET_DATA,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.SecretData(
+                secret_data_type=primitives.Enumeration(
+                    enums.SecretDataType,
+                    value=enums.SecretDataType.PASSWORD,
+                    tag=enums.Tags.SECRET_DATA_TYPE
+                ),
+                key_block=objects.KeyBlock(
+                    key_format_type=objects.KeyFormatType(
+                        enums.KeyFormatType.OPAQUE
+                    ),
+                    key_value=objects.KeyValue(
+                        key_material=objects.KeyMaterial(
+                            (
+                                b'\x53\x65\x63\x72\x65\x74\x50\x61\x73\x73\x77'
+                                b'\x6F\x72\x64'
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        self.assertEqual(
+            "RegisterRequestPayload("
+            "object_type=ObjectType.SECRET_DATA, "
+            "template_attribute=Struct(), "
+            "managed_object=Struct())",
+            repr(payload)
+        )
+
+    def test_str(self):
+        """
+        Test that str can be applied to a Register request payload structure.
+        """
+        payload = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SECRET_DATA,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.SecretData(
+                secret_data_type=primitives.Enumeration(
+                    enums.SecretDataType,
+                    value=enums.SecretDataType.PASSWORD,
+                    tag=enums.Tags.SECRET_DATA_TYPE
+                ),
+                key_block=objects.KeyBlock(
+                    key_format_type=objects.KeyFormatType(
+                        enums.KeyFormatType.OPAQUE
+                    ),
+                    key_value=objects.KeyValue(
+                        key_material=objects.KeyMaterial(
+                            (
+                                b'\x53\x65\x63\x72\x65\x74\x50\x61\x73\x73\x77'
+                                b'\x6F\x72\x64'
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        self.assertEqual(
+            '{'
+            '"object_type": ObjectType.SECRET_DATA, '
+            '"template_attribute": Struct(), '
+            '"managed_object": Struct()'
+            '}',
+            str(payload)
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        Register request payloads with the same data.
+        """
+        a = payloads.RegisterRequestPayload()
+        b = payloads.RegisterRequestPayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_object_type(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register request payloads with different object types.
+        """
+        a = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SYMMETRIC_KEY
+        )
+        b = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SECRET_DATA
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register request payloads with different template attributes.
+        """
+        a = payloads.RegisterRequestPayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_managed_object(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register request payloads with different managed objects.
+        """
+        a = payloads.RegisterRequestPayload(
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.PGP,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register request payloads with different types.
+        """
+        a = payloads.RegisterRequestPayload()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        Register request payloads with the same data.
+        """
+        a = payloads.RegisterRequestPayload()
+        b = payloads.RegisterRequestPayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.CERTIFICATE,
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            enums.CryptographicUsageMask.SIGN.value |
+                            enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            ),
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_object_type(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register request payloads with different object types.
+        """
+        a = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SYMMETRIC_KEY
+        )
+        b = payloads.RegisterRequestPayload(
+            object_type=enums.ObjectType.SECRET_DATA
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register request payloads with different template attributes.
+        """
+        a = payloads.RegisterRequestPayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_managed_object(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register request payloads with different managed objects.
+        """
+        a = payloads.RegisterRequestPayload(
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.X_509,
+                certificate_value=self.certificate_value
+            )
+        )
+        b = payloads.RegisterRequestPayload(
+            managed_object=secrets.Certificate(
+                certificate_type=enums.CertificateType.PGP,
+                certificate_value=self.certificate_value
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register request payloads with different types.
+        """
+        a = payloads.RegisterRequestPayload()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+
+class TestRegisterResponsePayload(testtools.TestCase):
+
+    def setUp(self):
+        super(TestRegisterResponsePayload, self).setUp()
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        # Modified to include the template attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Unique Identifier - 7091d0bf-548a-4d4a-93a6-6dd71cf75221
+        #     Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-active
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x60'
+            b'\x42\x00\x94\x07\x00\x00\x00\x24'
+            b'\x37\x30\x39\x31\x64\x30\x62\x66\x2D\x35\x34\x38\x61\x2D\x34\x64'
+            b'\x34\x61\x2D\x39\x33\x61\x36\x2D\x36\x64\x64\x37\x31\x63\x66\x37'
+            b'\x35\x32\x32\x31\x00\x00\x00\x00'
+            b'\x42\x00\x91\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        # Modified to include the template attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-active
+        self.no_unique_identifier_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x30'
+            b'\x42\x00\x91\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 13.2.2.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Unique Identifier - 7091d0bf-548a-4d4a-93a6-6dd71cf75221
+        self.no_template_attribute_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x30'
+            b'\x42\x00\x94\x07\x00\x00\x00\x24'
+            b'\x37\x30\x39\x31\x64\x30\x62\x66\x2D\x35\x34\x38\x61\x2D\x34\x64'
+            b'\x34\x61\x2D\x39\x33\x61\x36\x2D\x36\x64\x64\x37\x31\x63\x66\x37'
+            b'\x35\x32\x32\x31\x00\x00\x00\x00'
+        )
+
+    def test_invalid_unique_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the unique identifier of a Register response payload.
+        """
+        kwargs = {'unique_identifier': 0}
+        self.assertRaisesRegex(
+            TypeError,
+            "Unique identifier must be a string.",
+            payloads.RegisterResponsePayload,
+            **kwargs
+        )
+
+        args = (payloads.RegisterResponsePayload(), 'unique_identifier', 0)
+        self.assertRaisesRegex(
+            TypeError,
+            "Unique identifier must be a string.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the template attribute of a Register response payload.
+        """
+        kwargs = {'template_attribute': 'invalid'}
+        self.assertRaisesRegex(
+            TypeError,
+            "Template attribute must be a TemplateAttribute structure.",
+            payloads.RegisterResponsePayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.RegisterResponsePayload(),
+            'template_attribute',
+            'invalid'
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Template attribute must be a TemplateAttribute structure.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a Register response payload can be read from a data stream.
+        """
+        payload = payloads.RegisterResponsePayload()
+
+        self.assertIsNone(payload.unique_identifier)
+        self.assertIsNone(payload.template_attribute)
+
+        payload.read(self.full_encoding)
+
+        self.assertEqual(
+            "7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            payload.unique_identifier
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            ),
+            payload.template_attribute
+        )
+
+    def test_read_missing_unique_identifier(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a Register response payload when the unique identifier is missing
+        from the encoding.
+        """
+        payload = payloads.RegisterResponsePayload()
+
+        self.assertIsNone(payload.unique_identifier)
+        self.assertIsNone(payload.template_attribute)
+
+        args = (self.no_unique_identifier_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The Register response payload encoding is missing the unique "
+            "identifier.",
+            payload.read,
+            *args
+        )
+
+    def test_read_missing_template_attribute(self):
+        """
+        Test that a Register response payload can be read from a data stream
+        event when missing the template attribute.
+        """
+        payload = payloads.RegisterResponsePayload()
+
+        self.assertEqual(None, payload.unique_identifier)
+        self.assertEqual(None, payload.template_attribute)
+
+        payload.read(self.no_template_attribute_encoding)
+
+        self.assertEqual(
+            "7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            payload.unique_identifier
+        )
+        self.assertIsNone(payload.template_attribute)
+
+    def test_write(self):
+        """
+        Test that a Register response payload can be written to a data stream.
+        """
+        payload = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
+
+    def test_write_missing_unique_identifier(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        Register response payload when the payload is missing the unique
+        identifier.
+        """
+        payload = payloads.RegisterResponsePayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        args = (stream, )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The Register response payload is missing the unique identifier "
+            "field.",
+            payload.write,
+            *args
+        )
+
+    def test_write_missing_template_attribute(self):
+        """
+        Test that a Register response payload can be written to a data stream
+        even when missing the template attribute.
+        """
+        payload = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221"
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.no_template_attribute_encoding), len(stream))
+        self.assertEqual(str(self.no_template_attribute_encoding), str(stream))
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a Register response payload structure.
+        """
+        payload = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        self.assertEqual(
+            "RegisterResponsePayload("
+            "unique_identifier='7091d0bf-548a-4d4a-93a6-6dd71cf75221', "
+            "template_attribute=Struct())",
+            repr(payload)
+        )
+
+    def test_str(self):
+        """
+        Test that str can be applied to a Register response payload structure.
+        """
+        payload = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        self.assertEqual(
+            '{'
+            '"unique_identifier": "7091d0bf-548a-4d4a-93a6-6dd71cf75221", '
+            '"template_attribute": Struct()'
+            '}',
+            str(payload)
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        Register response payloads with the same data.
+        """
+        a = payloads.RegisterResponsePayload()
+        b = payloads.RegisterResponsePayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register response payloads with different unique identifiers.
+        """
+        a = payloads.RegisterResponsePayload(unique_identifier="a")
+        b = payloads.RegisterResponsePayload(unique_identifier="b")
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register response payloads with different template attributes.
+        """
+        a = payloads.RegisterResponsePayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterResponsePayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        Register response payloads with different types.
+        """
+        a = payloads.RegisterResponsePayload()
+        b = "invalid"
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        Register response payloads with the same data.
+        """
+        a = payloads.RegisterResponsePayload()
+        b = payloads.RegisterResponsePayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterResponsePayload(
+            unique_identifier="7091d0bf-548a-4d4a-93a6-6dd71cf75221",
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_unique_identifier(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register response payloads with different unique identifiers.
+        """
+        a = payloads.RegisterResponsePayload(unique_identifier="a")
+        b = payloads.RegisterResponsePayload(unique_identifier="b")
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register response payloads with different template attributes.
+        """
+        a = payloads.RegisterResponsePayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+        b = payloads.RegisterResponsePayload(
+            template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ]
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        Register response payloads with different types.
+        """
+        a = payloads.RegisterResponsePayload()
+        b = "invalid"
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)

--- a/kmip/tests/unit/core/messages/test_messages.py
+++ b/kmip/tests/unit/core/messages/test_messages.py
@@ -715,12 +715,12 @@ class TestRequestMessage(TestCase):
 
             object_type = request_payload.object_type
             msg = "Bad object type type: expected {0}, received {1}"
-            self.assertIsInstance(object_type, attr.ObjectType,
-                                  msg.format(attr.ObjectType,
+            self.assertIsInstance(object_type, enums.ObjectType,
+                                  msg.format(enums.ObjectType,
                                              type(object_type)))
             msg = "Bad object type value: expected {0}, received {1}"
             exp_value = enums.ObjectType.TEMPLATE
-            rcv_value = object_type.value
+            rcv_value = object_type
             self.assertEqual(exp_value, rcv_value,
                              msg.format(exp_value, rcv_value))
 
@@ -784,7 +784,7 @@ class TestRequestMessage(TestCase):
 
         operation = contents.Operation(enums.Operation.REGISTER)
 
-        object_type = attr.ObjectType(enums.ObjectType.TEMPLATE)
+        object_type = enums.ObjectType.TEMPLATE
         tmpl_attr = objects.TemplateAttribute()
 
         attributes = []
@@ -833,7 +833,7 @@ class TestRequestMessage(TestCase):
         request_payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=tmpl_attr,
-            secret=template)
+            managed_object=template)
         batch_item = messages.RequestBatchItem(operation=operation,
                                                request_payload=request_payload)
         request_message = messages.RequestMessage(request_header=req_header,
@@ -1891,12 +1891,12 @@ class TestResponseMessage(TestCase):
 
             unique_identifier = response_payload.unique_identifier
             msg = "Bad unique identifier type: expected {0}, received {1}"
-            self.assertIsInstance(unique_identifier, attr.UniqueIdentifier,
-                                  msg.format(attr.UniqueIdentifier,
+            self.assertIsInstance(unique_identifier, six.string_types,
+                                  msg.format(six.string_types,
                                              type(unique_identifier)))
             msg = "Bad unique identifier value: expected {0}, received {1}"
             exp_value = '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3'
-            rcv_value = unique_identifier.value
+            rcv_value = unique_identifier
             self.assertEqual(exp_value, rcv_value,
                              msg.format(exp_value, rcv_value))
 
@@ -1914,7 +1914,7 @@ class TestResponseMessage(TestCase):
         operation = contents.Operation(enums.Operation.REGISTER)
         result_status = contents.ResultStatus(enums.ResultStatus.SUCCESS)
 
-        uuid = attr.UniqueIdentifier('5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3')
+        uuid = '5c9b81ef-4ee5-42cd-ba2d-c002fdd0c7b3'
         resp_pl = payloads.RegisterResponsePayload(unique_identifier=uuid)
         batch_item = messages.ResponseBatchItem(operation=operation,
                                                 result_status=result_status,

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -1591,8 +1591,8 @@ class TestProxyKmipClient(testtools.TestCase):
 
         result = results.RegisterResult(
             contents.ResultStatus(enums.ResultStatus.SUCCESS),
-            uuid=attr.PublicKeyUniqueIdentifier(
-                'aaaaaaaa-1111-2222-3333-ffffffffffff'))
+            uuid='aaaaaaaa-1111-2222-3333-ffffffffffff'
+        )
 
         with ProxyKmipClient() as client:
             client.proxy.register.return_value = result

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -3357,7 +3357,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Build a SymmetricKey for registration.
-        object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
+        object_type = enums.ObjectType.SYMMETRIC_KEY
         template_attribute = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
@@ -3408,7 +3408,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
-            secret=secret
+            managed_object=secret
         )
 
         response_payload = e._process_register(payload)
@@ -3419,7 +3419,7 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: Register"
         )
 
-        uid = response_payload.unique_identifier.value
+        uid = response_payload.unique_identifier
         self.assertEqual('1', uid)
 
         # Retrieve the stored object and verify all attributes were set
@@ -3467,7 +3467,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._logger = mock.MagicMock()
 
-        object_type = attributes.ObjectType(enums.ObjectType.SPLIT_KEY)
+        object_type = enums.ObjectType.SPLIT_KEY
         payload = payloads.RegisterRequestPayload(object_type=object_type)
 
         args = (payload, )
@@ -3491,7 +3491,7 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._logger = mock.MagicMock()
 
-        object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
+        object_type = enums.ObjectType.SYMMETRIC_KEY
         payload = payloads.RegisterRequestPayload(object_type=object_type)
 
         args = (payload, )
@@ -8337,7 +8337,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Build a SymmetricKey for registration.
-        object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
+        object_type = enums.ObjectType.SYMMETRIC_KEY
         template_attribute = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
@@ -8385,7 +8385,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
-            secret=secret
+            managed_object=secret
         )
 
         response_payload = e._process_register(payload)
@@ -8396,7 +8396,7 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: Register"
         )
 
-        uid = response_payload.unique_identifier.value
+        uid = response_payload.unique_identifier
         self.assertEqual('1', uid)
 
         e._logger.reset_mock()
@@ -8479,7 +8479,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Build a SymmetricKey for registration.
-        object_type = attributes.ObjectType(enums.ObjectType.SYMMETRIC_KEY)
+        object_type = enums.ObjectType.SYMMETRIC_KEY
         template_attribute = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
@@ -8527,7 +8527,7 @@ class TestKmipEngine(testtools.TestCase):
         payload = payloads.RegisterRequestPayload(
             object_type=object_type,
             template_attribute=template_attribute,
-            secret=secret
+            managed_object=secret
         )
 
         response_payload = e._process_register(payload)
@@ -8538,7 +8538,7 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: Register"
         )
 
-        uuid = response_payload.unique_identifier.value
+        uuid = response_payload.unique_identifier
         self.assertEqual('1', uuid)
 
         e._logger.reset_mock()


### PR DESCRIPTION
This change updates the Register payloads to the current payload format, adding properties for different payload attributes and adding comparison and string operators. Changes are also made to the PyKMIP clients and the surrounding testing infrastructure to reflect the payload changes. An official unit test suite for the Register payloads has also been included, which will eventually replace the existing Register message tests elsewhere in the test suite.

This change prepares the Register payloads for future updates to support KMIP 2.0.