### PR TITLE
Fix a bug with the debug logging for Initial Date filtering

### DIFF
--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -4587,14 +4587,14 @@ class TestKmipEngine(testtools.TestCase):
         )
         obj_a.initial_date = int(time.time())
         obj_a_time_str = time.strftime(
-            "%a %b %d %H:%M:%S %Y",
+            "%a %b %-2d %H:%M:%S %Y",
             time.gmtime(obj_a.initial_date)
         )
 
         time.sleep(2)
         mid_time = int(time.time())
         mid_time_str = time.strftime(
-            "%a %b %d %H:%M:%S %Y",
+            "%a %b %-2d %H:%M:%S %Y",
             time.gmtime(mid_time)
         )
         time.sleep(2)
@@ -4607,7 +4607,7 @@ class TestKmipEngine(testtools.TestCase):
         )
         obj_b.initial_date = int(time.time())
         obj_b_time_str = time.strftime(
-            "%a %b %d %H:%M:%S %Y",
+            "%a %b %-2d %H:%M:%S %Y",
             time.gmtime(obj_b.initial_date)
         )
 


### PR DESCRIPTION
This change fixes a bug in the server engine unit tests that check the debug logs for Locate filtering on the Initial Date attribute. Specifically, time.asctime does not use the default '%d' notation for stringifying numerical day values. This change updates the string notation to match the format produced by time.asctime.

Impacts #572