### PR TITLE
Implement simple CLI for GET_ATTRIBUTES operation

### DIFF
--- a/kmip/demos/pie/get_attributes.py
+++ b/kmip/demos/pie/get_attributes.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+from kmip.pie import client
+
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    # Build and parse arguments
+    parser = utils.build_cli_parser(enums.Operation.GET_ATTRIBUTES)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+    uid = opts.uuid
+
+    # Exit early if the UUID is not specified
+    if uid is None:
+        logger.error('No ID provided, exiting early from demo')
+        sys.exit()
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(
+            config=config,
+            config_file=opts.config_file
+    ) as client:
+        try:
+            _, attributes = client.get_attributes(
+                uid, attribute_names=opts.attribute_names)
+            logger.info("Successfully retrieved {0} attributes:".format(
+                len(attributes)))
+            for attribute in attributes:
+                logger.info("Attribute {0}: {1}".format(
+                    attribute.attribute_name, attribute.attribute_value))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -211,6 +211,24 @@ def build_cli_parser(operation=None):
             default=None,
             dest="uuid",
             help="UID of a managed object")
+    elif operation is Operation.GET_ATTRIBUTES:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
+        parser.add_option(
+            "-a",
+            "--attribute-names",
+            action="append",
+            type="str",
+            default=None,
+            dest="attribute_names",
+            help="List of attribute names to retrieve, defaults to all "
+                 "attributes")
     elif operation is Operation.LOCATE:
         parser.add_option(
             "-n",


### PR DESCRIPTION
Examples:

```
$ kmip/demos/pie/get_attributes.py -s ./vault-client.conf -i ca4a423c-d7a3-8771-028c-58feb78afca3 -a 'State' -a 'Object Type'
2019-03-25 19:28:25,868 - demo - INFO - Successfully retrieved 2 attributes:
2019-03-25 19:28:25,868 - demo - INFO - Attribute State: State.ACTIVE
2019-03-25 19:28:25,868 - demo - INFO - Attribute Object Type: ObjectType.SYMMETRIC_KEY
```

All attributes:

```
$ kmip/demos/pie/get_attributes.py -s ./vault-client.conf -i ca4a423c-d7a3-8771-028c-58feb78afca3
2019-03-25 19:28:29,985 - demo - INFO - Successfully retrieved 8 attributes:
2019-03-25 19:28:29,985 - demo - INFO - Attribute Unique Identifier: ca4a423c-d7a3-8771-028c-58feb78afca3
2019-03-25 19:28:29,985 - demo - INFO - Attribute Object Type: ObjectType.SYMMETRIC_KEY
2019-03-25 19:28:29,985 - demo - INFO - Attribute Cryptographic Algorithm: CryptographicAlgorithm.AES
2019-03-25 19:28:29,985 - demo - INFO - Attribute Cryptographic Length: 256
2019-03-25 19:28:29,985 - demo - INFO - Attribute Cryptographic Usage Mask: 12
2019-03-25 19:28:29,985 - demo - INFO - Attribute State: State.ACTIVE
2019-03-25 19:28:29,985 - demo - INFO - Attribute Initial Date: Mon Mar 25 14:28:44 2019
2019-03-25 19:28:29,985 - demo - INFO - Attribute Last Change Date: Mon Mar 25 14:28:44 2019
```