### PR TITLE
Add State filtering support for the Locate operation

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     config = opts.config
     name = opts.name
     initial_dates = opts.initial_dates
+    state = opts.state
 
     attribute_factory = AttributeFactory()
 
@@ -71,6 +72,18 @@ if __name__ == '__main__':
                 t
             )
         )
+    if state:
+        state = getattr(enums.State, state, None)
+        if state:
+            attributes.append(
+                attribute_factory.create_attribute(
+                    enums.AttributeType.STATE,
+                    state
+                )
+            )
+        else:
+            logger.error("Invalid state provided: {}".format(opts.state))
+            sys.exit(-3)
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(

--- a/kmip/demos/units/locate.py
+++ b/kmip/demos/units/locate.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
     config = opts.config
     name = opts.name
     initial_dates = opts.initial_dates
+    state = opts.state
 
     attribute_factory = AttributeFactory()
     credential_factory = CredentialFactory()
@@ -94,6 +95,19 @@ if __name__ == '__main__':
                 t
             )
         )
+    if state:
+        state = getattr(enums.State, state, None)
+        if state:
+            attributes.append(
+                attribute_factory.create_attribute(
+                    enums.AttributeType.STATE,
+                    state
+                )
+            )
+        else:
+            logger.error("Invalid state provided: {}".format(opts.state))
+            client.close()
+            sys.exit(-1)
 
     result = client.locate(attributes=attributes, credential=credential)
     client.close()

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -252,6 +252,14 @@ def build_cli_parser(operation=None):
                 "'Tue Jul 23 18:39:01 2019'"
             )
         )
+        parser.add_option(
+            "--state",
+            action="store",
+            type="str",
+            default=None,
+            dest="state",
+            help="The state of the secret (e.g., PRE_ACTIVE, ACTIVE)"
+        )
     elif operation is Operation.REGISTER:
         parser.add_option(
             "-f",

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1601,6 +1601,10 @@ class KmipEngine(object):
         managed_objects = self._list_objects_with_access_controls(
                                 enums.Operation.LOCATE)
 
+        # TODO (ph) Do a single pass on the provided attributes and preprocess
+        # them as needed (e.g., tracking multiple 'Initial Date' values, etc).
+        # Locate needs to be able to error out if multiple singleton attributes
+        # like 'State' are provided in the same request.
         if payload.attributes:
 
             managed_objects_filtered = []
@@ -1633,6 +1637,19 @@ class KmipEngine(object):
                                 "any of the object's names ({}).".format(
                                     value,
                                     attribute
+                                )
+                            )
+                            add_object = False
+                            break
+                    elif name == enums.AttributeType.STATE.value:
+                        value = value.value
+                        if value != attribute:
+                            self._logger.debug(
+                                "Failed match: "
+                                "the specified state ({}) does not match "
+                                "the object's state ({}).".format(
+                                    value.name,
+                                    attribute.name
                                 )
                             )
                             add_object = False

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -1345,6 +1345,20 @@ class TestIntegration(testtools.TestCase):
         self.assertIn(uid_a, result.uuids)
         self.assertIn(uid_b, result.uuids)
 
+        # Test locating each key based off of its state.
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.STATE,
+                    enums.State.PRE_ACTIVE
+                )
+            ]
+        )
+        self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)
+        self.assertEqual(2, len(result.uuids))
+        self.assertIn(uid_a, result.uuids)
+        self.assertIn(uid_b, result.uuids)
+
         # Clean up keys
         result = self.client.destroy(uid_a)
         self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -984,6 +984,19 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIn(a_id, result)
         self.assertIn(b_id, result)
 
+        # Test locating each key by its state.
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.STATE,
+                    enums.State.PRE_ACTIVE
+                )
+            ]
+        )
+        self.assertEqual(2, len(result))
+        self.assertIn(a_id, result)
+        self.assertIn(b_id, result)
+
         # Clean up the keys
         self.client.destroy(a_id)
         self.client.destroy(b_id)


### PR DESCRIPTION
This change updates Locate operation support in the PyKMIP server, allowing users to filter objects based on the object's State. Unit tests and integration tests have been added to test and verify the correctness of this feature.

Additionally, the Locate demo scripts have also been updated to support State filtering. Simply use the "--state" flag to specify a State enumeration for the Locate script to filter on.