### PR TITLE
Add conversion utilities for SplitKey objects

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -123,7 +123,7 @@ class KmipEngine(object):
             enums.ObjectType.SYMMETRIC_KEY: objects.SymmetricKey,
             enums.ObjectType.PUBLIC_KEY: objects.PublicKey,
             enums.ObjectType.PRIVATE_KEY: objects.PrivateKey,
-            enums.ObjectType.SPLIT_KEY: None,
+            enums.ObjectType.SPLIT_KEY: objects.SplitKey,
             enums.ObjectType.TEMPLATE: None,
             enums.ObjectType.SECRET_DATA: objects.SecretData,
             enums.ObjectType.OPAQUE_DATA: objects.OpaqueObject

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -3494,11 +3494,11 @@ class TestKmipEngine(testtools.TestCase):
         e._data_session = e._data_store_session_factory()
         e._logger = mock.MagicMock()
 
-        object_type = enums.ObjectType.SPLIT_KEY
+        object_type = enums.ObjectType.TEMPLATE
         payload = payloads.RegisterRequestPayload(object_type=object_type)
 
         args = (payload, )
-        regex = "The SplitKey object type is not supported."
+        regex = "The Template object type is not supported."
         six.assertRaisesRegex(
             self,
             exceptions.InvalidField,


### PR DESCRIPTION
This change adds conversion utilities for SplitKey objects, allowing for conversions between the Pie and Core object spaces. The server is also updated to recognize the new Pie SplitKey object. Unit tests have been added and tweaked to accommodate these changes.

Partially implements #545