### PR TITLE
Update the CreateKeyPair payloads

### DIFF
--- a/kmip/core/messages/payloads/create_key_pair.py
+++ b/kmip/core/messages/payloads/create_key_pair.py
@@ -13,243 +13,590 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core import attributes
-from kmip.core import objects
+import six
 
 from kmip.core import enums
+from kmip.core import exceptions
+from kmip.core import objects
+from kmip.core import primitives
+from kmip.core import utils
 
-from kmip.core.primitives import Struct
 
-from kmip.core.utils import BytearrayStream
+class CreateKeyPairRequestPayload(primitives.Struct):
+    """
+    A request payload for the CreateKeyPair operation.
 
-
-class CreateKeyPairRequestPayload(Struct):
+    Attributes:
+        common_template_attribute: A group of attributes to set on the new
+            public and private keys.
+        private_key_template_attribute: A group of attributes to set on the new
+            private key.
+        public_key_template_attribute: A group of attributes to set on the new
+            public key.
+    """
 
     def __init__(self,
                  common_template_attribute=None,
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
+        """
+        Construct a CreateKeyPair request payload structure.
+
+        Args:
+            common_template_attribute (TemplateAttribute): A TemplateAttribute
+                structure with the CommonTemplateAttribute tag containing a set
+                of attributes to set on the new public and private keys.
+                Optional, defaults to None.
+            private_key_template_attribute (TemplateAttribute): A
+                TemplateAttribute structure with the
+                PrivateKeyTemplateAttribute tag containing a set of attributes
+                to set on the new private key. Optional, defaults to None.
+            public_key_template_attribute (TemplateAttribute): A
+                TemplateAttribute structure with the PublicKeyTemplateAttribute
+                tag containing a set of attributes to set on the new public
+                key. Optional, defaults to None.
+        """
         super(CreateKeyPairRequestPayload, self).__init__(
             enums.Tags.REQUEST_PAYLOAD
         )
+
+        self._common_template_attribute = None
+        self._private_key_template_attribute = None
+        self._public_key_template_attribute = None
 
         self.common_template_attribute = common_template_attribute
         self.private_key_template_attribute = private_key_template_attribute
         self.public_key_template_attribute = public_key_template_attribute
 
-        self.validate()
+    @property
+    def common_template_attribute(self):
+        return self._common_template_attribute
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    @common_template_attribute.setter
+    def common_template_attribute(self, value):
+        if value is None:
+            self._common_template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            if value.tag == enums.Tags.COMMON_TEMPLATE_ATTRIBUTE:
+                self._common_template_attribute = value
+            else:
+                raise TypeError(
+                    "Common template attribute must be a TemplateAttribute "
+                    "structure with a CommonTemplateAttribute tag."
+                )
+        else:
+            raise TypeError(
+                "Common template attribute must be a TemplateAttribute "
+                "structure."
+            )
+
+    @property
+    def private_key_template_attribute(self):
+        return self._private_key_template_attribute
+
+    @private_key_template_attribute.setter
+    def private_key_template_attribute(self, value):
+        if value is None:
+            self._private_key_template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            if value.tag == enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE:
+                self._private_key_template_attribute = value
+            else:
+                raise TypeError(
+                    "Private key template attribute must be a "
+                    "TemplateAttribute structure with a "
+                    "PrivateKeyTemplateAttribute tag."
+                )
+        else:
+            raise TypeError(
+                "Private key template attribute must be a TemplateAttribute "
+                "structure."
+            )
+
+    @property
+    def public_key_template_attribute(self):
+        return self._public_key_template_attribute
+
+    @public_key_template_attribute.setter
+    def public_key_template_attribute(self, value):
+        if value is None:
+            self._public_key_template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            if value.tag == enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE:
+                self._public_key_template_attribute = value
+            else:
+                raise TypeError(
+                    "Public key template attribute must be a "
+                    "TemplateAttribute structure with a "
+                    "PublicKeyTemplateAttribute tag."
+                )
+        else:
+            raise TypeError(
+                "Public key template attribute must be a TemplateAttribute "
+                "structure."
+            )
+
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Read the data encoding the CreateKeyPair request payload and decode it
+        into its constituent parts.
+
+        Args:
+            input_buffer (stream): A data buffer containing encoded object
+                data, supporting a read method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
+        """
         super(CreateKeyPairRequestPayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        if self.is_tag_next(enums.Tags.COMMON_TEMPLATE_ATTRIBUTE, tstream):
-            self.common_template_attribute = objects.CommonTemplateAttribute()
-            self.common_template_attribute.read(
-                tstream,
+        if self.is_tag_next(
+                enums.Tags.COMMON_TEMPLATE_ATTRIBUTE,
+                local_buffer
+        ):
+            self._common_template_attribute = objects.TemplateAttribute(
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            )
+            self._common_template_attribute.read(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.is_tag_next(enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
-                            tstream):
-            self.private_key_template_attribute = \
-                objects.PrivateKeyTemplateAttribute()
-            self.private_key_template_attribute.read(
-                tstream,
+        if self.is_tag_next(
+                enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+                local_buffer
+        ):
+            self._private_key_template_attribute = objects.TemplateAttribute(
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+            self._private_key_template_attribute.read(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.is_tag_next(enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE, tstream):
-            self.public_key_template_attribute = \
-                objects.PublicKeyTemplateAttribute()
-            self.public_key_template_attribute.read(
-                tstream,
+        if self.is_tag_next(
+                enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE,
+                local_buffer
+        ):
+            self._public_key_template_attribute = objects.TemplateAttribute(
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+            self._public_key_template_attribute.read(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        self.is_oversized(tstream)
-        self.validate()
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
-        tstream = BytearrayStream()
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Write the data encoding the CreateKeyPair request payload to a buffer.
 
-        if self.common_template_attribute is not None:
-            self.common_template_attribute.write(
-                tstream,
+        Args:
+            output_buffer (stream): A data buffer in which to encode object
+                data, supporting a write method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
+        """
+        local_buffer = utils.BytearrayStream()
+
+        if self._common_template_attribute is not None:
+            self._common_template_attribute.write(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.private_key_template_attribute is not None:
-            self.private_key_template_attribute.write(
-                tstream,
+        if self._private_key_template_attribute is not None:
+            self._private_key_template_attribute.write(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.public_key_template_attribute is not None:
-            self.public_key_template_attribute.write(
-                tstream,
+        if self._public_key_template_attribute is not None:
+            self._public_key_template_attribute.write(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        self.length = tstream.length()
+        self.length = local_buffer.length()
         super(CreateKeyPairRequestPayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
-    def validate(self):
-        self.__validate()
+    def __eq__(self, other):
+        if isinstance(other, CreateKeyPairRequestPayload):
+            if self.common_template_attribute != \
+                    other.common_template_attribute:
+                return False
+            elif self.private_key_template_attribute != \
+                    other.private_key_template_attribute:
+                return False
+            elif self.public_key_template_attribute != \
+                    other.public_key_template_attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
 
-    def __validate(self):
-        if self.common_template_attribute is not None:
-            if not isinstance(self.common_template_attribute,
-                              objects.CommonTemplateAttribute):
-                msg = "invalid common template attribute"
-                msg += "; expected {0}, received {1}".format(
-                    objects.CommonTemplateAttribute,
-                    self.common_template_attribute)
-                raise TypeError(msg)
+    def __ne__(self, other):
+        if isinstance(other, CreateKeyPairRequestPayload):
+            return not (self == other)
+        else:
+            return NotImplemented
 
-        if self.private_key_template_attribute is not None:
-            if not isinstance(self.private_key_template_attribute,
-                              objects.PrivateKeyTemplateAttribute):
-                msg = "invalid private key template attribute"
-                msg += "; expected {0}, received {1}".format(
-                    objects.PrivateKeyTemplateAttribute,
-                    self.private_key_template_attribute)
-                raise TypeError(msg)
+    def __repr__(self):
+        args = ", ".join([
+            "common_template_attribute={}".format(
+                self.common_template_attribute
+            ),
+            "private_key_template_attribute={}".format(
+                self.private_key_template_attribute
+            ),
+            "public_key_template_attribute={}".format(
+                self.public_key_template_attribute
+            )
+        ])
+        return "CreateKeyPairRequestPayload({})".format(args)
 
-        if self.public_key_template_attribute is not None:
-            if not isinstance(self.public_key_template_attribute,
-                              objects.PublicKeyTemplateAttribute):
-                msg = "invalid public key template attribute"
-                msg += "; expected {0}, received {1}".format(
-                    objects.PublicKeyTemplateAttribute,
-                    self.public_key_template_attribute)
-                raise TypeError(msg)
+    def __str__(self):
+        value = ", ".join(
+            [
+                '"common_template_attribute": {}'.format(
+                    self.common_template_attribute
+                ),
+                '"private_key_template_attribute": {}'.format(
+                    self.private_key_template_attribute
+                ),
+                '"public_key_template_attribute": {}'.format(
+                    self.public_key_template_attribute
+                )
+            ]
+        )
+        return '{' + value + '}'
 
 
-class CreateKeyPairResponsePayload(Struct):
+class CreateKeyPairResponsePayload(primitives.Struct):
+    """
+    A response payload for the CreateKeyPair operation.
+
+    Attributes:
+        private_key_unique_identifier: The ID of the new private key.
+        public_key_unique_identifier: The ID of the new public key.
+        private_key_template_attribute: A group of attributes to set on the new
+            private key.
+        public_key_template_attribute: A group of attributes to set on the new
+            public key.
+    """
 
     def __init__(self,
-                 private_key_uuid=None,
-                 public_key_uuid=None,
+                 private_key_unique_identifier=None,
+                 public_key_unique_identifier=None,
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
         super(CreateKeyPairResponsePayload, self).__init__(
             enums.Tags.RESPONSE_PAYLOAD
         )
 
-        # Private and public UUIDs are required so make defaults as backup
-        if private_key_uuid is None:
-            self.private_key_uuid = attributes.PrivateKeyUniqueIdentifier('')
-        else:
-            self.private_key_uuid = private_key_uuid
+        self._private_key_unique_identifier = None
+        self._public_key_unique_identifier = None
+        self._private_key_template_attribute = None
+        self._public_key_template_attribute = None
 
-        if public_key_uuid is None:
-            self.public_key_uuid = attributes.PublicKeyUniqueIdentifier('')
-        else:
-            self.public_key_uuid = public_key_uuid
-
+        self.private_key_unique_identifier = private_key_unique_identifier
+        self.public_key_unique_identifier = public_key_unique_identifier
         self.private_key_template_attribute = private_key_template_attribute
         self.public_key_template_attribute = public_key_template_attribute
 
-        self.validate()
+    @property
+    def private_key_unique_identifier(self):
+        if self._private_key_unique_identifier:
+            return self._private_key_unique_identifier.value
+        else:
+            return None
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    @private_key_unique_identifier.setter
+    def private_key_unique_identifier(self, value):
+        if value is None:
+            self._private_key_unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._private_key_unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Private key unique identifier must be a string.")
+
+    @property
+    def public_key_unique_identifier(self):
+        if self._public_key_unique_identifier:
+            return self._public_key_unique_identifier.value
+        else:
+            return None
+
+    @public_key_unique_identifier.setter
+    def public_key_unique_identifier(self, value):
+        if value is None:
+            self._public_key_unique_identifier = None
+        elif isinstance(value, six.string_types):
+            self._public_key_unique_identifier = primitives.TextString(
+                value=value,
+                tag=enums.Tags.PUBLIC_KEY_UNIQUE_IDENTIFIER
+            )
+        else:
+            raise TypeError("Public key unique identifier must be a string.")
+
+    @property
+    def private_key_template_attribute(self):
+        return self._private_key_template_attribute
+
+    @private_key_template_attribute.setter
+    def private_key_template_attribute(self, value):
+        if value is None:
+            self._private_key_template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            if value.tag == enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE:
+                self._private_key_template_attribute = value
+            else:
+                raise TypeError(
+                    "Private key template attribute must be a "
+                    "TemplateAttribute structure with a "
+                    "PrivateKeyTemplateAttribute tag."
+                )
+        else:
+            raise TypeError(
+                "Private key template attribute must be a TemplateAttribute "
+                "structure."
+            )
+
+    @property
+    def public_key_template_attribute(self):
+        return self._public_key_template_attribute
+
+    @public_key_template_attribute.setter
+    def public_key_template_attribute(self, value):
+        if value is None:
+            self._public_key_template_attribute = None
+        elif isinstance(value, objects.TemplateAttribute):
+            if value.tag == enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE:
+                self._public_key_template_attribute = value
+            else:
+                raise TypeError(
+                    "Public key template attribute must be a "
+                    "TemplateAttribute structure with a "
+                    "PublicKeyTemplateAttribute tag."
+                )
+        else:
+            raise TypeError(
+                "Public key template attribute must be a TemplateAttribute "
+                "structure."
+            )
+
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Read the data encoding the CreateKeyPair response payload and decode it
+        into its constituent parts.
+
+        Args:
+            input_buffer (stream): A data buffer containing encoded object
+                data, supporting a read method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be decoded. Optional,
+                defaults to KMIP 1.0.
+
+        Raises:
+            InvalidKmipEncoding: Raised if the private key unique identifier or
+                the public key unique identifier is missing from the encoded
+                payload.
+        """
         super(CreateKeyPairResponsePayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        self.private_key_uuid.read(tstream, kmip_version=kmip_version)
-        self.public_key_uuid.read(tstream, kmip_version=kmip_version)
+        if self.is_tag_next(
+                enums.Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER,
+                local_buffer
+        ):
+            self._private_key_unique_identifier = primitives.TextString(
+                tag=enums.Tags.PRIVATE_KEY_UNIQUE_IDENTIFIER
+            )
+            self._private_key_unique_identifier.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The CreateKeyPair response payload encoding is missing the "
+                "private key unique identifier."
+            )
 
-        if self.is_tag_next(enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
-                            tstream):
-            self.private_key_template_attribute = \
-                objects.PrivateKeyTemplateAttribute()
-            self.private_key_template_attribute.read(
-                tstream,
+        if self.is_tag_next(
+                enums.Tags.PUBLIC_KEY_UNIQUE_IDENTIFIER,
+                local_buffer
+        ):
+            self._public_key_unique_identifier = primitives.TextString(
+                tag=enums.Tags.PUBLIC_KEY_UNIQUE_IDENTIFIER
+            )
+            self._public_key_unique_identifier.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidKmipEncoding(
+                "The CreateKeyPair response payload encoding is missing the "
+                "public key unique identifier."
+            )
+
+        if self.is_tag_next(
+                enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE,
+                local_buffer
+        ):
+            self._private_key_template_attribute = objects.TemplateAttribute(
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+            self._private_key_template_attribute.read(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.is_tag_next(enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE,
-                            tstream):
-            self.public_key_template_attribute = \
-                objects.PublicKeyTemplateAttribute()
-            self.public_key_template_attribute.read(
-                tstream,
+        if self.is_tag_next(
+                enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE,
+                local_buffer
+        ):
+            self._public_key_template_attribute = objects.TemplateAttribute(
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+            self._public_key_template_attribute.read(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        self.is_oversized(tstream)
-        self.validate()
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
-        tstream = BytearrayStream()
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
+        """
+        Write the data encoding the CreateKeyPair response payload to a buffer.
 
-        self.private_key_uuid.write(tstream, kmip_version=kmip_version)
-        self.public_key_uuid.write(tstream, kmip_version=kmip_version)
+        Args:
+            output_buffer (stream): A data buffer in which to encode object
+                data, supporting a write method.
+            kmip_version (KMIPVersion): An enumeration defining the KMIP
+                version with which the object will be encoded. Optional,
+                defaults to KMIP 1.0.
 
-        if self.private_key_template_attribute is not None:
-            self.private_key_template_attribute.write(
-                tstream,
+        Raises:
+            InvalidField: Raised if the private key unique identifier or the
+                public key unique identifier is not defined.
+        """
+        local_buffer = utils.BytearrayStream()
+
+        if self._private_key_unique_identifier:
+            self._private_key_unique_identifier.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The CreateKeyPair response payload is missing the private "
+                "key unique identifier field."
+            )
+
+        if self._public_key_unique_identifier:
+            self._public_key_unique_identifier.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
+        else:
+            raise exceptions.InvalidField(
+                "The CreateKeyPair response payload is missing the public "
+                "key unique identifier field."
+            )
+
+        if self._private_key_template_attribute:
+            self._private_key_template_attribute.write(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        if self.public_key_template_attribute is not None:
-            self.public_key_template_attribute.write(
-                tstream,
+        if self._public_key_template_attribute:
+            self._public_key_template_attribute.write(
+                local_buffer,
                 kmip_version=kmip_version
             )
 
-        self.length = tstream.length()
+        self.length = local_buffer.length()
         super(CreateKeyPairResponsePayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
-    def validate(self):
-        self.__validate()
+    def __eq__(self, other):
+        if isinstance(other, CreateKeyPairResponsePayload):
+            if self.private_key_unique_identifier != \
+                    other.private_key_unique_identifier:
+                return False
+            elif self.public_key_unique_identifier != \
+                    other.public_key_unique_identifier:
+                return False
+            elif self.private_key_template_attribute != \
+                    other.private_key_template_attribute:
+                return False
+            elif self.public_key_template_attribute != \
+                    other.public_key_template_attribute:
+                return False
+            else:
+                return True
+        else:
+            return NotImplemented
 
-    def __validate(self):
-        if not isinstance(self.private_key_uuid,
-                          attributes.PrivateKeyUniqueIdentifier):
-            msg = "invalid private key unique identifier"
-            msg += "; expected {0}, received {1}".format(
-                attributes.PrivateKeyUniqueIdentifier,
-                self.private_key_uuid)
-            raise TypeError(msg)
+    def __ne__(self, other):
+        if isinstance(other, CreateKeyPairResponsePayload):
+            return not (self == other)
+        else:
+            return NotImplemented
 
-        if not isinstance(self.public_key_uuid,
-                          attributes.PublicKeyUniqueIdentifier):
-            msg = "invalid public key unique identifier"
-            msg += "; expected {0}, received {1}".format(
-                attributes.PublicKeyUniqueIdentifier,
-                self.public_key_uuid)
-            raise TypeError(msg)
+    def __repr__(self):
+        args = ", ".join([
+            "private_key_unique_identifier='{}'".format(
+                self.private_key_unique_identifier
+            ),
+            "public_key_unique_identifier='{}'".format(
+                self.public_key_unique_identifier
+            ),
+            "private_key_template_attribute={}".format(
+                self.private_key_template_attribute
+            ),
+            "public_key_template_attribute={}".format(
+                self.public_key_template_attribute
+            )
+        ])
+        return "CreateKeyPairResponsePayload({})".format(args)
 
-        if self.private_key_template_attribute is not None:
-            if not isinstance(self.private_key_template_attribute,
-                              objects.PrivateKeyTemplateAttribute):
-                msg = "invalid private key template attribute"
-                msg += "; expected {0}, received {1}".format(
-                    objects.PrivateKeyTemplateAttribute,
-                    self.private_key_template_attribute)
-                raise TypeError(msg)
-
-        if self.public_key_template_attribute is not None:
-            if not isinstance(self.public_key_template_attribute,
-                              objects.PublicKeyTemplateAttribute):
-                msg = "invalid public key template attribute"
-                msg += "; expected {0}, received {1}".format(
-                    objects.PublicKeyTemplateAttribute,
-                    self.public_key_template_attribute)
-                raise TypeError(msg)
+    def __str__(self):
+        value = ", ".join(
+            [
+                '"private_key_unique_identifier": "{}"'.format(
+                    self.private_key_unique_identifier
+                ),
+                '"public_key_unique_identifier": "{}"'.format(
+                    self.public_key_unique_identifier
+                ),
+                '"private_key_template_attribute": {}'.format(
+                    self.private_key_template_attribute
+                ),
+                '"public_key_template_attribute": {}'.format(
+                    self.public_key_template_attribute
+                )
+            ]
+        )
+        return '{' + value + '}'

--- a/kmip/core/messages/payloads/rekey_key_pair.py
+++ b/kmip/core/messages/payloads/rekey_key_pair.py
@@ -168,6 +168,7 @@ class RekeyKeyPairRequestPayload(Struct):
                 raise TypeError(msg)
 
 
+# TODO (ph) Remove the dependency on the CreateKeyPairResponsePayload
 class RekeyKeyPairResponsePayload(CreateKeyPairResponsePayload):
 
     def __init__(self,

--- a/kmip/demos/pie/create_key_pair.py
+++ b/kmip/demos/pie/create_key_pair.py
@@ -51,7 +51,9 @@ if __name__ == '__main__':
             public_uid, private_uid = client.create_key_pair(
                 algorithm,
                 length,
-                operation_policy_name=opts.operation_policy_name
+                operation_policy_name=opts.operation_policy_name,
+                public_usage_mask=[enums.CryptographicUsageMask.VERIFY],
+                private_usage_mask=[enums.CryptographicUsageMask.SIGN]
             )
             logger.info("Successfully created public key with ID: {0}".format(
                 public_uid))

--- a/kmip/demos/units/create_key_pair.py
+++ b/kmip/demos/units/create_key_pair.py
@@ -30,9 +30,7 @@ from kmip.core.factories.credentials import CredentialFactory
 from kmip.core.attributes import Name
 from kmip.core.attributes import CryptographicUsageMask
 
-from kmip.core.objects import CommonTemplateAttribute
-from kmip.core.objects import PrivateKeyTemplateAttribute
-from kmip.core.objects import PublicKeyTemplateAttribute
+from kmip.core.objects import TemplateAttribute
 from kmip.core.objects import Attribute
 
 from kmip.services.kmip_client import KMIPProxy
@@ -117,14 +115,25 @@ if __name__ == '__main__':
         )
         attributes.append(opn)
 
-    common = CommonTemplateAttribute(attributes=attributes)
-    private = PrivateKeyTemplateAttribute(attributes=attributes)
-    public = PublicKeyTemplateAttribute(attributes=attributes)
+    common = TemplateAttribute(
+        attributes=attributes,
+        tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+    )
+    private = TemplateAttribute(
+        attributes=attributes,
+        tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+    )
+    public = TemplateAttribute(
+        attributes=attributes,
+        tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+    )
 
     # Create the SYMMETRIC_KEY object
-    result = client.create_key_pair(common_template_attribute=common,
-                                    private_key_template_attribute=private,
-                                    public_key_template_attribute=public)
+    result = client.create_key_pair(
+        common_template_attribute=common,
+        private_key_template_attribute=private,
+        public_key_template_attribute=public
+    )
     client.close()
 
     # Display operation results

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -313,8 +313,9 @@ class ProxyKmipClient(object):
         )
 
         common_attributes.extend([algorithm_attribute, length_attribute])
-        template = cobjects.CommonTemplateAttribute(
-            attributes=common_attributes
+        template = cobjects.TemplateAttribute(
+            attributes=common_attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
 
         # Create public / private specific attributes
@@ -331,9 +332,10 @@ class ProxyKmipClient(object):
                 )
             ]
         if names or attrs:
-            public_template = cobjects.PublicKeyTemplateAttribute(
+            public_template = cobjects.TemplateAttribute(
                 names=names,
-                attributes=attrs
+                attributes=attrs,
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
             )
 
         private_template = None
@@ -349,9 +351,10 @@ class ProxyKmipClient(object):
                 )
             ]
         if names or attrs:
-            private_template = cobjects.PrivateKeyTemplateAttribute(
+            private_template = cobjects.TemplateAttribute(
                 names=names,
-                attributes=attrs
+                attributes=attrs,
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
             )
 
         # Create the asymmetric key pair and handle the results
@@ -362,8 +365,8 @@ class ProxyKmipClient(object):
 
         status = result.result_status.value
         if status == enums.ResultStatus.SUCCESS:
-            public_uid = result.public_key_uuid.value
-            private_uid = result.private_key_uuid.value
+            public_uid = result.public_key_uuid
+            private_uid = result.private_key_uuid
             return public_uid, private_uid
         else:
             reason = result.result_reason.value

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -1222,8 +1222,8 @@ class KMIPProxy(object):
         payload_public_key_template_attribute = None
 
         if payload is not None:
-            payload_private_key_uuid = payload.private_key_uuid
-            payload_public_key_uuid = payload.public_key_uuid
+            payload_private_key_uuid = payload.private_key_unique_identifier
+            payload_public_key_uuid = payload.public_key_unique_identifier
             payload_private_key_template_attribute = \
                 payload.private_key_template_attribute
             payload_public_key_template_attribute = \

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1270,12 +1270,8 @@ class KmipEngine(object):
         )
 
         response_payload = payloads.CreateKeyPairResponsePayload(
-            private_key_uuid=attributes.PrivateKeyUniqueIdentifier(
-                str(private_key.unique_identifier)
-            ),
-            public_key_uuid=attributes.PublicKeyUniqueIdentifier(
-                str(public_key.unique_identifier)
-            )
+            private_key_unique_identifier=str(private_key.unique_identifier),
+            public_key_unique_identifier=str(public_key.unique_identifier)
         )
 
         self._id_placeholder = str(private_key.unique_identifier)

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -20,6 +20,7 @@ from kmip.core.attributes import CryptographicAlgorithm
 from kmip.core.attributes import CryptographicLength
 from kmip.core.attributes import Name
 
+from kmip.core import enums
 from kmip.core.enums import AttributeType
 from kmip.core.enums import CryptographicAlgorithm as CryptoAlgorithmEnum
 from kmip.core.enums import CryptographicUsageMask
@@ -44,9 +45,6 @@ from kmip.core.objects import KeyBlock
 from kmip.core.objects import KeyMaterial
 from kmip.core.objects import KeyValue
 from kmip.core.objects import TemplateAttribute
-from kmip.core.objects import PrivateKeyTemplateAttribute
-from kmip.core.objects import PublicKeyTemplateAttribute
-from kmip.core.objects import CommonTemplateAttribute
 
 from kmip.core.misc import QueryFunction
 
@@ -149,11 +147,18 @@ class TestIntegration(TestCase):
         private_key_attributes = [priv_name]
         public_key_attributes = [pub_name]
 
-        common = CommonTemplateAttribute(attributes=common_attributes)
-        priv_templ_attr = PrivateKeyTemplateAttribute(
-            attributes=private_key_attributes)
-        pub_templ_attr = PublicKeyTemplateAttribute(
-            attributes=public_key_attributes)
+        common = TemplateAttribute(
+            attributes=common_attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+        )
+        priv_templ_attr = TemplateAttribute(
+            attributes=private_key_attributes,
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+        )
+        pub_templ_attr = TemplateAttribute(
+            attributes=public_key_attributes,
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+        )
 
         return self.client.\
             create_key_pair(common_template_attribute=common,
@@ -488,12 +493,12 @@ class TestIntegration(TestCase):
         self._check_result_status(result, ResultStatus, ResultStatus.SUCCESS)
 
         # Check UUID value for Private key
-        self._check_uuid(result.private_key_uuid.value, str)
+        self._check_uuid(result.private_key_uuid, str)
         # Check UUID value for Public key
-        self._check_uuid(result.public_key_uuid.value, str)
+        self._check_uuid(result.public_key_uuid, str)
 
-        priv_key_uuid = result.private_key_uuid.value
-        pub_key_uuid = result.public_key_uuid.value
+        priv_key_uuid = result.private_key_uuid
+        pub_key_uuid = result.public_key_uuid
 
         priv_key_result = self.client.get(uuid=priv_key_uuid, credential=None)
         pub_key_result = self.client.get(uuid=pub_key_uuid, credential=None)
@@ -522,17 +527,17 @@ class TestIntegration(TestCase):
         self.assertIsInstance(pub_secret, pub_expected)
 
         self.logger.debug('Destroying key: ' + key_name + ' Private' +
-                          '\n With UUID: ' + result.private_key_uuid.value)
+                          '\n With UUID: ' + result.private_key_uuid)
         destroy_priv_key_result = self.client.destroy(
-            result.private_key_uuid.value)
+            result.private_key_uuid)
 
         self._check_result_status(destroy_priv_key_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 
         self.logger.debug('Destroying key: ' + key_name + ' Public' +
-                          '\n With UUID: ' + result.public_key_uuid.value)
+                          '\n With UUID: ' + result.public_key_uuid)
         destroy_pub_key_result = self.client.destroy(
-            result.public_key_uuid.value)
+            result.public_key_uuid)
         self._check_result_status(destroy_pub_key_result, ResultStatus,
                                   ResultStatus.SUCCESS)
 

--- a/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_create_key_pair.py
@@ -13,294 +13,3134 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from testtools import TestCase
+import testtools
 
 from kmip.core import attributes
+from kmip.core import enums
+from kmip.core import exceptions
 from kmip.core import objects
+from kmip.core import primitives
 from kmip.core import utils
 
 from kmip.core.messages import payloads
 
 
-class TestCreateKeyPairRequestPayload(TestCase):
+class TestCreateKeyPairRequestPayload(testtools.TestCase):
 
     def setUp(self):
         super(TestCreateKeyPairRequestPayload, self).setUp()
 
-        self.common_template_attribute = objects.CommonTemplateAttribute()
-        self.private_key_template_attribute = \
-            objects.PrivateKeyTemplateAttribute()
-        self.public_key_template_attribute = \
-            objects.PublicKeyTemplateAttribute()
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Common Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Algorithm
+        #             Attribute Value - RSA
+        #         Attribute
+        #             Attribute Name - Cryptographic Length
+        #             Attribute Value - 1024
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PrivateKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PublicKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Verify
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x01\x88'
+            b'\x42\x00\x1F\x01\x00\x00\x00\x70'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x17'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x41\x6C'
+            b'\x67\x6F\x72\x69\x74\x68\x6D\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x14'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x4C\x65'
+            b'\x6E\x67\x74\x68\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x04\x00\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0B'
+            b'\x50\x72\x69\x76\x61\x74\x65\x4B\x65\x79\x31\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0A'
+            b'\x50\x75\x62\x6C\x69\x63\x4B\x65\x79\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x00'
+        )
 
-        self.encoding_empty = utils.BytearrayStream((
-            b'\x42\x00\x79\x01\x00\x00\x00\x00'))
-        self.encoding_full = utils.BytearrayStream((
-            b'\x42\x00\x79\x01\x00\x00\x00\x18\x42\x00\x1F\x01\x00\x00\x00\x00'
-            b'\x42\x00\x65\x01\x00\x00\x00\x00\x42\x00\x6E\x01\x00\x00\x00'
-            b'\x00'))
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PrivateKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PublicKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Verify
+        self.no_common_template_attribute_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x01\x10'
+            b'\x42\x00\x65\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0B'
+            b'\x50\x72\x69\x76\x61\x74\x65\x4B\x65\x79\x31\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0A'
+            b'\x50\x75\x62\x6C\x69\x63\x4B\x65\x79\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Common Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Algorithm
+        #             Attribute Value - RSA
+        #         Attribute
+        #             Attribute Name - Cryptographic Length
+        #             Attribute Value - 1024
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PublicKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Verify
+        self.no_private_key_template_attr_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x01\x00'
+            b'\x42\x00\x1F\x01\x00\x00\x00\x70'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x17'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x41\x6C'
+            b'\x67\x6F\x72\x69\x74\x68\x6D\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x14'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x4C\x65'
+            b'\x6E\x67\x74\x68\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x04\x00\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0A'
+            b'\x50\x75\x62\x6C\x69\x63\x4B\x65\x79\x31\x00\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        #
+        # This encoding matches the following set of values:
+        # Request Payload
+        #     Common Template Attribute
+        #         Attribute
+        #             Attribute Name - Cryptographic Algorithm
+        #             Attribute Value - RSA
+        #         Attribute
+        #             Attribute Name - Cryptographic Length
+        #             Attribute Value - 1024
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PrivateKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Sign
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - Name
+        #             Attribute Value
+        #                 Name Value - PublicKey1
+        #                 Name Type - Uninterpreted Text String
+        #         Attribute
+        #             Attribute Name - Cryptographic Usage Mask
+        #             Attribute Value - Verify
+        self.no_public_key_template_attribute_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x01\x00'
+            b'\x42\x00\x1F\x01\x00\x00\x00\x70'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x17'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x41\x6C'
+            b'\x67\x6F\x72\x69\x74\x68\x6D\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x14'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x4C\x65'
+            b'\x6E\x67\x74\x68\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x04\x00\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x80'
+            b'\x42\x00\x08\x01\x00\x00\x00\x40'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x04'
+            b'\x4E\x61\x6D\x65\x00\x00\x00\x00'
+            b'\x42\x00\x0B\x01\x00\x00\x00\x28'
+            b'\x42\x00\x55\x07\x00\x00\x00\x0B'
+            b'\x50\x72\x69\x76\x61\x74\x65\x4B\x65\x79\x31\x00\x00\x00\x00\x00'
+            b'\x42\x00\x54\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x08\x01\x00\x00\x00\x30'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x18'
+            b'\x43\x72\x79\x70\x74\x6F\x67\x72\x61\x70\x68\x69\x63\x20\x55\x73'
+            b'\x61\x67\x65\x20\x4D\x61\x73\x6B'
+            b'\x42\x00\x0B\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        # This encoding matches the following set of values:
+        # Request Payload
+        self.empty_encoding = utils.BytearrayStream(
+            b'\x42\x00\x79\x01\x00\x00\x00\x00'
+        )
 
     def tearDown(self):
         super(TestCreateKeyPairRequestPayload, self).tearDown()
 
-    def test_init_with_none(self):
-        payloads.CreateKeyPairRequestPayload()
-
-    def test_init_with_args(self):
-        payloads.CreateKeyPairRequestPayload(
-            self.common_template_attribute,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
-
-    def test_validate_with_invalid_common_template_attribute(self):
-        kwargs = {'common_template_attribute': 'invalid',
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': None}
+    def test_invalid_common_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the common template attribute of a CreateKeyPair request payload.
+        """
+        kwargs = {'common_template_attribute': 'invalid'}
         self.assertRaisesRegex(
-            TypeError, "invalid common template attribute",
-            payloads.CreateKeyPairRequestPayload, **kwargs)
+            TypeError,
+            "Common template attribute must be a TemplateAttribute structure.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
 
-    def test_validate_with_invalid_private_key_template_attribute(self):
-        kwargs = {'common_template_attribute': None,
-                  'private_key_template_attribute': 'invalid',
-                  'public_key_template_attribute': None}
+        kwargs = {'common_template_attribute': objects.TemplateAttribute()}
         self.assertRaisesRegex(
-            TypeError, "invalid private key template attribute",
-            payloads.CreateKeyPairRequestPayload, **kwargs)
+            TypeError,
+            "Common template attribute must be a TemplateAttribute structure "
+            "with a CommonTemplateAttribute tag.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
 
-    def test_validate_with_invalid_public_key_template_attribute(self):
-        kwargs = {'common_template_attribute': None,
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': 'invalid'}
-        self.assertRaises(
-            TypeError, "invalid public key template attribute",
-            payloads.CreateKeyPairRequestPayload, **kwargs)
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            'common_template_attribute',
+            'invalid'
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Common template attribute must be a TemplateAttribute structure.",
+            setattr,
+            *args
+        )
 
-    def _test_read(self, stream, payload, common_template_attribute,
-                   private_key_template_attribute,
-                   public_key_template_attribute):
-        payload.read(stream)
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            'common_template_attribute',
+            objects.TemplateAttribute()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Common template attribute must be a TemplateAttribute structure "
+            "with a CommonTemplateAttribute tag.",
+            setattr,
+            *args
+        )
 
-        msg = "common_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            common_template_attribute, payload.common_template_attribute)
-        self.assertEqual(common_template_attribute,
-                         payload.common_template_attribute, msg)
+    def test_invalid_private_key_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the private key template attribute of a CreateKeyPair request payload.
+        """
+        kwargs = {"private_key_template_attribute": "invalid"}
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
 
-        msg = "private_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            private_key_template_attribute,
-            payload.private_key_template_attribute)
-        self.assertEqual(private_key_template_attribute,
-                         payload.private_key_template_attribute, msg)
+        kwargs = {
+            "private_key_template_attribute": objects.TemplateAttribute()
+        }
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure with a PrivateKeyTemplateAttribute tag.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
 
-        msg = "public_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            public_key_template_attribute,
-            payload.public_key_template_attribute)
-        self.assertEqual(public_key_template_attribute,
-                         payload.public_key_template_attribute, msg)
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            "private_key_template_attribute",
+            "invalid"
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure.",
+            setattr,
+            *args
+        )
 
-    def test_read_with_none(self):
-        stream = self.encoding_empty
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            "private_key_template_attribute",
+            objects.TemplateAttribute()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure with a PrivateKeyTemplateAttribute tag.",
+            setattr,
+            *args
+        )
+
+    def test_invalid_public_key_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the public key template attribute of a CreateKeyPair request payload.
+        """
+        kwargs = {"public_key_template_attribute": "invalid"}
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
+
+        kwargs = {"public_key_template_attribute": objects.TemplateAttribute()}
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure with a PublicKeyTemplateAttribute tag.",
+            payloads.CreateKeyPairRequestPayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            "public_key_template_attribute",
+            "invalid"
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure.",
+            setattr,
+            *args
+        )
+
+        args = (
+            payloads.CreateKeyPairRequestPayload(),
+            "public_key_template_attribute",
+            objects.TemplateAttribute()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure with a PublicKeyTemplateAttribute tag.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a CreateKeyPair request payload can be read from a data
+        stream.
+        """
         payload = payloads.CreateKeyPairRequestPayload()
 
-        self._test_read(stream, payload, None, None, None)
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
 
-    def test_read_with_args(self):
-        stream = self.encoding_full
+        payload.read(self.full_encoding)
+
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            payload.common_template_attribute
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.private_key_template_attribute
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.public_key_template_attribute
+        )
+
+    def test_read_missing_common_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be read from a data
+        stream even when missing the common template attribute.
+        """
         payload = payloads.CreateKeyPairRequestPayload()
 
-        self._test_read(stream, payload, self.common_template_attribute,
-                        self.private_key_template_attribute,
-                        self.public_key_template_attribute)
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
 
-    def _test_write(self, stream, payload, expected):
+        payload.read(self.no_common_template_attribute_encoding)
+
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.private_key_template_attribute
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.public_key_template_attribute
+        )
+
+    def test_read_missing_private_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be read from a data
+        stream even when missing the private key template attribute.
+        """
+        payload = payloads.CreateKeyPairRequestPayload()
+
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+        payload.read(self.no_private_key_template_attr_encoding)
+
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            payload.common_template_attribute
+        )
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.public_key_template_attribute
+        )
+
+    def test_read_missing_public_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be read from a data
+        stream even when missing the public key template attribute.
+        """
+        payload = payloads.CreateKeyPairRequestPayload()
+
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+        payload.read(self.no_public_key_template_attribute_encoding)
+
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            payload.common_template_attribute
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.private_key_template_attribute
+        )
+        self.assertIsNone(payload.public_key_template_attribute)
+
+    def test_read_missing_everything(self):
+        """
+        Test that a CreateKeyPair request payload can be read from a data
+        stream even when missing all fields.
+        """
+        payload = payloads.CreateKeyPairRequestPayload()
+
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+        payload.read(self.empty_encoding)
+
+        self.assertIsNone(payload.common_template_attribute)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+    def test_write(self):
+        """
+        Test that a CreateKeyPair request payload can be written to a data
+        stream.
+        """
+        payload = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
         payload.write(stream)
 
-        length_expected = len(expected)
-        length_received = len(stream)
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
 
-        msg = "encoding lengths not equal"
-        msg += "; expected {0}, received {1}".format(
-            length_expected, length_received)
-        self.assertEqual(length_expected, length_received, msg)
+    def test_write_missing_common_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be written to a data
+        stream even when missing the common template attribute.
+        """
+        payload = payloads.CreateKeyPairRequestPayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
 
-        msg = "encoding mismatch"
-        msg += ";\nexpected:\n{0}\nreceived:\n{1}".format(expected, stream)
-
-        self.assertEqual(expected, stream, msg)
-
-    def test_write_with_none(self):
         stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(
+            len(self.no_common_template_attribute_encoding),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.no_common_template_attribute_encoding),
+            str(stream)
+        )
+
+    def test_write_missing_private_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be written to a data
+        stream even when missing the private key template attribute.
+        """
+        payload = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(
+            len(self.no_private_key_template_attr_encoding),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.no_private_key_template_attr_encoding),
+            str(stream)
+        )
+
+    def test_write_missing_public_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair request payload can be written to a data
+        stream even when missing the public key template attribute.
+        """
+        payload = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(
+            len(self.no_public_key_template_attribute_encoding),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.no_public_key_template_attribute_encoding),
+            str(stream)
+        )
+
+    def test_write_missing_everything(self):
+        """
+        Test that a CreateKeyPair request payload can be written to a data
+        stream even when missing all fields.
+        """
         payload = payloads.CreateKeyPairRequestPayload()
 
-        self._test_write(stream, payload, self.encoding_empty)
-
-    def test_write_with_args(self):
         stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(len(self.empty_encoding), len(stream))
+        self.assertEqual(str(self.empty_encoding), str(stream))
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a CreateKeyPair request payload
+        structure.
+        """
         payload = payloads.CreateKeyPairRequestPayload(
-            self.common_template_attribute,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        self.assertEqual(
+            "CreateKeyPairRequestPayload("
+            "common_template_attribute=Struct(), "
+            "private_key_template_attribute=Struct(), "
+            "public_key_template_attribute=Struct())",
+            repr(payload)
+        )
 
-        self._test_write(stream, payload, self.encoding_full)
+    def test_str(self):
+        """
+        Test that str can be applied to a CreateKeyPair request payload
+        structure.
+        """
+        payload = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        self.assertEqual(
+            '{'
+            '"common_template_attribute": Struct(), '
+            '"private_key_template_attribute": Struct(), '
+            '"public_key_template_attribute": Struct()'
+            '}',
+            str(payload)
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        CreateKeyPair request payloads with the same data.
+        """
+        a = payloads.CreateKeyPairRequestPayload()
+        b = payloads.CreateKeyPairRequestPayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_common_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair request payloads with different common template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_private_key_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair request payloads with different private key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_public_key_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair request payloads with different public key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair request payloads with different types.
+        """
+        a = payloads.CreateKeyPairRequestPayload()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        CreateKeyPair request payloads with the same data.
+        """
+        a = payloads.CreateKeyPairRequestPayload()
+        b = payloads.CreateKeyPairRequestPayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    ),
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_common_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair request payloads with different common template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Algorithm'
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.CryptographicAlgorithm,
+                            value=enums.CryptographicAlgorithm.RSA,
+                            tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            common_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            'Cryptographic Length'
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=1024,
+                            tag=enums.Tags.CRYPTOGRAPHIC_LENGTH
+                        )
+                    )
+                ],
+                tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_private_key_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair request payloads with different private key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PrivateKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.SIGN.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_public_key_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair request payloads with different public key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairRequestPayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName("Name"),
+                        attribute_value=attributes.Name(
+                            name_value=attributes.Name.NameValue(
+                                "PublicKey1"
+                            ),
+                            name_type=attributes.Name.NameType(
+                                enums.NameType.UNINTERPRETED_TEXT_STRING
+                            )
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairRequestPayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "Cryptographic Usage Mask"
+                        ),
+                        attribute_value=primitives.Integer(
+                            value=enums.CryptographicUsageMask.VERIFY.value,
+                            tag=enums.Tags.CRYPTOGRAPHIC_USAGE_MASK
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair request payloads with different types.
+        """
+        a = payloads.CreateKeyPairRequestPayload()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
 
 
-class TestCreateKeyPairResponsePayload(TestCase):
+class TestCreateKeyPairResponsePayload(testtools.TestCase):
 
     def setUp(self):
         super(TestCreateKeyPairResponsePayload, self).setUp()
 
-        self.uuid = '00000000-0000-0000-0000-000000000000'
-        self.private_key_uuid = attributes.PrivateKeyUniqueIdentifier(
-            self.uuid)
-        self.public_key_uuid = attributes.PublicKeyUniqueIdentifier(
-            self.uuid)
-        self.empty_private_key_uuid = attributes.PrivateKeyUniqueIdentifier('')
-        self.empty_public_key_uuid = attributes.PublicKeyUniqueIdentifier('')
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        # Modified to include the Private Key Template Attribute and the
+        # Public Key Template Attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Private Key Unique Identifier -
+        #         7f7ee394-40f9-444c-818c-fb1ae57bdf15
+        #     Public Key Unique Identifier -
+        #         79c0eb55-d020-43de-b72f-5e18c862647c
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-Active
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value
+        #                 Name Value - Pre-Active
+        self.full_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\xC0'
+            b'\x42\x00\x66\x07\x00\x00\x00\x24'
+            b'\x37\x66\x37\x65\x65\x33\x39\x34\x2D\x34\x30\x66\x39\x2D\x34\x34'
+            b'\x34\x63\x2D\x38\x31\x38\x63\x2D\x66\x62\x31\x61\x65\x35\x37\x62'
+            b'\x64\x66\x31\x35\x00\x00\x00\x00'
+            b'\x42\x00\x6F\x07\x00\x00\x00\x24'
+            b'\x37\x39\x63\x30\x65\x62\x35\x35\x2D\x64\x30\x32\x30\x2D\x34\x33'
+            b'\x64\x65\x2D\x62\x37\x32\x66\x2D\x35\x65\x31\x38\x63\x38\x36\x32'
+            b'\x36\x34\x37\x63\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
 
-        self.private_key_template_attribute = \
-            objects.PrivateKeyTemplateAttribute()
-        self.public_key_template_attribute = \
-            objects.PublicKeyTemplateAttribute()
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        # Modified to include the Private Key Template Attribute and the
+        # Public Key Template Attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Public Key Unique Identifier -
+        #         79c0eb55-d020-43de-b72f-5e18c862647c
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-Active
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value
+        #                 Name Value - Pre-Active
+        self.no_private_key_unique_identifier_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x90'
+            b'\x42\x00\x6F\x07\x00\x00\x00\x24'
+            b'\x37\x39\x63\x30\x65\x62\x35\x35\x2D\x64\x30\x32\x30\x2D\x34\x33'
+            b'\x64\x65\x2D\x62\x37\x32\x66\x2D\x35\x65\x31\x38\x63\x38\x36\x32'
+            b'\x36\x34\x37\x63\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
 
-        self.encoding_empty = utils.BytearrayStream((
-            b'\x42\x00\x7C\x01\x00\x00\x00\x10\x42\x00\x66\x07\x00\x00\x00\x00'
-            b'\x42\x00\x6F\x07\x00\x00\x00\x00'))
-        self.encoding_full = utils.BytearrayStream((
-            b'\x42\x00\x7C\x01\x00\x00\x00\x70\x42\x00\x66\x07\x00\x00\x00\x24'
-            b'\x30\x30\x30\x30\x30\x30\x30\x30\x2d\x30\x30\x30\x30\x2d\x30\x30'
-            b'\x30\x30\x2d\x30\x30\x30\x30\x2d\x30\x30\x30\x30\x30\x30\x30\x30'
-            b'\x30\x30\x30\x30\x00\x00\x00\x00\x42\x00\x6F\x07\x00\x00\x00\x24'
-            b'\x30\x30\x30\x30\x30\x30\x30\x30\x2d\x30\x30\x30\x30\x2d\x30\x30'
-            b'\x30\x30\x2d\x30\x30\x30\x30\x2d\x30\x30\x30\x30\x30\x30\x30\x30'
-            b'\x30\x30\x30\x30\x00\x00\x00\x00\x42\x00\x65\x01\x00\x00\x00\x00'
-            b'\x42\x00\x6E\x01\x00\x00\x00\x00'))
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        # Modified to include the Private Key Template Attribute and the
+        # Public Key Template Attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Private Key Unique Identifier -
+        #         7f7ee394-40f9-444c-818c-fb1ae57bdf15
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-Active
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value
+        #                 Name Value - Pre-Active
+        self.no_public_key_unique_identifier_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x90'
+            b'\x42\x00\x66\x07\x00\x00\x00\x24'
+            b'\x37\x66\x37\x65\x65\x33\x39\x34\x2D\x34\x30\x66\x39\x2D\x34\x34'
+            b'\x34\x63\x2D\x38\x31\x38\x63\x2D\x66\x62\x31\x61\x65\x35\x37\x62'
+            b'\x64\x66\x31\x35\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        # Modified to include the Public Key Template Attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Private Key Unique Identifier -
+        #         7f7ee394-40f9-444c-818c-fb1ae57bdf15
+        #     Public Key Unique Identifier -
+        #         79c0eb55-d020-43de-b72f-5e18c862647c
+        #     Public Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value
+        #                 Name Value - Pre-Active
+        self.no_private_key_template_attr_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x90'
+            b'\x42\x00\x66\x07\x00\x00\x00\x24'
+            b'\x37\x66\x37\x65\x65\x33\x39\x34\x2D\x34\x30\x66\x39\x2D\x34\x34'
+            b'\x34\x63\x2D\x38\x31\x38\x63\x2D\x66\x62\x31\x61\x65\x35\x37\x62'
+            b'\x64\x66\x31\x35\x00\x00\x00\x00'
+            b'\x42\x00\x6F\x07\x00\x00\x00\x24'
+            b'\x37\x39\x63\x30\x65\x62\x35\x35\x2D\x64\x30\x32\x30\x2D\x34\x33'
+            b'\x64\x65\x2D\x62\x37\x32\x66\x2D\x35\x65\x31\x38\x63\x38\x36\x32'
+            b'\x36\x34\x37\x63\x00\x00\x00\x00'
+            b'\x42\x00\x6E\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
+
+        # Encoding obtained from the KMIP 1.1 testing document, Section 8.1.0.
+        # Modified to include the Private Key Template Attribute.
+        #
+        # This encoding matches the following set of values:
+        # Response Payload
+        #     Private Key Unique Identifier -
+        #         7f7ee394-40f9-444c-818c-fb1ae57bdf15
+        #     Public Key Unique Identifier -
+        #         79c0eb55-d020-43de-b72f-5e18c862647c
+        #     Private Key Template Attribute
+        #         Attribute
+        #             Attribute Name - State
+        #             Attribute Value - Pre-Active
+        self.no_public_key_template_attribute_encoding = utils.BytearrayStream(
+            b'\x42\x00\x7C\x01\x00\x00\x00\x90'
+            b'\x42\x00\x66\x07\x00\x00\x00\x24'
+            b'\x37\x66\x37\x65\x65\x33\x39\x34\x2D\x34\x30\x66\x39\x2D\x34\x34'
+            b'\x34\x63\x2D\x38\x31\x38\x63\x2D\x66\x62\x31\x61\x65\x35\x37\x62'
+            b'\x64\x66\x31\x35\x00\x00\x00\x00'
+            b'\x42\x00\x6F\x07\x00\x00\x00\x24'
+            b'\x37\x39\x63\x30\x65\x62\x35\x35\x2D\x64\x30\x32\x30\x2D\x34\x33'
+            b'\x64\x65\x2D\x62\x37\x32\x66\x2D\x35\x65\x31\x38\x63\x38\x36\x32'
+            b'\x36\x34\x37\x63\x00\x00\x00\x00'
+            b'\x42\x00\x65\x01\x00\x00\x00\x28'
+            b'\x42\x00\x08\x01\x00\x00\x00\x20'
+            b'\x42\x00\x0A\x07\x00\x00\x00\x05'
+            b'\x53\x74\x61\x74\x65\x00\x00\x00'
+            b'\x42\x00\x0B\x05\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00'
+        )
 
     def tearDown(self):
         super(TestCreateKeyPairResponsePayload, self).tearDown()
 
-    def test_init_with_none(self):
-        payloads.CreateKeyPairResponsePayload()
-
-    def test_init_with_args(self):
-        payloads.CreateKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
-
-    def test_validate_with_invalid_private_key_unique_identifier(self):
-        kwargs = {'private_key_uuid': 'invalid',
-                  'public_key_uuid': None,
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': None}
+    def test_invalid_private_key_unique_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the private key unique identifier of a CreateKeyPair response payload.
+        """
+        kwargs = {"private_key_unique_identifier": 0}
         self.assertRaisesRegex(
-            TypeError, "invalid private key unique identifier",
-            payloads.CreateKeyPairResponsePayload, **kwargs)
+            TypeError,
+            "Private key unique identifier must be a string.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
 
-    def test_validate_with_invalid_public_key_unique_identifier(self):
-        kwargs = {'private_key_uuid': None,
-                  'public_key_uuid': 'invalid',
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': None}
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "private_key_unique_identifier",
+            0
+        )
         self.assertRaisesRegex(
-            TypeError, "invalid public key unique identifier",
-            payloads.CreateKeyPairResponsePayload, **kwargs)
+            TypeError,
+            "Private key unique identifier must be a string.",
+            setattr,
+            *args
+        )
 
-    def test_validate_with_invalid_private_key_template_attribute(self):
-        kwargs = {'private_key_uuid': self.private_key_uuid,
-                  'public_key_uuid': self.public_key_uuid,
-                  'private_key_template_attribute': 'invalid',
-                  'public_key_template_attribute': None}
+    def test_invalid_public_key_unique_identifier(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the public key unique identifier of a CreateKeyPair response payload.
+        """
+        kwargs = {"public_key_unique_identifier": 0}
         self.assertRaisesRegex(
-            TypeError, "invalid private key template attribute",
-            payloads.CreateKeyPairResponsePayload, **kwargs)
+            TypeError,
+            "Public key unique identifier must be a string.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
 
-    def test_validate_with_invalid_public_key_template_attribute(self):
-        kwargs = {'private_key_uuid': self.private_key_uuid,
-                  'public_key_uuid': self.public_key_uuid,
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': 'invalid'}
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "public_key_unique_identifier",
+            0
+        )
         self.assertRaisesRegex(
-            TypeError, "invalid public key template attribute",
-            payloads.CreateKeyPairResponsePayload, **kwargs)
+            TypeError,
+            "Public key unique identifier must be a string.",
+            setattr,
+            *args
+        )
 
-    def _test_read(self, stream, payload, private_key_uuid, public_key_uuid,
-                   private_key_template_attribute,
-                   public_key_template_attribute):
-        payload.read(stream)
+    def test_invalid_private_key_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the private key template attribute of a CreateKeyPair response payload.
+        """
+        kwargs = {"private_key_template_attribute": "invalid"}
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
 
-        msg = "private_key_uuid decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            private_key_uuid, payload.private_key_uuid)
-        self.assertEqual(private_key_uuid, payload.private_key_uuid, msg)
+        kwargs = {
+            "private_key_template_attribute": objects.TemplateAttribute()
+        }
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure with a PrivateKeyTemplateAttribute tag.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
 
-        msg = "public_key_uuid decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            public_key_uuid, payload.public_key_uuid)
-        self.assertEqual(public_key_uuid, payload.public_key_uuid, msg)
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "private_key_template_attribute",
+            "invalid"
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure.",
+            setattr,
+            *args
+        )
 
-        msg = "private_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            private_key_template_attribute,
-            payload.private_key_template_attribute)
-        self.assertEqual(private_key_template_attribute,
-                         payload.private_key_template_attribute, msg)
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "private_key_template_attribute",
+            objects.TemplateAttribute()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Private key template attribute must be a TemplateAttribute "
+            "structure with a PrivateKeyTemplateAttribute tag.",
+            setattr,
+            *args
+        )
 
-        msg = "public_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            public_key_template_attribute,
-            payload.public_key_template_attribute)
-        self.assertEqual(public_key_template_attribute,
-                         payload.public_key_template_attribute, msg)
+    def test_invalid_public_key_template_attribute(self):
+        """
+        Test that a TypeError is raised when an invalid value is used to set
+        the public key template attribute of a CreateKeyPair response payload.
+        """
+        kwargs = {"public_key_template_attribute": "invalid"}
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
 
-    def test_read_with_none(self):
-        stream = self.encoding_empty
+        kwargs = {"public_key_template_attribute": objects.TemplateAttribute()}
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure with a PublicKeyTemplateAttribute tag.",
+            payloads.CreateKeyPairResponsePayload,
+            **kwargs
+        )
+
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "public_key_template_attribute",
+            "invalid"
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure.",
+            setattr,
+            *args
+        )
+
+        args = (
+            payloads.CreateKeyPairResponsePayload(),
+            "public_key_template_attribute",
+            objects.TemplateAttribute()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "Public key template attribute must be a TemplateAttribute "
+            "structure with a PublicKeyTemplateAttribute tag.",
+            setattr,
+            *args
+        )
+
+    def test_read(self):
+        """
+        Test that a CreateKeyPair response payload can be read from a data
+        stream.
+        """
         payload = payloads.CreateKeyPairResponsePayload()
 
-        self._test_read(stream, payload, self.empty_private_key_uuid,
-                        self.empty_public_key_uuid, None, None)
+        self.assertIsNone(payload.private_key_unique_identifier)
+        self.assertIsNone(payload.public_key_unique_identifier)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
 
-    def test_read_with_args(self):
-        stream = self.encoding_full
+        payload.read(self.full_encoding)
+
+        self.assertEqual(
+            "7f7ee394-40f9-444c-818c-fb1ae57bdf15",
+            payload.private_key_unique_identifier
+        )
+        self.assertEqual(
+            "79c0eb55-d020-43de-b72f-5e18c862647c",
+            payload.public_key_unique_identifier
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.private_key_template_attribute
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.public_key_template_attribute
+        )
+
+    def test_read_missing_private_key_unique_identifier(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a CreateKeyPair response payload when the private key unique
+        identifier is missing from the encoding.
+        """
+        payload = payloads.CreateKeyPairResponsePayload()
+
+        self.assertEqual(None, payload.private_key_unique_identifier)
+
+        args = (self.no_private_key_unique_identifier_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The CreateKeyPair response payload encoding is missing the "
+            "private key unique identifier.",
+            payload.read,
+            *args
+        )
+
+    def test_read_missing_public_key_unique_identifier(self):
+        """
+        Test that an InvalidKmipEncoding error is raised during the decoding
+        of a CreateKeyPair response payload when the public key unique
+        identifier is missing from the encoding.
+        """
+        payload = payloads.CreateKeyPairResponsePayload()
+
+        self.assertEqual(None, payload.public_key_unique_identifier)
+
+        args = (self.no_public_key_unique_identifier_encoding, )
+        self.assertRaisesRegex(
+            exceptions.InvalidKmipEncoding,
+            "The CreateKeyPair response payload encoding is missing the "
+            "public key unique identifier.",
+            payload.read,
+            *args
+        )
+
+    def test_read_missing_private_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair response payload can be read from a data
+        stream event when missing the private key template attribute.
+        """
+        payload = payloads.CreateKeyPairResponsePayload()
+
+        self.assertIsNone(payload.private_key_unique_identifier)
+        self.assertIsNone(payload.public_key_unique_identifier)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+        payload.read(self.no_private_key_template_attr_encoding)
+
+        self.assertEqual(
+            "7f7ee394-40f9-444c-818c-fb1ae57bdf15",
+            payload.private_key_unique_identifier
+        )
+        self.assertEqual(
+            "79c0eb55-d020-43de-b72f-5e18c862647c",
+            payload.public_key_unique_identifier
+        )
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.public_key_template_attribute
+        )
+
+    def test_read_missing_public_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair response payload can be read from a data
+        stream event when missing the public key template attribute.
+        """
+        payload = payloads.CreateKeyPairResponsePayload()
+
+        self.assertIsNone(payload.private_key_unique_identifier)
+        self.assertIsNone(payload.public_key_unique_identifier)
+        self.assertIsNone(payload.private_key_template_attribute)
+        self.assertIsNone(payload.public_key_template_attribute)
+
+        payload.read(self.no_public_key_template_attribute_encoding)
+
+        self.assertEqual(
+            "7f7ee394-40f9-444c-818c-fb1ae57bdf15",
+            payload.private_key_unique_identifier
+        )
+        self.assertEqual(
+            "79c0eb55-d020-43de-b72f-5e18c862647c",
+            payload.public_key_unique_identifier
+        )
+        self.assertEqual(
+            objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            payload.private_key_template_attribute
+        )
+        self.assertIsNone(payload.public_key_template_attribute)
+
+    def test_write(self):
+        """
+        Test that a CreateKeyPair response payload can be written to a data
+        stream.
+        """
         payload = payloads.CreateKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
 
-        self._test_read(stream, payload, self.private_key_uuid,
-                        self.public_key_uuid,
-                        self.private_key_template_attribute,
-                        self.public_key_template_attribute)
-
-    def _test_write(self, stream, payload, expected):
+        stream = utils.BytearrayStream()
         payload.write(stream)
 
-        length_expected = len(expected)
-        length_received = len(stream)
+        self.assertEqual(len(self.full_encoding), len(stream))
+        self.assertEqual(str(self.full_encoding), str(stream))
 
-        msg = "encoding lengths not equal"
-        msg += "; expected {0}, received {1}".format(
-            length_expected, length_received)
-        self.assertEqual(length_expected, length_received, msg)
-
-        msg = "encoding mismatch"
-        msg += ";\nexpected:\n{0}\nreceived:\n{1}".format(expected, stream)
-
-        self.assertEqual(expected, stream, msg)
-
-    def test_write_with_none(self):
-        stream = utils.BytearrayStream()
-        payload = payloads.CreateKeyPairResponsePayload()
-
-        self._test_write(stream, payload, self.encoding_empty)
-
-    def test_write_with_args(self):
-        stream = utils.BytearrayStream()
+    def test_write_missing_private_key_unique_identifier(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        CreateKeyPair response payload when the payload is missing the private
+        key unique identifier.
+        """
         payload = payloads.CreateKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
 
-        self._test_write(stream, payload, self.encoding_full)
+        stream = utils.BytearrayStream()
+        args = (stream, )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The CreateKeyPair response payload is missing the private key "
+            "unique identifier field.",
+            payload.write,
+            *args
+        )
+
+    def test_write_missing_public_key_unique_identifier(self):
+        """
+        Test that an InvalidField error is raised during the encoding of a
+        CreateKeyPair response payload when the payload is missing the public
+        key unique identifier.
+        """
+        payload = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        args = (stream, )
+        self.assertRaisesRegex(
+            exceptions.InvalidField,
+            "The CreateKeyPair response payload is missing the public key "
+            "unique identifier field.",
+            payload.write,
+            *args
+        )
+
+    def test_write_missing_private_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair response payload can be written to a data
+        stream even when missing the private key template attribute.
+        """
+        payload = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(
+            len(self.no_private_key_template_attr_encoding),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.no_private_key_template_attr_encoding),
+            str(stream)
+        )
+
+    def test_write_missing_public_key_template_attribute(self):
+        """
+        Test that a CreateKeyPair response payload can be written to a data
+        stream even when missing the public key template attribute.
+        """
+        payload = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        stream = utils.BytearrayStream()
+        payload.write(stream)
+
+        self.assertEqual(
+            len(self.no_public_key_template_attribute_encoding),
+            len(stream)
+        )
+        self.assertEqual(
+            str(self.no_public_key_template_attribute_encoding),
+            str(stream)
+        )
+
+    def test_repr(self):
+        """
+        Test that repr can be applied to a CreateKeyPair response payload
+        structure.
+        """
+        payload = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        self.assertEqual(
+            "CreateKeyPairResponsePayload("
+            "private_key_unique_identifier="
+            "'7f7ee394-40f9-444c-818c-fb1ae57bdf15', "
+            "public_key_unique_identifier="
+            "'79c0eb55-d020-43de-b72f-5e18c862647c', "
+            "private_key_template_attribute=Struct(), "
+            "public_key_template_attribute=Struct())",
+            repr(payload)
+        )
+
+    def test_str(self):
+        """
+        Test that str can be applied to a CreateKeyPair response payload
+        structure.
+        """
+        payload = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        self.assertEqual(
+            '{'
+            '"private_key_unique_identifier": '
+            '"7f7ee394-40f9-444c-818c-fb1ae57bdf15", '
+            '"public_key_unique_identifier": '
+            '"79c0eb55-d020-43de-b72f-5e18c862647c", '
+            '"private_key_template_attribute": Struct(), '
+            '"public_key_template_attribute": Struct()'
+            '}',
+            str(payload)
+        )
+
+    def test_equal_on_equal(self):
+        """
+        Test that the equality operator returns True when comparing two
+        CreateKeyPair response payloads with the same data.
+        """
+        a = payloads.CreateKeyPairResponsePayload()
+        b = payloads.CreateKeyPairResponsePayload()
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a == b)
+        self.assertTrue(b == a)
+
+    def test_equal_on_not_equal_private_key_unique_identifiers(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair response payloads with different private key unique
+        identifiers.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier="a"
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier="b"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_public_key_unique_identifiers(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair response payloads with different public key unique
+        identifiers.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            public_key_unique_identifier="a"
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            public_key_unique_identifier="b"
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_private_key_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair response payloads with different private key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_not_equal_public_key_template_attribute(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair response payloads with different public key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_equal_on_type_mismatch(self):
+        """
+        Test that the equality operator returns False when comparing two
+        CreateKeyPair response payloads with different types.
+        """
+        a = payloads.CreateKeyPairResponsePayload()
+        b = 'invalid'
+
+        self.assertFalse(a == b)
+        self.assertFalse(b == a)
+
+    def test_not_equal_on_equal(self):
+        """
+        Test that the inequality operator returns False when comparing two
+        CreateKeyPair response payloads with the same data.
+        """
+        a = payloads.CreateKeyPairResponsePayload()
+        b = payloads.CreateKeyPairResponsePayload()
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier=(
+                "7f7ee394-40f9-444c-818c-fb1ae57bdf15"
+            ),
+            public_key_unique_identifier=(
+                "79c0eb55-d020-43de-b72f-5e18c862647c"
+            ),
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            ),
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertFalse(a != b)
+        self.assertFalse(b != a)
+
+    def test_not_equal_on_not_equal_private_key_unique_identifiers(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair response payloads with different private key unique
+        identifiers.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier="a"
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_unique_identifier="b"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_public_key_unique_identifiers(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair response payloads with different public key unique
+        identifiers.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            public_key_unique_identifier="a"
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            public_key_unique_identifier="b"
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_private_key_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair response payloads with different private key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            private_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_not_equal_public_key_template_attribute(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair response payloads with different public key template
+        attributes.
+        """
+        a = payloads.CreateKeyPairResponsePayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.PRE_ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+        b = payloads.CreateKeyPairResponsePayload(
+            public_key_template_attribute=objects.TemplateAttribute(
+                attributes=[
+                    objects.Attribute(
+                        attribute_name=objects.Attribute.AttributeName(
+                            "State"
+                        ),
+                        attribute_value=primitives.Enumeration(
+                            enums.State,
+                            value=enums.State.ACTIVE,
+                            tag=enums.Tags.STATE
+                        )
+                    )
+                ],
+                tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+            )
+        )
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)
+
+    def test_not_equal_on_type_mismatch(self):
+        """
+        Test that the inequality operator returns True when comparing two
+        CreateKeyPair response payloads with different types.
+        """
+        a = payloads.CreateKeyPairResponsePayload()
+        b = 'invalid'
+
+        self.assertTrue(a != b)
+        self.assertTrue(b != a)

--- a/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
+++ b/kmip/tests/unit/core/messages/payloads/test_rekey_key_pair.py
@@ -187,23 +187,11 @@ class TestRekeyKeyPairRequestPayload(TestCase):
         self._test_write(stream, payload, self.encoding_full)
 
 
+# TODO (ph) Replicate CreateKeyPairResponsePayload test suite here
 class TestRekeyKeyPairResponsePayload(TestCase):
 
     def setUp(self):
         super(TestRekeyKeyPairResponsePayload, self).setUp()
-
-        self.uuid = '00000000-0000-0000-0000-000000000000'
-        self.private_key_uuid = attributes.PrivateKeyUniqueIdentifier(
-            self.uuid)
-        self.public_key_uuid = attributes.PublicKeyUniqueIdentifier(
-            self.uuid)
-        self.empty_private_key_uuid = attributes.PrivateKeyUniqueIdentifier('')
-        self.empty_public_key_uuid = attributes.PublicKeyUniqueIdentifier('')
-
-        self.private_key_template_attribute = \
-            objects.PrivateKeyTemplateAttribute()
-        self.public_key_template_attribute = \
-            objects.PublicKeyTemplateAttribute()
 
         self.encoding_empty = utils.BytearrayStream((
             b'\x42\x00\x7C\x01\x00\x00\x00\x10\x42\x00\x66\x07\x00\x00\x00\x00'
@@ -220,127 +208,3 @@ class TestRekeyKeyPairResponsePayload(TestCase):
 
     def tearDown(self):
         super(TestRekeyKeyPairResponsePayload, self).tearDown()
-
-    def test_init_with_none(self):
-        payloads.RekeyKeyPairResponsePayload()
-
-    def test_init_with_args(self):
-        payloads.RekeyKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
-
-    def test_validate_with_invalid_private_key_unique_identifier(self):
-        kwargs = {'private_key_uuid': 'invalid',
-                  'public_key_uuid': None,
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': None}
-        self.assertRaisesRegex(
-            TypeError, "invalid private key unique identifier",
-            payloads.RekeyKeyPairResponsePayload, **kwargs)
-
-    def test_validate_with_invalid_public_key_unique_identifier(self):
-        kwargs = {'private_key_uuid': None,
-                  'public_key_uuid': 'invalid',
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': None}
-        self.assertRaisesRegex(
-            TypeError, "invalid public key unique identifier",
-            payloads.RekeyKeyPairResponsePayload, **kwargs)
-
-    def test_validate_with_invalid_private_key_template_attribute(self):
-        kwargs = {'private_key_uuid': None,
-                  'public_key_uuid': None,
-                  'private_key_template_attribute': 'invalid',
-                  'public_key_template_attribute': None}
-        self.assertRaisesRegex(
-            TypeError, "invalid private key template attribute",
-            payloads.RekeyKeyPairResponsePayload, **kwargs)
-
-    def test_validate_with_invalid_public_key_template_attribute(self):
-        kwargs = {'private_key_uuid': None,
-                  'public_key_uuid': None,
-                  'private_key_template_attribute': None,
-                  'public_key_template_attribute': 'invalid'}
-        self.assertRaisesRegex(
-            TypeError, "invalid public key template attribute",
-            payloads.RekeyKeyPairResponsePayload, **kwargs)
-
-    def _test_read(self, stream, payload, private_key_uuid, public_key_uuid,
-                   private_key_template_attribute,
-                   public_key_template_attribute):
-        payload.read(stream)
-
-        msg = "private_key_uuid decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            private_key_uuid, payload.private_key_uuid)
-        self.assertEqual(private_key_uuid, payload.private_key_uuid, msg)
-
-        msg = "public_key_uuid decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            public_key_uuid, payload.public_key_uuid)
-        self.assertEqual(public_key_uuid, payload.public_key_uuid, msg)
-
-        msg = "private_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            private_key_template_attribute,
-            payload.private_key_template_attribute)
-        self.assertEqual(private_key_template_attribute,
-                         payload.private_key_template_attribute, msg)
-
-        msg = "public_key_template_attribute decoding mismatch"
-        msg += "; expected {0}, received {1}".format(
-            public_key_template_attribute,
-            payload.public_key_template_attribute)
-        self.assertEqual(public_key_template_attribute,
-                         payload.public_key_template_attribute, msg)
-
-    def test_read_with_none(self):
-        stream = self.encoding_empty
-        payload = payloads.RekeyKeyPairResponsePayload()
-
-        self._test_read(stream, payload, self.empty_private_key_uuid,
-                        self.empty_public_key_uuid, None, None)
-
-    def test_read_with_args(self):
-        stream = self.encoding_full
-        payload = payloads.RekeyKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
-
-        self._test_read(stream, payload, self.private_key_uuid,
-                        self.public_key_uuid,
-                        self.private_key_template_attribute,
-                        self.public_key_template_attribute)
-
-    def _test_write(self, stream, payload, expected):
-        payload.write(stream)
-
-        length_expected = len(expected)
-        length_received = len(stream)
-
-        msg = "encoding lengths not equal"
-        msg += "; expected {0}, received {1}".format(
-            length_expected, length_received)
-        self.assertEqual(length_expected, length_received, msg)
-
-        msg = "encoding mismatch"
-        msg += ";\nexpected:\n{0}\nreceived:\n{1}".format(expected, stream)
-
-        self.assertEqual(expected, stream, msg)
-
-    def test_write_with_none(self):
-        stream = utils.BytearrayStream()
-        payload = payloads.RekeyKeyPairResponsePayload()
-
-        self._test_write(stream, payload, self.encoding_empty)
-
-    def test_write_with_args(self):
-        stream = utils.BytearrayStream()
-        payload = payloads.RekeyKeyPairResponsePayload(
-            self.private_key_uuid, self.public_key_uuid,
-            self.private_key_template_attribute,
-            self.public_key_template_attribute)
-
-        self._test_write(stream, payload, self.encoding_full)

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -483,15 +483,17 @@ class TestProxyKmipClient(testtools.TestCase):
             enums.AttributeType.CRYPTOGRAPHIC_LENGTH, length)
 
         attributes = [algorithm_attribute, length_attribute]
-        template = obj.CommonTemplateAttribute(attributes=attributes)
+        template = obj.TemplateAttribute(
+            attributes=attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+        )
 
         status = enums.ResultStatus.SUCCESS
         result = results.CreateKeyPairResult(
             contents.ResultStatus(status),
-            public_key_uuid=attr.PublicKeyUniqueIdentifier(
-                'aaaaaaaa-1111-2222-3333-ffffffffffff'),
-            private_key_uuid=attr.PrivateKeyUniqueIdentifier(
-                'ffffffff-3333-2222-1111-aaaaaaaaaaaa'))
+            public_key_uuid="aaaaaaaa-1111-2222-3333-ffffffffffff",
+            private_key_uuid="ffffffff-3333-2222-1111-aaaaaaaaaaaa"
+        )
 
         with ProxyKmipClient() as client:
             client.proxy.create_key_pair.return_value = result
@@ -501,9 +503,11 @@ class TestProxyKmipClient(testtools.TestCase):
                 2048
             )
 
-            kwargs = {'common_template_attribute': template,
-                      'private_key_template_attribute': None,
-                      'public_key_template_attribute': None}
+            kwargs = {
+                "common_template_attribute": template,
+                "private_key_template_attribute": None,
+                "public_key_template_attribute": None
+            }
             client.proxy.create_key_pair.assert_called_with(**kwargs)
             self.assertIsInstance(public_uid, six.string_types)
             self.assertIsInstance(private_uid, six.string_types)
@@ -533,15 +537,17 @@ class TestProxyKmipClient(testtools.TestCase):
             algorithm_attribute,
             length_attribute
         ]
-        template = obj.CommonTemplateAttribute(attributes=pair_attributes)
+        template = obj.TemplateAttribute(
+            attributes=pair_attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+        )
 
         status = enums.ResultStatus.SUCCESS
         result = results.CreateKeyPairResult(
             contents.ResultStatus(status),
-            public_key_uuid=attr.PublicKeyUniqueIdentifier(
-                'aaaaaaaa-1111-2222-3333-ffffffffffff'),
-            private_key_uuid=attr.PrivateKeyUniqueIdentifier(
-                'ffffffff-3333-2222-1111-aaaaaaaaaaaa'))
+            public_key_uuid="aaaaaaaa-1111-2222-3333-ffffffffffff",
+            private_key_uuid="ffffffff-3333-2222-1111-aaaaaaaaaaaa"
+        )
 
         with ProxyKmipClient() as client:
             client.proxy.create_key_pair.return_value = result
@@ -552,9 +558,11 @@ class TestProxyKmipClient(testtools.TestCase):
                 operation_policy_name='test'
             )
 
-            kwargs = {'common_template_attribute': template,
-                      'private_key_template_attribute': None,
-                      'public_key_template_attribute': None}
+            kwargs = {
+                "common_template_attribute": template,
+                "private_key_template_attribute": None,
+                "public_key_template_attribute": None
+            }
             client.proxy.create_key_pair.assert_called_with(**kwargs)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -583,19 +591,25 @@ class TestProxyKmipClient(testtools.TestCase):
             length_attribute
         ]
 
-        template = obj.CommonTemplateAttribute(attributes=pair_attributes)
-        private_template = obj.PrivateKeyTemplateAttribute(
-            names=[private_name_attribute])
-        public_template = obj.PublicKeyTemplateAttribute(
-            names=[public_name_attribute])
+        template = obj.TemplateAttribute(
+            attributes=pair_attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+        )
+        private_template = obj.TemplateAttribute(
+            names=[private_name_attribute],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+        )
+        public_template = obj.TemplateAttribute(
+            names=[public_name_attribute],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+        )
 
         status = enums.ResultStatus.SUCCESS
         result = results.CreateKeyPairResult(
             contents.ResultStatus(status),
-            public_key_uuid=attr.PublicKeyUniqueIdentifier(
-                'aaaaaaaa-1111-2222-3333-ffffffffffff'),
-            private_key_uuid=attr.PrivateKeyUniqueIdentifier(
-                'ffffffff-3333-2222-1111-aaaaaaaaaaaa'))
+            public_key_uuid="aaaaaaaa-1111-2222-3333-ffffffffffff",
+            private_key_uuid="ffffffff-3333-2222-1111-aaaaaaaaaaaa"
+        )
 
         with ProxyKmipClient() as client:
             client.proxy.create_key_pair.return_value = result
@@ -607,9 +621,11 @@ class TestProxyKmipClient(testtools.TestCase):
                 private_name="private"
             )
 
-            kwargs = {'common_template_attribute': template,
-                      'private_key_template_attribute': private_template,
-                      'public_key_template_attribute': public_template}
+            kwargs = {
+                "common_template_attribute": template,
+                "private_key_template_attribute": private_template,
+                "public_key_template_attribute": public_template
+            }
             client.proxy.create_key_pair.assert_called_with(**kwargs)
 
     @mock.patch('kmip.pie.client.KMIPProxy',
@@ -642,19 +658,25 @@ class TestProxyKmipClient(testtools.TestCase):
             length_attribute
         ]
 
-        template = obj.CommonTemplateAttribute(attributes=pair_attributes)
-        private_template = obj.PrivateKeyTemplateAttribute(
-            attributes=[private_usage_mask])
-        public_template = obj.PublicKeyTemplateAttribute(
-            attributes=[public_usage_mask])
+        template = obj.TemplateAttribute(
+            attributes=pair_attributes,
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
+        )
+        private_template = obj.TemplateAttribute(
+            attributes=[private_usage_mask],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
+        )
+        public_template = obj.TemplateAttribute(
+            attributes=[public_usage_mask],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+        )
 
         status = enums.ResultStatus.SUCCESS
         result = results.CreateKeyPairResult(
             contents.ResultStatus(status),
-            public_key_uuid=attr.PublicKeyUniqueIdentifier(
-                'aaaaaaaa-1111-2222-3333-ffffffffffff'),
-            private_key_uuid=attr.PrivateKeyUniqueIdentifier(
-                'ffffffff-3333-2222-1111-aaaaaaaaaaaa'))
+            public_key_uuid="aaaaaaaa-1111-2222-3333-ffffffffffff",
+            private_key_uuid="ffffffff-3333-2222-1111-aaaaaaaaaaaa"
+        )
 
         with ProxyKmipClient() as client:
             client.proxy.create_key_pair.return_value = result
@@ -666,9 +688,11 @@ class TestProxyKmipClient(testtools.TestCase):
                 private_usage_mask=[enums.CryptographicUsageMask.SIGN]
             )
 
-            kwargs = {'common_template_attribute': template,
-                      'private_key_template_attribute': private_template,
-                      'public_key_template_attribute': public_template}
+            kwargs = {
+                "common_template_attribute": template,
+                "private_key_template_attribute": private_template,
+                "public_key_template_attribute": public_template
+            }
             client.proxy.create_key_pair.assert_called_with(**kwargs)
 
     @mock.patch('kmip.pie.client.KMIPProxy',

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -2666,7 +2666,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -2683,9 +2683,10 @@ class TestKmipEngine(testtools.TestCase):
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
                     2048
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
@@ -2693,9 +2694,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
@@ -2703,7 +2705,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -2719,9 +2722,9 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: CreateKeyPair"
         )
 
-        public_id = response_payload.public_key_uuid.value
+        public_id = response_payload.public_key_unique_identifier
         self.assertEqual('1', public_id)
-        private_id = response_payload.private_key_uuid.value
+        private_id = response_payload.private_key_unique_identifier
         self.assertEqual('2', private_id)
 
         # Retrieve the stored public key and verify all attributes were set
@@ -2794,7 +2797,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Test that a missing PublicKey CryptographicAlgorithm raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -2803,9 +2806,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
@@ -2817,9 +2821,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -2835,7 +2840,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -2861,7 +2867,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that a missing PrivateKey CryptographicAlgorithm raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -2870,9 +2876,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -2888,9 +2895,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
@@ -2902,7 +2910,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -2928,7 +2937,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that a missing PublicKey CryptographicLength raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -2937,9 +2946,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -2951,9 +2961,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -2969,7 +2980,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -2995,7 +3007,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that a missing PrivateKey CryptographicLength raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -3004,9 +3016,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3022,9 +3035,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3036,7 +3050,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -3062,7 +3077,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that a missing PublicKey CryptographicUsageMask raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -3071,9 +3086,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3083,9 +3099,10 @@ class TestKmipEngine(testtools.TestCase):
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
                     2048
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3101,7 +3118,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -3127,7 +3145,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that a missing PrivateKey CryptographicUsageMask raises an error
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -3136,9 +3154,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3154,9 +3173,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3166,7 +3186,8 @@ class TestKmipEngine(testtools.TestCase):
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
                     2048
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -3205,7 +3226,7 @@ class TestKmipEngine(testtools.TestCase):
         attribute_factory = factory.AttributeFactory()
 
         # Test that mismatched CryptographicAlgorithms raise an error.
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -3214,9 +3235,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3232,9 +3254,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3250,7 +3273,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -3275,7 +3299,7 @@ class TestKmipEngine(testtools.TestCase):
         e._logger.reset_mock()
 
         # Test that mismatched CryptographicAlgorithms raise an error.
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -3284,9 +3308,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.NameType.UNINTERPRETED_TEXT_STRING
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3302,9 +3327,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
@@ -3320,7 +3346,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -8125,7 +8152,7 @@ class TestKmipEngine(testtools.TestCase):
 
         attribute_factory = factory.AttributeFactory()
 
-        common_template = objects.CommonTemplateAttribute(
+        common_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
@@ -8142,9 +8169,10 @@ class TestKmipEngine(testtools.TestCase):
                     enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
                     2048
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
-        public_template = objects.PublicKeyTemplateAttribute(
+        public_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
@@ -8152,9 +8180,10 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.ENCRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
-        private_template = objects.PrivateKeyTemplateAttribute(
+        private_template = objects.TemplateAttribute(
             attributes=[
                 attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
@@ -8162,7 +8191,8 @@ class TestKmipEngine(testtools.TestCase):
                         enums.CryptographicUsageMask.DECRYPT
                     ]
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         payload = payloads.CreateKeyPairRequestPayload(
             common_template,
@@ -8178,9 +8208,9 @@ class TestKmipEngine(testtools.TestCase):
             "Processing operation: CreateKeyPair"
         )
 
-        public_id = response_payload.public_key_uuid.value
+        public_id = response_payload.public_key_unique_identifier
         self.assertEqual('1', public_id)
-        private_id = response_payload.private_key_uuid.value
+        private_id = response_payload.private_key_unique_identifier
         self.assertEqual('2', private_id)
 
         e._logger.reset_mock()


### PR DESCRIPTION
This change updates the CreateKeyPair payloads to the current payload format, adding properties for different payload attributes and adding comparison and string operators. Changes are also made to the PyKMIP clients and the surrounding testing infrastructure to reflect the payload changes. The official unit test suite for the CreateKeyPair payloads has been updated to also reflect these changes.

This change prepares the CreateKeyPair payloads for future updates to support KMIP 2.0.