### PR TITLE
Update utilities to remove use of TemplateAttribute subclasses

### DIFF
--- a/kmip/core/objects.py
+++ b/kmip/core/objects.py
@@ -2979,11 +2979,11 @@ def convert_template_attribute_to_attributes(value):
         raise TypeError("Input must be a TemplateAttribute structure.")
 
     tag = enums.Tags.ATTRIBUTES
-    if isinstance(value, CommonTemplateAttribute):
+    if value.tag == enums.Tags.COMMON_TEMPLATE_ATTRIBUTE:
         tag = enums.Tags.COMMON_ATTRIBUTES
-    elif isinstance(value, PrivateKeyTemplateAttribute):
+    elif value.tag == enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE:
         tag = enums.Tags.PRIVATE_KEY_ATTRIBUTES
-    elif isinstance(value, PublicKeyTemplateAttribute):
+    elif value.tag == enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE:
         tag = enums.Tags.PUBLIC_KEY_ATTRIBUTES
 
     attribute_values = []
@@ -3014,14 +3014,18 @@ def convert_attributes_to_template_attribute(value):
             )
         )
 
+    template_tag = enums.Tags.TEMPLATE_ATTRIBUTE
     if value.tag == enums.Tags.COMMON_ATTRIBUTES:
-        return CommonTemplateAttribute(attributes=attribute_structures)
+        template_tag = enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
     elif value.tag == enums.Tags.PRIVATE_KEY_ATTRIBUTES:
-        return PrivateKeyTemplateAttribute(attributes=attribute_structures)
+        template_tag = enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
     elif value.tag == enums.Tags.PUBLIC_KEY_ATTRIBUTES:
-        return PublicKeyTemplateAttribute(attributes=attribute_structures)
-    else:
-        return TemplateAttribute(attributes=attribute_structures)
+        template_tag = enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
+
+    return TemplateAttribute(
+        attributes=attribute_structures,
+        tag=template_tag
+    )
 
 
 # 2.1.9

--- a/kmip/tests/unit/core/objects/test_objects.py
+++ b/kmip/tests/unit/core/objects/test_objects.py
@@ -823,7 +823,7 @@ class TestAttributeUtilities(testtools.TestCase):
         )
 
     def test_convert_common_template_attribute_to_attributes(self):
-        template_attribute = objects.CommonTemplateAttribute(
+        template_attribute = objects.TemplateAttribute(
             attributes=[
                 objects.Attribute(
                     attribute_name=objects.Attribute.AttributeName(
@@ -835,7 +835,8 @@ class TestAttributeUtilities(testtools.TestCase):
                         tag=enums.Tags.CRYPTOGRAPHIC_ALGORITHM
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
 
         value = objects.convert_template_attribute_to_attributes(
@@ -856,7 +857,7 @@ class TestAttributeUtilities(testtools.TestCase):
         )
 
     def test_convert_private_key_template_attribute_to_attributes(self):
-        template_attribute = objects.PrivateKeyTemplateAttribute(
+        template_attribute = objects.TemplateAttribute(
             attributes=[
                 objects.Attribute(
                     attribute_name=objects.Attribute.AttributeName(
@@ -868,7 +869,8 @@ class TestAttributeUtilities(testtools.TestCase):
                         tag=enums.Tags.KEY_FORMAT_TYPE
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
 
         value = objects.convert_template_attribute_to_attributes(
@@ -889,7 +891,7 @@ class TestAttributeUtilities(testtools.TestCase):
         )
 
     def test_convert_public_key_template_attribute_to_attributes(self):
-        template_attribute = objects.PublicKeyTemplateAttribute(
+        template_attribute = objects.TemplateAttribute(
             attributes=[
                 objects.Attribute(
                     attribute_name=objects.Attribute.AttributeName(
@@ -901,7 +903,8 @@ class TestAttributeUtilities(testtools.TestCase):
                         tag=enums.Tags.OBJECT_TYPE
                     )
                 )
-            ]
+            ],
+            tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
 
         value = objects.convert_template_attribute_to_attributes(
@@ -945,6 +948,7 @@ class TestAttributeUtilities(testtools.TestCase):
         value = objects.convert_attributes_to_template_attribute(attributes)
 
         self.assertIsInstance(value, objects.TemplateAttribute)
+        self.assertEqual(value.tag, enums.Tags.TEMPLATE_ATTRIBUTE)
         self.assertIsInstance(value.attributes, list)
         self.assertEqual(1, len(value.attributes))
         self.assertIsInstance(
@@ -978,7 +982,8 @@ class TestAttributeUtilities(testtools.TestCase):
 
         value = objects.convert_attributes_to_template_attribute(attributes)
 
-        self.assertIsInstance(value, objects.CommonTemplateAttribute)
+        self.assertIsInstance(value, objects.TemplateAttribute)
+        self.assertEqual(value.tag, enums.Tags.COMMON_TEMPLATE_ATTRIBUTE)
         self.assertIsInstance(value.attributes, list)
         self.assertEqual(1, len(value.attributes))
         self.assertIsInstance(
@@ -1012,7 +1017,8 @@ class TestAttributeUtilities(testtools.TestCase):
 
         value = objects.convert_attributes_to_template_attribute(attributes)
 
-        self.assertIsInstance(value, objects.PrivateKeyTemplateAttribute)
+        self.assertIsInstance(value, objects.TemplateAttribute)
+        self.assertEqual(value.tag, enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE)
         self.assertIsInstance(value.attributes, list)
         self.assertEqual(1, len(value.attributes))
         self.assertIsInstance(
@@ -1046,7 +1052,8 @@ class TestAttributeUtilities(testtools.TestCase):
 
         value = objects.convert_attributes_to_template_attribute(attributes)
 
-        self.assertIsInstance(value, objects.PublicKeyTemplateAttribute)
+        self.assertIsInstance(value, objects.TemplateAttribute)
+        self.assertEqual(value.tag, enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE)
         self.assertIsInstance(value.attributes, list)
         self.assertEqual(1, len(value.attributes))
         self.assertIsInstance(


### PR DESCRIPTION
This change updates the TemplateAttribute conversion utilities to remove use of various TemplateAttribute subclasses. This reflects the usage updates added for CreateKeyPair support. All related unit tests have been updated to reflect this change.