### PR TITLE
Fix a bug with how key pair names are handled in the client

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -238,7 +238,14 @@ class ProxyKmipClient(object):
         key_attributes.extend(common_attributes)
 
         if name:
-            key_attributes.extend(self._build_name_attribute(name))
+            key_attributes.extend(
+                [
+                    self.attribute_factory.create_attribute(
+                        enums.AttributeType.NAME,
+                        name
+                    )
+                ]
+            )
 
         template = cobjects.TemplateAttribute(attributes=key_attributes)
 
@@ -320,39 +327,45 @@ class ProxyKmipClient(object):
 
         # Create public / private specific attributes
         public_template = None
-        names = None
-        if public_name:
-            names = self._build_name_attribute(name=public_name)
         attrs = []
+        if public_name:
+            attrs.append(
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    public_name
+                )
+            )
         if public_usage_mask:
-            attrs = [
+            attrs.append(
                 self.attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
                     public_usage_mask
                 )
-            ]
-        if names or attrs:
+            )
+        if attrs:
             public_template = cobjects.TemplateAttribute(
-                names=names,
                 attributes=attrs,
                 tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
             )
 
         private_template = None
-        names = None
-        if private_name:
-            names = self._build_name_attribute(name=private_name)
         attrs = []
+        if private_name:
+            attrs.append(
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    private_name
+                )
+            )
         if private_usage_mask:
-            attrs = [
+            attrs.append(
                 self.attribute_factory.create_attribute(
                     enums.AttributeType.CRYPTOGRAPHIC_USAGE_MASK,
                     private_usage_mask
                 )
-            ]
-        if names or attrs:
+            )
+        if attrs:
             private_template = cobjects.TemplateAttribute(
-                names=names,
                 attributes=attrs,
                 tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
             )
@@ -1603,19 +1616,6 @@ class ProxyKmipClient(object):
             )
 
         return common_attributes
-
-    def _build_name_attribute(self, name=None):
-        '''
-        Build a name attribute, returned in a list for ease
-        of use in the caller
-        '''
-        name_list = []
-        if name:
-            name_list.append(self.attribute_factory.create_attribute(
-                enums.AttributeType.NAME,
-                name)
-            )
-        return name_list
 
     def __enter__(self):
         self.open()

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -573,34 +573,35 @@ class TestProxyKmipClient(testtools.TestCase):
         specifically testing that the private / public names are correctly
         sent with the request
         """
-        # Create the template to test the create key pair call
-        algorithm = enums.CryptographicAlgorithm.RSA
-        length = 2048
-        algorithm_attribute = self.attribute_factory.create_attribute(
-            enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM, algorithm)
-        length_attribute = self.attribute_factory.create_attribute(
-            enums.AttributeType.CRYPTOGRAPHIC_LENGTH, length)
-
-        private_name_attribute = self.attribute_factory.create_attribute(
-            enums.AttributeType.NAME, "private")
-        public_name_attribute = self.attribute_factory.create_attribute(
-            enums.AttributeType.NAME, "public")
-
-        pair_attributes = [
-            algorithm_attribute,
-            length_attribute
-        ]
-
-        template = obj.TemplateAttribute(
-            attributes=pair_attributes,
+        common_template = obj.TemplateAttribute(
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_ALGORITHM,
+                    enums.CryptographicAlgorithm.RSA
+                ),
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.CRYPTOGRAPHIC_LENGTH,
+                    2048
+                )
+            ],
             tag=enums.Tags.COMMON_TEMPLATE_ATTRIBUTE
         )
         private_template = obj.TemplateAttribute(
-            names=[private_name_attribute],
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    "Test_Private_Key"
+                )
+            ],
             tag=enums.Tags.PRIVATE_KEY_TEMPLATE_ATTRIBUTE
         )
         public_template = obj.TemplateAttribute(
-            names=[public_name_attribute],
+            attributes=[
+                self.attribute_factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    "Test_Public_Key"
+                )
+            ],
             tag=enums.Tags.PUBLIC_KEY_TEMPLATE_ATTRIBUTE
         )
 
@@ -617,12 +618,12 @@ class TestProxyKmipClient(testtools.TestCase):
             public_uid, private_uid = client.create_key_pair(
                 enums.CryptographicAlgorithm.RSA,
                 2048,
-                public_name="public",
-                private_name="private"
+                public_name="Test_Public_Key",
+                private_name="Test_Private_Key"
             )
 
             kwargs = {
-                "common_template_attribute": template,
+                "common_template_attribute": common_template,
                 "private_key_template_attribute": private_template,
                 "public_key_template_attribute": public_template
             }


### PR DESCRIPTION
This change fixes a bug with how key pair names are handled by the ProxyKmipClient. The original implementation stored key pair names in the 'names' field of the various template attributes used to define the key pair attributes. However, the 'names' field is meant for the names of existing template objects that should be used as another source for attribute values. Before KMIP 2.0 support was added, this worked because attributes and names were encoded the same way and were interpreted by the server correctly. The addition of KMIP 2.0 drops the 'names' field when handling template attributes, dropping the names from being sent to the server when creating new key pairs. This change fixes this and updates relevant client unit tests to detect this error in the future.

Fixes #560