### PR TITLE
Add InitialDate filtering support for the Locate operation

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -13,44 +13,64 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core.enums import NameType
-from kmip.core.enums import Operation
-
-from kmip.core.attributes import Name
-
-from kmip.core.objects import Attribute
-
-from kmip.demos import utils
-
-from kmip.pie import client
-
+import calendar
 import logging
 import sys
+import time
+
+from kmip.core import enums
+from kmip.core.factories.attributes import AttributeFactory
+from kmip.demos import utils
+from kmip.pie import client
 
 
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
     # Build and parse arguments
-    parser = utils.build_cli_parser(Operation.LOCATE)
+    parser = utils.build_cli_parser(enums.Operation.LOCATE)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config
     name = opts.name
+    initial_dates = opts.initial_dates
 
-    # Exit early if name is not specified
-    if name is None:
-        logger.error('No name provided, exiting early from demo')
-        sys.exit()
+    attribute_factory = AttributeFactory()
 
-    # Build name attribute
-    # TODO Push this into the AttributeFactory
-    attribute_name = Attribute.AttributeName('Name')
-    name_value = Name.NameValue(name)
-    name_type = Name.NameType(NameType.UNINTERPRETED_TEXT_STRING)
-    value = Name.create(name_value=name_value, name_type=name_type)
-    name_obj = Attribute(attribute_name=attribute_name, attribute_value=value)
-    attributes = [name_obj]
+    # Build attributes if any are specified
+    attributes = []
+    if name:
+        attributes.append(
+            attribute_factory.create_attribute(enums.AttributeType.NAME, name)
+        )
+    for initial_date in initial_dates:
+        try:
+            t = time.strptime(initial_date)
+        except ValueError, TypeError:
+            logger.error(
+                "Invalid initial date provided: {}".format(initial_date)
+            )
+            logger.info(
+                "Date values should be formatted like this: "
+                "'Tue Jul 23 18:39:01 2019'"
+            )
+            sys.exit(-1)
+
+        try:
+            t = calendar.timegm(t)
+        except Exception:
+            logger.error(
+                "Failed to convert initial date time tuple "
+                "to an integer: {}".format(t)
+            )
+            sys.exit(-2)
+
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.INITIAL_DATE,
+                t
+            )
+        )
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(

--- a/kmip/demos/units/locate.py
+++ b/kmip/demos/units/locate.py
@@ -13,42 +13,30 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from kmip.core.enums import CredentialType
-from kmip.core.enums import NameType
-from kmip.core.enums import Operation
-from kmip.core.enums import ResultStatus
-
-from kmip.core.attributes import Name
-
-from kmip.core.factories.attributes import AttributeFactory
-from kmip.core.factories.credentials import CredentialFactory
-
-from kmip.core.objects import Attribute
-
-from kmip.demos import utils
-
-from kmip.services.kmip_client import KMIPProxy
-
+import calendar
 import logging
 import sys
+import time
+
+from kmip.core import enums
+from kmip.core.factories.attributes import AttributeFactory
+from kmip.core.factories.credentials import CredentialFactory
+from kmip.demos import utils
+from kmip.services import kmip_client
 
 
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
     # Build and parse arguments
-    parser = utils.build_cli_parser(Operation.LOCATE)
+    parser = utils.build_cli_parser(enums.Operation.LOCATE)
     opts, args = parser.parse_args(sys.argv[1:])
 
     username = opts.username
     password = opts.password
     config = opts.config
     name = opts.name
-
-    # Exit early if the UUID is not specified
-    if name is None:
-        logger.error('No name provided, exiting early from demo')
-        sys.exit()
+    initial_dates = opts.initial_dates
 
     attribute_factory = AttributeFactory()
     credential_factory = CredentialFactory()
@@ -58,34 +46,63 @@ if __name__ == '__main__':
     if (username is None) and (password is None):
         credential = None
     else:
-        credential_type = CredentialType.USERNAME_AND_PASSWORD
-        credential_value = {'Username': username,
-                            'Password': password}
-        credential = credential_factory.create_credential(credential_type,
-                                                          credential_value)
+        credential_type = enums.CredentialType.USERNAME_AND_PASSWORD
+        credential_value = {
+            "Username": username,
+            "Password": password
+        }
+        credential = credential_factory.create_credential(
+            credential_type,
+            credential_value
+        )
+
     # Build the client and connect to the server
-    client = KMIPProxy(config=config, config_file=opts.config_file)
+    client = kmip_client.KMIPProxy(config=config, config_file=opts.config_file)
     client.open()
 
-    # Build name attribute
-    # TODO (peter-hamilton) Push this into the AttributeFactory
-    attribute_name = Attribute.AttributeName('Name')
-    name_value = Name.NameValue(name)
-    name_type = Name.NameType(NameType.UNINTERPRETED_TEXT_STRING)
-    value = Name.create(name_value=name_value, name_type=name_type)
-    name_obj = Attribute(attribute_name=attribute_name, attribute_value=value)
-    attributes = [name_obj]
+    # Build attributes if any are specified
+    attributes = []
+    if name:
+        attributes.append(
+            attribute_factory.create_attribute(enums.AttributeType.NAME, name)
+        )
+    for initial_date in initial_dates:
+        try:
+            t = time.strptime(initial_date)
+        except ValueError:
+            logger.error(
+                "Invalid initial date provided: {}".format(initial_date)
+            )
+            logger.info(
+                "Date values should be formatted like this: "
+                "'Tue Jul 23 18:39:01 2019'"
+            )
+            sys.exit(-1)
 
-    # Locate UUID of specified SYMMETRIC_KEY object
-    result = client.locate(attributes=attributes,
-                           credential=credential)
+        try:
+            t = calendar.timegm(t)
+        except Exception:
+            logger.error(
+                "Failed to convert initial date time tuple "
+                "to an integer: {}".format(t)
+            )
+            sys.exit(-2)
+
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.INITIAL_DATE,
+                t
+            )
+        )
+
+    result = client.locate(attributes=attributes, credential=credential)
     client.close()
 
     # Display operation results
     logger.info('locate() result status: {0}'.format(
         result.result_status.value))
 
-    if result.result_status.value == ResultStatus.SUCCESS:
+    if result.result_status.value == enums.ResultStatus.SUCCESS:
         logger.info('located UUIDs:')
         for uuid in result.uuids:
             logger.info('{0}'.format(uuid))

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -238,6 +238,20 @@ def build_cli_parser(operation=None):
             default=None,
             dest="name",
             help="Name of secret to retrieve from the KMIP server")
+        parser.add_option(
+            "--initial-date",
+            action="append",
+            type="str",
+            default=[],
+            dest="initial_dates",
+            help=(
+                "Initial date(s) in UTC of the secret to retrieve from the "
+                "KMIP server. Use once to perform an exact date match. Use "
+                "twice to create a date range that the secret's date should "
+                "be within. The value format should look like this: "
+                "'Tue Jul 23 18:39:01 2019'"
+            )
+        )
     elif operation is Operation.REGISTER:
         parser.add_option(
             "-f",


### PR DESCRIPTION
This change updates Locate operation support in the PyKMIP server, allowing users to filter objects based on the objects InitialDate attribute value. Specifying a single InitialDate attribute in the Locate request will perform an exact match on objects; specifying two InitialDate attributes will perform a ranged match. Unit tests and integration tests have been added to test and verify the correctness of this feature.

Additionally, the Locate demo scripts have also been updated to support InitialDate filtering. Simply use the "--initial-date" flag to provide one or more InitialDate values to the Locate script to filter on those dates.