### PR TITLE
Add session encoding debug logging to the server

### DIFF
--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -13,6 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import binascii
 import logging
 import socket
 import struct
@@ -345,8 +346,14 @@ class KmipSession(threading.Thread):
                 "does not match the advertised header length."
             )
         else:
+            self._logger.debug(
+                "Request encoding: {}".format(binascii.hexlify(message))
+            )
             return message
 
     def _send_response(self, data):
         if len(data) > 0:
+            self._logger.debug(
+                "Response encoding: {}".format(binascii.hexlify(bytes(data)))
+            )
             self._connection.sendall(bytes(data))


### PR DESCRIPTION
This change adds debug logging statements for the request and response message encodings sent and received by the server session. These provide direct visability into each message that is handled by the server, facilitating debugging and correctness checking. Given the content of these encodings may contain sensitive information, debug logging should only be enabled when testing or developing server features.