### PR TITLE
Add ObjectType filtering support for the Locate operation

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
     name = opts.name
     initial_dates = opts.initial_dates
     state = opts.state
+    object_type = opts.object_type
 
     attribute_factory = AttributeFactory()
 
@@ -84,6 +85,20 @@ if __name__ == '__main__':
         else:
             logger.error("Invalid state provided: {}".format(opts.state))
             sys.exit(-3)
+    if object_type:
+        object_type = getattr(enums.ObjectType, object_type, None)
+        if object_type:
+            attributes.append(
+                attribute_factory.create_attribute(
+                    enums.AttributeType.OBJECT_TYPE,
+                    object_type
+                )
+            )
+        else:
+            logger.error(
+                "Invalid object type provided: {}".format(opts.object_type)
+            )
+            sys.exit(-4)
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(

--- a/kmip/demos/units/locate.py
+++ b/kmip/demos/units/locate.py
@@ -38,6 +38,7 @@ if __name__ == '__main__':
     name = opts.name
     initial_dates = opts.initial_dates
     state = opts.state
+    object_type = opts.object_type
 
     attribute_factory = AttributeFactory()
     credential_factory = CredentialFactory()
@@ -107,7 +108,22 @@ if __name__ == '__main__':
         else:
             logger.error("Invalid state provided: {}".format(opts.state))
             client.close()
-            sys.exit(-1)
+            sys.exit(-3)
+    if object_type:
+        object_type = getattr(enums.ObjectType, object_type, None)
+        if object_type:
+            attributes.append(
+                attribute_factory.create_attribute(
+                    enums.AttributeType.OBJECT_TYPE,
+                    object_type
+                )
+            )
+        else:
+            logger.error(
+                "Invalid object type provided: {}".format(opts.object_type)
+            )
+            client.close()
+            sys.exit(-4)
 
     result = client.locate(attributes=attributes, credential=credential)
     client.close()

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -260,6 +260,17 @@ def build_cli_parser(operation=None):
             dest="state",
             help="The state of the secret (e.g., PRE_ACTIVE, ACTIVE)"
         )
+        parser.add_option(
+            "--object-type",
+            action="store",
+            type="str",
+            default=None,
+            dest="object_type",
+            help=(
+                "The object type of the secret "
+                "(e.g., CERTIFICATE, SYMMETRIC_KEY)"
+            )
+        )
     elif operation is Operation.REGISTER:
         parser.add_option(
             "-f",

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1654,6 +1654,19 @@ class KmipEngine(object):
                             )
                             add_object = False
                             break
+                    elif name == enums.AttributeType.OBJECT_TYPE.value:
+                        value = value.value
+                        if value != attribute:
+                            self._logger.debug(
+                                "Failed match: "
+                                "the specified object type ({}) does not "
+                                "match the object's object type ({}).".format(
+                                    value.name,
+                                    attribute.name
+                                )
+                            )
+                            add_object = False
+                            break
                     elif name == enums.AttributeType.INITIAL_DATE.value:
                         initial_date["value"] = attribute
                         self._track_date_attributes(

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -1359,6 +1359,20 @@ class TestIntegration(testtools.TestCase):
         self.assertIn(uid_a, result.uuids)
         self.assertIn(uid_b, result.uuids)
 
+        # Test locating each key based off of its object type.
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.OBJECT_TYPE,
+                    enums.ObjectType.SYMMETRIC_KEY
+                )
+            ]
+        )
+        self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)
+        self.assertEqual(2, len(result.uuids))
+        self.assertIn(uid_a, result.uuids)
+        self.assertIn(uid_b, result.uuids)
+
         # Clean up keys
         result = self.client.destroy(uid_a)
         self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -997,6 +997,19 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertIn(a_id, result)
         self.assertIn(b_id, result)
 
+        # Test locating each key by its object type.
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.OBJECT_TYPE,
+                    enums.ObjectType.SYMMETRIC_KEY
+                )
+            ]
+        )
+        self.assertEqual(2, len(result))
+        self.assertIn(a_id, result)
+        self.assertIn(b_id, result)
+
         # Clean up the keys
         self.client.destroy(a_id)
         self.client.destroy(b_id)


### PR DESCRIPTION
This change updates Locate operation support in the PyKMIP server, allowing users to filter objects based on the object's Object Type. Unit tests and integration tests have been added to test and verify the correctness of this feature.

Additionally, the Locate demo scripts have also been updated to support Object Type filtering. Simply use the "--object-type" flag to specify an Object Type enumeration for the Locate script to filter on.