### PR TITLE
Require enum-compat instead of enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography>=1.4
-enum34
+enum-compat
 requests
 six>=1.11.0
 sqlalchemy>=1.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     },
     install_requires=[
         "cryptography",
-        "enum34",
+        "enum-compat",
         "requests",
         "six",
         "sqlalchemy"


### PR DESCRIPTION
The enum34 package is not compatible with python 3.4+. By
requiring enum-compat instead, this requirement will be a
noop when installing the dependencies from a python 3.4+ environment.

Closes: #450