### PR TITLE
Remove basepython for non-default tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,14 +18,12 @@ commands = flake8 kmip/
 [testenv:integration]
 # Note: This requires local or remote access to a KMIP appliance or service
 deps = {[testenv]deps}
-basepython=python2.7
 commands =
     py.test --strict kmip/tests/integration -m "not ignore" {posargs}
 
 [testenv:functional]
 # Note: This requires local access to instances of the PyKMIP server and SLUGS.
 deps = {[testenv]deps}
-basepython=python2.7
 commands =
     py.test --strict kmip/tests/functional -m "not ignore" {posargs}
 
@@ -38,7 +36,6 @@ changedir = docs
 deps =
     sphinx
     sphinx_rtd_theme
-basepython = python2.7
 commands =
 	sphinx-build -j4 -T -W -b html -d {envtmpdir}/doctrees source {envtmpdir}/html
 
@@ -46,7 +43,6 @@ commands =
 changedir = docs
 extras =
 deps = {[testenv:docs]deps}
-basepython = python2.7
 commands =
     sphinx-build -W -b linkcheck source {envtmpdir}/html
 


### PR DESCRIPTION
This change removes the basepython setting for non-default tox environments, allowing those environments to use the default system Python instead of forcing the use of Python 2.7. This will now allow various TravisCI test runs to use the right version of Python.