### PR TITLE
Add CryptographicUsageMask filtering support for Locate

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
     object_type = opts.object_type
     cryptographic_algorithm = opts.cryptographic_algorithm
     cryptographic_length = opts.cryptographic_length
+    cryptographic_usage_masks = opts.cryptographic_usage_masks
     unique_identifier = opts.unique_identifier
     operation_policy_name = opts.operation_policy_name
 
@@ -147,6 +148,29 @@ if __name__ == '__main__':
                 )
             )
             sys.exit(-6)
+    if cryptographic_usage_masks:
+        masks = []
+        for cryptographic_usage_mask in cryptographic_usage_masks:
+            mask = getattr(
+                enums.CryptographicUsageMask,
+                cryptographic_usage_mask,
+                None
+            )
+            if mask:
+                masks.append(mask)
+            else:
+                logger.error(
+                    "Invalid cryptographic usage mask provided: {}".format(
+                        cryptographic_usage_mask
+                    )
+                )
+                sys.exit(-7)
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                masks
+            )
+        )
     if unique_identifier:
         attributes.append(
             attribute_factory.create_attribute(

--- a/kmip/demos/units/locate.py
+++ b/kmip/demos/units/locate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     object_type = opts.object_type
     cryptographic_algorithm = opts.cryptographic_algorithm
     cryptographic_length = opts.cryptographic_length
+    cryptographic_usage_masks = opts.cryptographic_usage_masks
     unique_identifier = opts.unique_identifier
     operation_policy_name = opts.operation_policy_name
 
@@ -174,6 +175,29 @@ if __name__ == '__main__':
             )
             client.close()
             sys.exit(-6)
+    if cryptographic_usage_masks:
+        masks = []
+        for cryptographic_usage_mask in cryptographic_usage_masks:
+            mask = getattr(
+                enums.CryptographicUsageMask,
+                cryptographic_usage_mask,
+                None
+            )
+            if mask:
+                masks.append(mask)
+            else:
+                logger.error(
+                    "Invalid cryptographic usage mask provided: {}".format(
+                        cryptographic_usage_mask
+                    )
+                )
+                sys.exit(-7)
+        attributes.append(
+            attribute_factory.create_attribute(
+                enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                masks
+            )
+        )
     if unique_identifier:
         attributes.append(
             attribute_factory.create_attribute(

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -304,6 +304,20 @@ def build_cli_parser(operation=None):
             help="The cryptographic length of the secret (e.g., 128, 2048)"
         )
         parser.add_option(
+            "--cryptographic-usage-mask",
+            action="append",
+            type="str",
+            default=[],
+            dest="cryptographic_usage_masks",
+            help=(
+                "The cryptographic usage mask(s) the secret should have set "
+                "(e.g., ENCRYPT, DECRYPT). Use multiple times to specify "
+                "multiple cryptographic usage mask enumeration values. All "
+                "values will get combined into a single mask when sent to the "
+                "server."
+            )
+        )
+        parser.add_option(
             "-i",
             "--unique-identifier",
             action="store",

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1743,6 +1743,25 @@ class KmipEngine(object):
                             )
                             add_object = False
                             break
+                    elif name == "Cryptographic Usage Mask":
+                        value = value.value
+                        mask_values = enums.get_enumerations_from_bit_mask(
+                            enums.CryptographicUsageMask,
+                            value
+                        )
+                        for mask_value in mask_values:
+                            if mask_value not in attribute:
+                                self._logger.debug(
+                                    "Failed match: "
+                                    "the specified cryptographic usage mask "
+                                    "({}) is not set on the object.".format(
+                                        mask_value.name
+                                    )
+                                )
+                                add_object = False
+                                break
+                        if not add_object:
+                            break
                     elif name == enums.AttributeType.INITIAL_DATE.value:
                         initial_date["value"] = attribute
                         self._track_date_attributes(

--- a/kmip/tests/integration/services/test_integration.py
+++ b/kmip/tests/integration/services/test_integration.py
@@ -1493,6 +1493,55 @@ class TestIntegration(testtools.TestCase):
         self.assertEqual(1, len(result.uuids))
         self.assertIn(uid_a, result.uuids)
 
+        # Test locating keys using their cryptographic usage masks
+        mask = [enums.CryptographicUsageMask.ENCRYPT]
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(2, len(result.uuids))
+        self.assertIn(uid_a, result.uuids)
+        self.assertIn(uid_b, result.uuids)
+
+        mask.append(enums.CryptographicUsageMask.DECRYPT)
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(2, len(result.uuids))
+        self.assertIn(uid_a, result.uuids)
+        self.assertIn(uid_b, result.uuids)
+
+        mask.append(enums.CryptographicUsageMask.SIGN)
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(0, len(result.uuids))
+
+        mask = [enums.CryptographicUsageMask.EXPORT]
+        result = self.client.locate(
+            attributes=[
+                self.attr_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(0, len(result.uuids))
+
         # Clean up keys
         result = self.client.destroy(uid_a)
         self.assertEqual(ResultStatus.SUCCESS, result.result_status.value)

--- a/kmip/tests/integration/services/test_proxykmipclient.py
+++ b/kmip/tests/integration/services/test_proxykmipclient.py
@@ -1148,6 +1148,55 @@ class TestProxyKmipClientIntegration(testtools.TestCase):
         self.assertEqual(1, len(result))
         self.assertIn(a_id, result)
 
+        # Test locating keys using their cryptographic usage masks
+        mask = [enums.CryptographicUsageMask.ENCRYPT]
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(2, len(result))
+        self.assertIn(a_id, result)
+        self.assertIn(b_id, result)
+
+        mask.append(enums.CryptographicUsageMask.DECRYPT)
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(2, len(result))
+        self.assertIn(a_id, result)
+        self.assertIn(b_id, result)
+
+        mask.append(enums.CryptographicUsageMask.SIGN)
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(0, len(result))
+
+        mask = [enums.CryptographicUsageMask.EXPORT]
+        result = self.client.locate(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
+                    mask
+                )
+            ]
+        )
+        self.assertEqual(0, len(result))
+
         # Clean up the keys
         self.client.destroy(a_id)
         self.client.destroy(b_id)


### PR DESCRIPTION
This change updates Locate operation support in the PyKMIP server, allowing users to filter objects based on the object's Cryptographic Usage Masks. Unit tests and integration tests have been added to test and verify the correctness of this feature.

Additionally, the Locate demo scripts have also been updated to support Cryptographic Usage Mask filtering. Simply use the "--cryptographic-usage-mask" flag to specify one or more Cryptographic Usage Mask enumeration values for the Locate script to filter on.