### PR TITLE
Add ApplicationSpecificInformation support to the server

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -1248,10 +1248,10 @@ class ApplicationSpecificInformation(primitives.Struct):
     def __str__(self):
         value = ", ".join(
             [
-                '"application_namespace": {}'.format(
+                '"application_namespace": "{}"'.format(
                     self.application_namespace
                 ),
-                '"application_data": {}'.format(self.application_data)
+                '"application_data": "{}"'.format(self.application_data)
             ]
         )
         return "{" + value + "}"

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -277,28 +277,13 @@ class AttributeValueFactory(object):
         return attributes.ObjectGroup(group)
 
     def _create_application_specific_information(self, info):
-        if info is None:
-            return attributes.ApplicationSpecificInformation()
+        if info:
+            return attributes.ApplicationSpecificInformation(
+                application_namespace=info.get("application_namespace"),
+                application_data=info.get("application_data")
+            )
         else:
-            application_namespace = info.get('application_namespace')
-            application_data = info.get('application_data')
-
-            if not isinstance(application_namespace, str):
-                msg = utils.build_er_error(
-                    attributes.ApplicationSpecificInformation,
-                    'constructor argument type',
-                    str, type(application_namespace))
-                raise TypeError(msg)
-
-            if not isinstance(application_data, str):
-                msg = utils.build_er_error(
-                    attributes.ApplicationSpecificInformation,
-                    'constructor argument type',
-                    str, type(application_data))
-                raise TypeError(msg)
-
-            return attributes.ApplicationSpecificInformation.create(
-                application_namespace, application_data)
+            return attributes.ApplicationSpecificInformation()
 
     def _create_contact_information(self, info):
         if info is None:

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -730,8 +730,16 @@ class KmipEngine(object):
             return None
         elif attr_name == 'Link':
             return None
-        elif attr_name == 'Application Specific Information':
-            return None
+        elif attr_name == "Application Specific Information":
+            values = []
+            for info in managed_object.app_specific_info:
+                values.append(
+                    {
+                        "application_namespace": info.application_namespace,
+                        "application_data": info.application_data
+                    }
+                )
+            return values
         elif attr_name == 'Contact Information':
             return None
         elif attr_name == 'Last Change Date':
@@ -781,6 +789,14 @@ class KmipEngine(object):
                         raise exceptions.InvalidField(
                             "Cannot set duplicate name values."
                         )
+            elif attribute_name == "Application Specific Information":
+                for value in attribute_value:
+                    managed_object.app_specific_info.append(
+                        objects.ApplicationSpecificInformation(
+                            application_namespace=value.application_namespace,
+                            application_data=value.application_data
+                        )
+                    )
             else:
                 # TODO (peterhamilton) Remove when all attributes are supported
                 raise exceptions.InvalidField(
@@ -1662,6 +1678,26 @@ class KmipEngine(object):
                     )
                     if attribute is None:
                         continue
+                    elif name == "Application Specific Information":
+                        application_namespace = value.application_namespace
+                        application_data = value.application_data
+                        v = {
+                            "application_namespace": application_namespace,
+                            "application_data": application_data
+                        }
+                        if v not in attribute:
+                            self._logger.debug(
+                                "Failed match: "
+                                "the specified application specific "
+                                "information ('{}', '{}') does not match any "
+                                "of the object's associated application "
+                                "specific information attributes.".format(
+                                    v.get("application_namespace"),
+                                    v.get("application_data")
+                                )
+                            )
+                            add_object = False
+                            break
                     elif name == "Name":
                         if value not in attribute:
                             self._logger.debug(

--- a/kmip/tests/unit/core/attributes/test_application_specific_information.py
+++ b/kmip/tests/unit/core/attributes/test_application_specific_information.py
@@ -278,7 +278,7 @@ class TestApplicationSpecificInformation(testtools.TestCase):
             ("application_data", "www.example.com")
         ]
         value = "{}".format(
-            ", ".join(['"{}": {}'.format(arg[0], arg[1]) for arg in args])
+            ", ".join(['"{}": "{}"'.format(arg[0], arg[1]) for arg in args])
         )
         self.assertEqual(
             "{" + value + "}",

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -418,7 +418,55 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that an ApplicationSpecificInformation attribute can be created.
         """
-        self.skipTest('')
+        attribute = self.factory.create_attribute_value(
+            enums.AttributeType.APPLICATION_SPECIFIC_INFORMATION,
+            {
+                "application_namespace": "ssl",
+                "application_data": "www.example.com"
+            }
+        )
+        self.assertIsInstance(
+            attribute,
+            attributes.ApplicationSpecificInformation
+        )
+        self.assertEqual("ssl", attribute.application_namespace)
+        self.assertEqual("www.example.com", attribute.application_data)
+
+        attribute = self.factory.create_attribute_value(
+            enums.AttributeType.APPLICATION_SPECIFIC_INFORMATION,
+            None
+        )
+        self.assertIsInstance(
+            attribute,
+            attributes.ApplicationSpecificInformation
+        )
+        self.assertIsNone(attribute.application_namespace)
+        self.assertIsNone(attribute.application_data)
+
+        attribute = self.factory.create_attribute_value_by_enum(
+            enums.Tags.APPLICATION_SPECIFIC_INFORMATION,
+            {
+                "application_namespace": "ssl",
+                "application_data": "www.example.com"
+            }
+        )
+        self.assertIsInstance(
+            attribute,
+            attributes.ApplicationSpecificInformation
+        )
+        self.assertEqual("ssl", attribute.application_namespace)
+        self.assertEqual("www.example.com", attribute.application_data)
+
+        attribute = self.factory.create_attribute_value_by_enum(
+            enums.Tags.APPLICATION_SPECIFIC_INFORMATION,
+            None
+        )
+        self.assertIsInstance(
+            attribute,
+            attributes.ApplicationSpecificInformation
+        )
+        self.assertIsNone(attribute.application_namespace)
+        self.assertIsNone(attribute.application_data)
 
     def test_create_contact_information(self):
         """

--- a/kmip/tests/unit/pie/objects/test_application_specific_information.py
+++ b/kmip/tests/unit/pie/objects/test_application_specific_information.py
@@ -247,11 +247,15 @@ class TestApplicationSpecificInformation(testtools.TestCase):
         session.add(app_specific_info)
         session.commit()
 
+        # Grab the ID now before making a new session to avoid a Detached error
+        # See http://sqlalche.me/e/bhk3 for more info.
+        app_specific_info_id = app_specific_info.id
+
         session = sqlalchemy.orm.sessionmaker(bind=engine)()
         retrieved_info = session.query(
             objects.ApplicationSpecificInformation
         ).filter(
-            objects.ApplicationSpecificInformation.id == app_specific_info.id
+            objects.ApplicationSpecificInformation.id == app_specific_info_id
         ).one()
         session.commit()
 


### PR DESCRIPTION
This change adds ApplicationSpecificInformation attribute support to the server, allowing for the storage and retrieval of the new attribute in addition to object filtering based on its value. New unit tests have been added to cover the new changes.