### PR TITLE
Update the GetAttributes payloads

### DIFF
--- a/kmip/core/messages/payloads/get_attributes.py
+++ b/kmip/core/messages/payloads/get_attributes.py
@@ -74,7 +74,7 @@ class GetAttributesRequestPayload(primitives.Struct):
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
         else:
-            raise TypeError("unique identifier must be a string")
+            raise TypeError("Unique identifier must be a string.")
 
     @property
     def attribute_names(self):
@@ -96,8 +96,8 @@ class GetAttributesRequestPayload(primitives.Struct):
                 name = value[i]
                 if not isinstance(name, six.string_types):
                     raise TypeError(
-                        "attribute_names must be a list of strings; "
-                        "item {0} has type {1}".format(i + 1, type(name))
+                        "Attribute names must be a list of strings; "
+                        "item {0} has type {1}.".format(i + 1, type(name))
                     )
                 if name not in names:
                     names.append(name)
@@ -110,69 +110,77 @@ class GetAttributesRequestPayload(primitives.Struct):
                     )
                 )
         else:
-            raise TypeError("attribute_names must be a list of strings")
+            raise TypeError("Attribute names must be a list of strings.")
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributes request payload and decode
         it into its constituent parts.
 
         Args:
-            istream (stream): A data stream containing encoded object data,
-                supporting a read method; usually a BytearrayStream object.
+            input_buffer (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
             kmip_version (KMIPVersion): An enumeration defining the KMIP
                 version with which the object will be decoded. Optional,
                 defaults to KMIP 1.0.
         """
         super(GetAttributesRequestPayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = utils.BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_buffer):
             self._unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            self._unique_identifier.read(tstream, kmip_version=kmip_version)
+            self._unique_identifier.read(
+                local_buffer,
+                kmip_version=kmip_version
+            )
         else:
             self._unique_identifier = None
 
         names = list()
-        while self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, tstream):
+        while self.is_tag_next(enums.Tags.ATTRIBUTE_NAME, local_buffer):
             name = primitives.TextString(tag=enums.Tags.ATTRIBUTE_NAME)
-            name.read(tstream, kmip_version=kmip_version)
+            name.read(local_buffer, kmip_version=kmip_version)
             names.append(name)
         self._attribute_names = names
 
-        self.is_oversized(tstream)
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributes request payload to a
         stream.
 
         Args:
-            ostream (stream): A data stream in which to encode object data,
-                supporting a write method; usually a BytearrayStream object.
+            output_buffer (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
             kmip_version (KMIPVersion): An enumeration defining the KMIP
                 version with which the object will be encoded. Optional,
                 defaults to KMIP 1.0.
         """
-        tstream = utils.BytearrayStream()
+        local_buffer = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream, kmip_version=kmip_version)
+            self._unique_identifier.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
 
         for attribute_name in self._attribute_names:
-            attribute_name.write(tstream, kmip_version=kmip_version)
+            attribute_name.write(local_buffer, kmip_version=kmip_version)
 
