### PR TITLE
Add SplitKey server integration tests

### DIFF
--- a/kmip/core/factories/secrets.py
+++ b/kmip/core/factories/secrets.py
@@ -31,6 +31,7 @@ from kmip.core.secrets import OpaqueObject
 from kmip.core.secrets import PrivateKey
 from kmip.core.secrets import PublicKey
 from kmip.core.secrets import SecretData
+from kmip.core.secrets import SplitKey
 from kmip.core.secrets import SymmetricKey
 from kmip.core.secrets import Template
 
@@ -116,7 +117,18 @@ class SecretFactory(object):
             return PrivateKey(key_block)
 
     def _create_split_key(self, value):
-        raise NotImplementedError()
+        if value is None:
+            return SplitKey()
+        else:
+            key_block = self._build_key_block(value)
+            return SplitKey(
+                split_key_parts=value.get("split_key_parts"),
+                key_part_identifier=value.get("key_part_identifier"),
+                split_key_threshold=value.get("split_key_threshold"),
+                split_key_method=value.get("split_key_method"),
+                prime_field_size=value.get("prime_field_size"),
+                key_block=key_block
+            )
 
     def _create_template(self, value):
         if value is None:

--- a/kmip/pie/factory.py
+++ b/kmip/pie/factory.py
@@ -194,6 +194,11 @@ class ObjectFactory:
     def _build_core_split_key(self, secret):
         key_material = cobjects.KeyMaterial(secret.value)
         key_value = cobjects.KeyValue(key_material)
+        key_wrapping_data = None
+        if secret.key_wrapping_data:
+            key_wrapping_data = cobjects.KeyWrappingData(
+                **secret.key_wrapping_data
+            )
         key_block = cobjects.KeyBlock(
             key_format_type=misc.KeyFormatType(secret.key_format_type),
             key_compression_type=None,
@@ -204,9 +209,7 @@ class ObjectFactory:
             cryptographic_length=attributes.CryptographicLength(
                 secret.cryptographic_length
             ),
-            key_wrapping_data=cobjects.KeyWrappingData(
-                **secret.key_wrapping_data
-            )
+            key_wrapping_data=key_wrapping_data
         )
         return secrets.SplitKey(
             split_key_parts=secret.split_key_parts,

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -519,6 +519,19 @@ class KmipEngine(object):
                 'opaque_data_type': obj.opaque_type,
                 'opaque_data_value': obj.value
             }
+        elif object_type == enums.ObjectType.SPLIT_KEY:
+            value = {
+                "cryptographic_algorithm": obj.cryptographic_algorithm,
+                "cryptographic_length": obj.cryptographic_length,
+                "key_format_type": obj.key_format_type,
+                "key_value": obj.value,
+                "key_wrapping_data": obj.key_wrapping_data,
+                "split_key_parts": obj.split_key_parts,
+                "key_part_identifier": obj.key_part_identifier,
+                "split_key_threshold": obj.split_key_threshold,
+                "split_key_method": obj.split_key_method,
+                "prime_field_size": obj.prime_field_size
+            }
         else:
             name = object_type.name
             raise exceptions.InvalidField(

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -1038,10 +1038,10 @@ class TestKmipEngine(testtools.TestCase):
 
         class DummyObject:
             def __init__(self):
-                self._object_type = enums.ObjectType.SPLIT_KEY
+                self._object_type = enums.ObjectType.TEMPLATE
 
         args = (DummyObject(), )
-        regex = "The SplitKey object type is not supported."
+        regex = "The Template object type is not supported."
         six.assertRaisesRegex(
             self,
             exceptions.InvalidField,


### PR DESCRIPTION
This change adds integration tests that test registering, retrieving, and destroying SplitKey objects with the server. Minor updates are included for the client and server to ensure that SplitKey operations function as expected.

Partially implements #545