### PR TITLE
Fix a bug with how the server retrieves attributes under KMIP 2.0

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -593,9 +593,13 @@ class KmipEngine(object):
         for attribute_name in attr_names:
             object_type = managed_object._object_type
 
+            # TODO (ph) Create the policy once and just pass these calls the
+            #           KMIP version for the current request.
             if not self._attribute_policy.is_attribute_supported(
                     attribute_name
             ):
+                continue
+            if self._attribute_policy.is_attribute_deprecated(attribute_name):
                 continue
 
             if self._attribute_policy.is_attribute_applicable_to_object_type(

--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -521,7 +521,8 @@ class AttributePolicy(object):
                     enums.ObjectType.SECRET_DATA,
                     enums.ObjectType.OPAQUE_DATA
                 ),
-                contents.ProtocolVersion(1, 0)
+                contents.ProtocolVersion(1, 0),
+                contents.ProtocolVersion(2, 0)
             ),
             'Cryptographic Usage Mask': AttributeRuleSet(
                 True,


### PR DESCRIPTION
This change fixes a bug in the server attribute handling logic that manifests when attributes are deprecated and removed in KMIP 2.0. Now these attributes are effectively ignored for KMIP 2.0 messages, complying with the KMIP 2.0 specification.