### PR TITLE
Add UniqueIdentifier filtering support for the Locate operation

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -38,6 +38,7 @@ if __name__ == '__main__':
     object_type = opts.object_type
     cryptographic_algorithm = opts.cryptographic_algorithm
     cryptographic_length = opts.cryptographic_length
+    unique_identifier = opts.unique_identifier
 
     attribute_factory = AttributeFactory()
 
@@ -136,6 +137,13 @@ if __name__ == '__main__':
                 )
             )
             sys.exit(-6)
+    if unique_identifier:
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.UNIQUE_IDENTIFIER,
+                unique_identifier
+            )
+        )
 
     # Build the client and connect to the server
     with client.ProxyKmipClient(

--- a/kmip/demos/units/locate.py
+++ b/kmip/demos/units/locate.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     object_type = opts.object_type
     cryptographic_algorithm = opts.cryptographic_algorithm
     cryptographic_length = opts.cryptographic_length
+    unique_identifier = opts.unique_identifier
 
     attribute_factory = AttributeFactory()
     credential_factory = CredentialFactory()
@@ -163,6 +164,13 @@ if __name__ == '__main__':
             )
             client.close()
             sys.exit(-6)
+    if unique_identifier:
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.UNIQUE_IDENTIFIER,
+                unique_identifier
+            )
+        )
 
     result = client.locate(attributes=attributes, credential=credential)
     client.close()

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -287,6 +287,15 @@ def build_cli_parser(operation=None):
             dest="cryptographic_length",
             help="The cryptographic length of the secret (e.g., 128, 2048)"
         )
+        parser.add_option(
+            "-i",
+            "--unique-identifier",
+            action="store",
+            type="str",
+            default=None,
+            dest="unique_identifier",
+            help="The unique identifier of the secret (e.g., 1, 2, 3)"
+        )
     elif operation is Operation.REGISTER:
         parser.add_option(
             "-f",

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1715,6 +1715,20 @@ class KmipEngine(object):
                             )
                             add_object = False
                             break
+                    elif name == "Unique Identifier":
+                        value = value.value
+                        if value != attribute:
+                            self._logger.debug(
+                                "Failed match: "
+                                "the specified unique identifier ({}) "
+                                "does not match the object's unique "
+                                "identifier ({}).".format(
+                                    value,
+                                    attribute
+                                )
+                            )
+                            add_object = False
+                            break
                     elif name == enums.AttributeType.INITIAL_DATE.value:
                         initial_date["value"] = attribute
                         self._track_date_attributes(

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -1421,6 +1421,39 @@ class TestIntegration(testtools.TestCase):
         )
         self.assertEqual(0, len(result.uuids))
 
+        # Test locating each key by its unique identifier.
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    uid_a
+                )
+            ]
+        )
+        self.assertEqual(1, len(result.uuids))
+        self.assertIn(uid_a, result.uuids)
+
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    uid_b
+                )
+            ]
+        )
+        self.assertEqual(1, len(result.uuids))
+        self.assertIn(uid_b, result.uuids)
+
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    "unknown"
+                )
+            ]
+        )
+        self.assertEqual(0, len(result.uuids))
+
         # Clean up keys
         result = self.client.destroy(uid_a)
         self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -1076,6 +1076,39 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         )
         self.assertEqual(0, len(result))
 
+        # Test locating each key by its unique identifier.
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    a_id
+                )
+            ]
+        )
+        self.assertEqual(1, len(result))
+        self.assertIn(a_id, result)
+
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    b_id
+                )
+            ]
+        )
+        self.assertEqual(1, len(result))
+        self.assertIn(b_id, result)
+
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.UNIQUE_IDENTIFIER,
+                    "unknown"
+                )
+            ]
+        )
+        self.assertEqual(0, len(result))
+
         # Clean up the keys
         self.client.destroy(a_id)
         self.client.destroy(b_id)


### PR DESCRIPTION
This change updates Locate operation support in the PyKMIP server, allowing users to filter objects based on the object's Unique Identifier. Unit tests and integration tests have been added to test and verify the correctness of this feature.

Additionally, the Locate demo scripts have also been updated to support Unique Identifier filtering. Simply use the "--unique-identifier" flag to specify a Unique Identifier string value for the Locate script to filter on.