### PR TITLE
Temporarily pin bandit to 1.5.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ fixtures
 mock
 slugs
 sphinx
-bandit
+bandit==1.5.1


### PR DESCRIPTION
A recent regression in bandit 1.6.0 permits the scanning of test files for vulnerabilities even when those files should be excluded using the '-x' flag. This change temporarily pins bandit to 1.5.1 in test requirements.txt to get around this issue in the short term.

This patch should be undone once bandit 1.6.1 is released, fixing this issue.