### PR TITLE
Update requirements and pin cryptography at 1.4+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=1.3
+cryptography>=1.4
 enum34
 requests
 six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     install_requires=[
         "cryptography",
         "enum34",
+        "requests",
         "six",
         "sqlalchemy"
     ],


### PR DESCRIPTION
This change updates requirements, pinning cryptography>=1.4. This is due to the use of kbkdf in the server's cryptography engine, which was not introduced until cryptography 1.4.

Fixes #525