### PR TITLE
Fix Locate attribute handling for KMIP 2.0 clients

### DIFF
--- a/kmip/core/messages/payloads/locate.py
+++ b/kmip/core/messages/payloads/locate.py
@@ -16,7 +16,6 @@
 import six
 
 from kmip.core import enums
-from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
@@ -262,11 +261,6 @@ class LocateRequestPayload(primitives.Struct):
                     attributes
                 )
                 self._attributes = temp_attr.attributes
-            else:
-                raise exceptions.InvalidKmipEncoding(
-                    "The Locate request payload encoding is missing the "
-                    "attributes structure."
-                )
 
     def write(self, output_buffer, kmip_version=enums.KMIPVersion.KMIP_1_0):
         """
@@ -316,11 +310,6 @@ class LocateRequestPayload(primitives.Struct):
                     template_attribute
                 )
                 attributes.write(local_buffer, kmip_version=kmip_version)
-            else:
-                raise exceptions.InvalidField(
-                    "The Locate request payload is missing the attributes "
-                    "list."
-                )
 
         self.length = local_buffer.length()
         super(LocateRequestPayload, self).write(

--- a/kmip/tests/unit/core/messages/payloads/test_locate.py
+++ b/kmip/tests/unit/core/messages/payloads/test_locate.py
@@ -16,7 +16,6 @@
 import testtools
 
 from kmip.core import enums
-from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
@@ -637,25 +636,6 @@ class TestLocateRequestPayload(testtools.TestCase):
         )
         self.assertEqual([], payload.attributes)
 
-    def test_read_missing_attributes_kmip_2_0(self):
-        """
-        Test that an InvalidKmipEncoding error is raised during the decoding
-        of a Locate request payload when the attributes structure is missing
-        from the encoding.
-        """
-        payload = payloads.LocateRequestPayload()
-
-        args = (self.no_attributes_encoding, )
-        kwargs = {"kmip_version": enums.KMIPVersion.KMIP_2_0}
-        self.assertRaisesRegex(
-            exceptions.InvalidKmipEncoding,
-            "The Locate request payload encoding is missing the attributes "
-            "structure.",
-            payload.read,
-            *args,
-            **kwargs
-        )
-
     def test_read_missing_everything(self):
         """
         Test that a Locate request payload can be read from a data stream
@@ -876,28 +856,6 @@ class TestLocateRequestPayload(testtools.TestCase):
 
         self.assertEqual(len(self.no_attributes_encoding), len(stream))
         self.assertEqual(str(self.no_attributes_encoding), str(stream))
-
-    def test_write_missing_attributes_kmip_2_0(self):
-        """
-        Test that an InvalidField error is raised during the encoding of a
-        Locate request payload when the payload is missing the attributes list.
-        """
-        payload = payloads.LocateRequestPayload(
-            maximum_items=1,
-            offset_items=1,
-            storage_status_mask=3,
-            object_group_member=enums.ObjectGroupMember.GROUP_MEMBER_DEFAULT
-        )
-
-        args = (utils.BytearrayStream(), )
-        kwargs = {"kmip_version": enums.KMIPVersion.KMIP_2_0}
-        self.assertRaisesRegex(
-            exceptions.InvalidField,
-            "The Locate request payload is missing the attributes list.",
-            payload.write,
-            *args,
-            **kwargs
-        )
 
     def test_write_missing_everything(self):
         """


### PR DESCRIPTION
This change loosens the constraints on including attributes in Locate messages for KMIP 2.0 clients. An early version of the KMIP 2.0 specification made attributes a required field for the Locate payloads, breaking backwards compatibility with earlier versions of the specification. A newer version of KMIP 2.0 reverses this change. The library has been updated to reflect this newer version of the specification. All relevant Locate unit tests have been modified or removed to reflect this change.

Fixes #556