### PR TITLE
Add a SplitKey register demo script

### DIFF
--- a/kmip/demos/pie/register_split_key.py
+++ b/kmip/demos/pie/register_split_key.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+from kmip.pie import objects
+
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    config = opts.config
+
+    split_key = objects.SplitKey(
+        cryptographic_algorithm=enums.CryptographicAlgorithm.AES,
+        cryptographic_length=128,
+        key_value=(
+            b'\x66\xC4\x6A\x77\x54\xF9\x4D\xE4'
+            b'\x20\xC7\xB1\xA7\xFF\xF5\xEC\x56'
+        ),
+        name="Demo Split Key",
+        cryptographic_usage_masks=[enums.CryptographicUsageMask.EXPORT],
+        key_format_type=enums.KeyFormatType.RAW,
+        key_wrapping_data=None,
+        split_key_parts=4,
+        key_part_identifier=1,
+        split_key_threshold=2,
+        split_key_method=enums.SplitKeyMethod.XOR,
+        prime_field_size=None
+    )
+    split_key.operation_policy_name = opts.operation_policy_name
+
+    # Build the client and connect to the server
+    with client.ProxyKmipClient(
+            config=config,
+            config_file=opts.config_file
+    ) as client:
+        try:
+            uid = client.register(split_key)
+            logger.info(
+                "Successfully registered split key with ID: {0}".format(uid)
+            )
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -56,7 +56,7 @@ def build_console_logger(level):
     return logger
 
 
-def build_cli_parser(operation=None):
+def build_cli_parser(operation):
     # Build the argument parser and setup expected options
     parser = optparse.OptionParser(
         usage="%prog [options]",
@@ -699,6 +699,8 @@ def log_secret(logger, secret_type, secret_value):
         log_public_key(logger, secret_value)
     elif secret_type is ObjectType.SYMMETRIC_KEY:
         log_symmetric_key(logger, secret_value)
+    elif secret_type is ObjectType.SPLIT_KEY:
+        log_split_key(logger, secret_value)
     else:
         logger.info('generic secret: {0}'.format(secret_value))
 
@@ -729,9 +731,23 @@ def log_symmetric_key(logger, skey):
     log_key_block(logger, key_block)
 
 
+def log_split_key(logger, split_key):
+    logger.info("Split Key:")
+    logger.info("* Split Key Parts: {}".format(split_key.split_key_parts))
+    logger.info(
+        "* Key Part Identifier: {}".format(split_key.key_part_identifier)
+    )
+    logger.info(
+        "* Split Key Threshold: {}".format(split_key.split_key_threshold)
+    )
+    logger.info("* Split Key Method: {}".format(split_key.split_key_method))
+    logger.info("* Prime Field Size: {}".format(split_key.prime_field_size))
+    log_key_block(logger, split_key.key_block)
+
+
 def log_key_block(logger, key_block):
     if key_block is not None:
-        logger.info('key block:')
+        logger.info("* Key Block:")
 
         key_format_type = key_block.key_format_type
         key_compression_type = key_block.key_compression_type
@@ -740,33 +756,25 @@ def log_key_block(logger, key_block):
         cryptographic_length = key_block.cryptographic_length
         key_wrapping_data = key_block.key_wrapping_data
 
-        logger.info('* key format type: {0}'.format(key_format_type))
-        logger.info('* key compression type: {0}'.format(
+        logger.info("  * Key Format Type: {}".format(key_format_type))
+        logger.info("  * Key Compression Type: {}".format(
             key_compression_type))
-        logger.info('* cryptographic algorithm: {0}'.format(
+        logger.info("  * Cryptographic Algorithm: {}".format(
             cryptographic_algorithm))
-        logger.info('* cryptographic length: {0}'.format(
+        logger.info("  * Cryptographic Length: {}".format(
             cryptographic_length))
+        logger.info("  * Key Wrapping Data: {}".format(key_wrapping_data))
 
         log_key_value(logger, key_value)
-        log_key_wrapping_data(logger, key_wrapping_data)
     else:
-        logger.info('key block: {0}'.format(key_block))
+        logger.info("* Key Block: {}".format(key_block))
 
 
 def log_key_value(logger, key_value):
     if key_value is not None:
-        logger.info('key value:')
-
-        key_material = key_value.key_material
-        attributes = key_value.attributes
-
-        logger.info('key material: {0}'.format(repr(key_material)))
-
-        log_attribute_list(logger, attributes)
+        logger.info("  * Key Value:")
+        logger.info(
+            "    * Key Material: {}".format(repr(key_value.key_material))
+        )
     else:
-        logger.info('key value: {0}'.format(key_value))
-
-
-def log_key_wrapping_data(logger, key_wrapping_data):
-    logger.info('key wrapping data: {0}'.format(key_wrapping_data))
+        logger.info("  * Key Value: {}".format(key_value))


### PR DESCRIPTION
This change adds a demo script showing how to register SplitKey objects. The existing Get and Destroy demo scripts also work with the new SplitKey objects. Demo utilities for logging object info have been updated and improved as well.

Closes #545