### PR TITLE
Sort the Locate matched objects by their creation date

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1773,6 +1773,13 @@ class KmipEngine(object):
 
             managed_objects = managed_objects_filtered
 
+        # Sort the matching results by their creation date.
+        managed_objects = sorted(
+            managed_objects,
+            key=lambda x: x.initial_date,
+            reverse=True
+        )
+
         unique_identifiers = [
             str(x.unique_identifier) for x in managed_objects
         ]


### PR DESCRIPTION
This change updates the PyKMIP server's support for the Locate operation, sorting the matched objects found by Locate by their initial date, newest objects first. This matches the KMIP specification's definition for how Locate results should be ordered.