### PR TITLE
Updating the Register payloads to properly use protection masks

### DIFF
--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -33,9 +33,9 @@ class RegisterRequestPayload(primitives.Struct):
         object_type: The type of the object to register.
         template_attribute: A group of attributes to set on the new object.
         managed_object: The object to register.
-        protection_storage_masks: An integer representing all of the
-            protection storage mask selections for the new object. Added in
-            KMIP 2.0.
+        protection_storage_masks: A ProtectionStorageMasks structure
+            containing the storage masks permissible for the new object.
+            Added in KMIP 2.0.
     """
 
     def __init__(self,
@@ -64,9 +64,9 @@ class RegisterRequestPayload(primitives.Struct):
                     * secrets.SymmetricKey
                     * secrets.Template
                 Optional, defaults to None. Required for read/write.
-            protection_storage_masks (int): An integer representing all of
-                the protection storage mask selections for the new object.
-                Optional, defaults to None. Added in KMIP 2.0.
+            protection_storage_masks (structure): A ProtectionStorageMasks
+                structure containing the storage masks permissible for the new
+                object. Added in KMIP 2.0. Optional, defaults to None.
         """
 
         super(RegisterRequestPayload, self).__init__(
@@ -151,22 +151,25 @@ class RegisterRequestPayload(primitives.Struct):
 
     @property
     def protection_storage_masks(self):
-        if self._protection_storage_masks:
-            return self._protection_storage_masks.value
-        return None
+        return self._protection_storage_masks
 
     @protection_storage_masks.setter
     def protection_storage_masks(self, value):
         if value is None:
             self._protection_storage_masks = None
-        elif isinstance(value, six.integer_types):
-            self._protection_storage_masks = primitives.Integer(
-                value=value,
-                tag=enums.Tags.PROTECTION_STORAGE_MASKS
-            )
+        elif isinstance(value, objects.ProtectionStorageMasks):
+            if value.tag == enums.Tags.PROTECTION_STORAGE_MASKS:
+                self._protection_storage_masks = value
+            else:
+                raise TypeError(
+                    "The protection storage masks must be a "
+                    "ProtectionStorageMasks structure with a "
+                    "ProtectionStorageMasks tag."
+                )
         else:
             raise TypeError(
-                "The protection storage masks must be an integer."
+                "The protection storage masks must be a "
+                "ProtectionStorageMasks structure."
             )
 
     def read(self, input_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
@@ -251,7 +254,7 @@ class RegisterRequestPayload(primitives.Struct):
                 enums.Tags.PROTECTION_STORAGE_MASKS,
                 local_buffer
             ):
-                protection_storage_masks = primitives.Integer(
+                protection_storage_masks = objects.ProtectionStorageMasks(
                     tag=enums.Tags.PROTECTION_STORAGE_MASKS
                 )
                 protection_storage_masks.read(
@@ -366,9 +369,7 @@ class RegisterRequestPayload(primitives.Struct):
             "template_attribute={}".format(repr(self.template_attribute)),
             "managed_object={}".format(repr(self.managed_object)),
             "protection_storage_masks={}".format(
-                "{}".format(
-                    repr(self.protection_storage_masks)
-                ) if self._protection_storage_masks else None
+                repr(self.protection_storage_masks)
             )
         ])
         return "RegisterRequestPayload({})".format(args)
@@ -380,9 +381,7 @@ class RegisterRequestPayload(primitives.Struct):
                 '"template_attribute": {}'.format(self.template_attribute),
                 '"managed_object": {}'.format(self.managed_object),
                 '"protection_storage_masks": {}'.format(
-                    "{}".format(
-                        str(self.protection_storage_masks)
-                    ) if self._protection_storage_masks else None
+                    str(self.protection_storage_masks)
                 )
             ]
         )


### PR DESCRIPTION
This change updates the Register payloads to properly use the new ProtectionStorageMasks structure. Unit tests have been updated to reflect this change.