-        self.length = tstream.length()
+        self.length = local_buffer.length()
         super(GetAttributesRequestPayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
     def __repr__(self):
         unique_identifier = "unique_identifier={0}".format(
@@ -260,7 +268,7 @@ class GetAttributesResponsePayload(primitives.Struct):
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
         else:
-            raise TypeError("unique identifier must be a string")
+            raise TypeError("Unique identifier must be a string.")
 
     @property
     def attributes(self):
@@ -275,80 +283,87 @@ class GetAttributesResponsePayload(primitives.Struct):
                 attribute = value[i]
                 if not isinstance(attribute, objects.Attribute):
                     raise TypeError(
-                        "attributes must be a list of attribute objects; "
-                        "item {0} has type {1}".format(i + 1, type(attribute))
+                        "Attributes must be a list of attribute objects; "
+                        "item {0} has type {1}.".format(i + 1, type(attribute))
                     )
             self._attributes = value
         else:
-            raise TypeError("attributes must be a list of attribute objects")
+            raise TypeError("Attributes must be a list of attribute objects.")
 
-    def read(self, istream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Read the data encoding the GetAttributes response payload and decode
         it into its constituent parts.
 
         Args:
-            istream (stream): A data stream containing encoded object data,
-                supporting a read method; usually a BytearrayStream object.
+            input_buffer (stream): A data stream containing encoded object
+                data, supporting a read method; usually a BytearrayStream
+                object.
             kmip_version (KMIPVersion): An enumeration defining the KMIP
                 version with which the object will be decoded. Optional,
                 defaults to KMIP 1.0.
         """
         super(GetAttributesResponsePayload, self).read(
-            istream,
+            input_buffer,
             kmip_version=kmip_version
         )
-        tstream = utils.BytearrayStream(istream.read(self.length))
+        local_buffer = utils.BytearrayStream(input_buffer.read(self.length))
 
-        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, tstream):
+        if self.is_tag_next(enums.Tags.UNIQUE_IDENTIFIER, local_buffer):
             unique_identifier = primitives.TextString(
                 tag=enums.Tags.UNIQUE_IDENTIFIER
             )
-            unique_identifier.read(tstream, kmip_version=kmip_version)
+            unique_identifier.read(local_buffer, kmip_version=kmip_version)
             self.unique_identifier = unique_identifier.value
         else:
             raise exceptions.InvalidKmipEncoding(
-                "expected GetAttributes response unique identifier not found"
+                "The GetAttributes response payload encoding is missing the "
+                "unique identifier."
             )
 
         self._attributes = list()
-        while self.is_tag_next(enums.Tags.ATTRIBUTE, tstream):
+        while self.is_tag_next(enums.Tags.ATTRIBUTE, local_buffer):
             attribute = objects.Attribute()
-            attribute.read(tstream, kmip_version=kmip_version)
+            attribute.read(local_buffer, kmip_version=kmip_version)
             self._attributes.append(attribute)
 
-        self.is_oversized(tstream)
+        self.is_oversized(local_buffer)
 
-    def write(self, ostream, kmip_version=enums.KMIPVersion.KMIP_1_0):
+    def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
         Write the data encoding the GetAttributes response payload to a
         stream.
 
         Args:
-            ostream (stream): A data stream in which to encode object data,
-                supporting a write method; usually a BytearrayStream object.
+            output_buffer (stream): A data stream in which to encode object
+                data, supporting a write method; usually a BytearrayStream
+                object.
             kmip_version (KMIPVersion): An enumeration defining the KMIP
                 version with which the object will be encoded. Optional,
                 defaults to KMIP 1.0.
         """
-        tstream = utils.BytearrayStream()
+        local_buffer = utils.BytearrayStream()
 
         if self._unique_identifier:
-            self._unique_identifier.write(tstream, kmip_version=kmip_version)
+            self._unique_identifier.write(
+                local_buffer,
+                kmip_version=kmip_version
+            )
         else:
             raise exceptions.InvalidField(
-                "The GetAttributes response unique identifier is required."
+                "The GetAttributes response payload is missing the unique "
+                "identifier field."
             )
 
         for attribute in self._attributes:
-            attribute.write(tstream, kmip_version=kmip_version)
+            attribute.write(local_buffer, kmip_version=kmip_version)
 
-        self.length = tstream.length()
+        self.length = local_buffer.length()
         super(GetAttributesResponsePayload, self).write(
-            ostream,
+            output_buffer,
             kmip_version=kmip_version
         )
-        ostream.write(tstream.buffer)
+        output_buffer.write(local_buffer.buffer)
 
     def __repr__(self):
         unique_identifier = "unique_identifier={0}".format(

--- a/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
@@ -124,7 +124,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegex(
             TypeError,
-            "unique identifier must be a string",
+            "Unique identifier must be a string.",
             setattr,
             *args
         )
@@ -172,7 +172,7 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         args = (payload, 'attribute_names', 0)
         self.assertRaisesRegex(
             TypeError,
-            "attribute_names must be a list of strings",
+            "Attribute names must be a list of strings.",
             setattr,
             *args
         )
@@ -191,8 +191,8 @@ class TestGetAttributesRequestPayload(testtools.TestCase):
         )
         self.assertRaisesRegex(
             TypeError,
-            "attribute_names must be a list of strings; "
-            "item 2 has type {0}".format(type(0)),
+            "Attribute names must be a list of strings; "
+            "item 2 has type {0}.".format(type(0)),
             setattr,
             *args
         )
@@ -833,7 +833,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         args = (payload, 'unique_identifier', 0)
         self.assertRaisesRegex(
             TypeError,
-            "unique identifier must be a string",
+            "Unique identifier must be a string.",
             setattr,
             *args
         )
@@ -867,7 +867,7 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         args = (payload, 'attributes', 0)
         self.assertRaisesRegex(
             TypeError,
-            "attributes must be a list of attribute objects",
+            "Attributes must be a list of attribute objects.",
             setattr,
             *args
         )
@@ -886,8 +886,8 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         )
         self.assertRaisesRegex(
             TypeError,
-            "attributes must be a list of attribute objects; "
-            "item 2 has type {0}".format(type(0)),
+            "Attributes must be a list of attribute objects; "
+            "item 2 has type {0}.".format(type(0)),
             setattr,
             *args
         )
@@ -935,7 +935,8 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         args = (self.encoding_sans_unique_identifier, )
         self.assertRaisesRegex(
             exceptions.InvalidKmipEncoding,
-            "expected GetAttributes response unique identifier not found",
+            "The GetAttributes response payload encoding is missing the "
+            "unique identifier.",
             payload.read,
             *args
         )
@@ -992,7 +993,8 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
         args = (stream, )
         self.assertRaisesRegex(
             exceptions.InvalidField,
-            "The GetAttributes response unique identifier is required.",
+            "The GetAttributes response payload is missing the unique "
+            "identifier field.",
             payload.write,
             *args
         )


### PR DESCRIPTION
This change makes minor updates to the GetAttributes payloads, fixing error messages, comments, and local variable names to comply with the current payload format. The corresponding unit test suite has been updated to reflect these changes.

This change prepares the GetAttributes payloads for future updates to support KMIP 2.0.