### PR TITLE
Update how the ObjectGroup attribute is defined and used

### DIFF
--- a/kmip/core/attributes.py
+++ b/kmip/core/attributes.py
@@ -1066,13 +1066,6 @@ class State(Enumeration):
         super(State, self).__init__(enums.State, value, Tags.STATE)
 
 
-# 3.33
-class ObjectGroup(TextString):
-
-    def __init__(self, value=None):
-        super(ObjectGroup, self).__init__(value, Tags.OBJECT_GROUP)
-
-
 class ApplicationSpecificInformation(primitives.Struct):
     """
     A structure used to store data specific to the applications that use a

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -93,7 +93,7 @@ class AttributeValueFactory(object):
         elif name is enums.AttributeType.ARCHIVE_DATE:
             return primitives.DateTime(value, enums.Tags.ARCHIVE_DATE)
         elif name is enums.AttributeType.OBJECT_GROUP:
-            return self._create_object_group(value)
+            return primitives.TextString(value, enums.Tags.OBJECT_GROUP)
         elif name is enums.AttributeType.FRESH:
             return primitives.Boolean(value, enums.Tags.FRESH)
         elif name is enums.AttributeType.LINK:
@@ -182,6 +182,7 @@ class AttributeValueFactory(object):
         elif enum is enums.Tags.ARCHIVE_DATE:
             return primitives.DateTime(value, enums.Tags.ARCHIVE_DATE)
         elif enum is enums.Tags.OBJECT_GROUP:
+            return primitives.TextString(value, enums.Tags.OBJECT_GROUP)
             return self._create_object_group(value)
         elif enum is enums.Tags.FRESH:
             return primitives.Boolean(value, enums.Tags.FRESH)
@@ -266,15 +267,6 @@ class AttributeValueFactory(object):
                 mask |= flag.value
 
         return attributes.CryptographicUsageMask(mask)
-
-    def _create_object_group(self, group):
-        if group is not None and not isinstance(group, str):
-            msg = utils.build_er_error(attributes.ObjectGroup,
-                                       'constructor argument type', str,
-                                       type(group))
-            raise TypeError(msg)
-
-        return attributes.ObjectGroup(group)
 
     def _create_application_specific_information(self, info):
         if info:

--- a/kmip/tests/unit/core/factories/test_attribute_values.py
+++ b/kmip/tests/unit/core/factories/test_attribute_values.py
@@ -393,7 +393,21 @@ class TestAttributeValueFactory(testtools.TestCase):
         """
         Test that an ObjectGroup attribute can be created.
         """
-        self.skipTest('')
+        object_group = self.factory.create_attribute_value(
+            enums.AttributeType.OBJECT_GROUP,
+            "Group1"
+        )
+        self.assertIsInstance(object_group, primitives.TextString)
+        self.assertEqual("Group1", object_group.value)
+        self.assertEqual(enums.Tags.OBJECT_GROUP, object_group.tag)
+
+        object_group = self.factory.create_attribute_value_by_enum(
+            enums.Tags.OBJECT_GROUP,
+            "Group1"
+        )
+        self.assertIsInstance(object_group, primitives.TextString)
+        self.assertEqual("Group1", object_group.value)
+        self.assertEqual(enums.Tags.OBJECT_GROUP, object_group.tag)
 
     def test_create_fresh(self):
         """

--- a/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
+++ b/kmip/tests/unit/core/messages/payloads/test_get_attributes.py
@@ -989,7 +989,10 @@ class TestGetAttributesResponsePayload(testtools.TestCase):
                 attribute_name=objects.Attribute.AttributeName(
                     'Object Group'
                 ),
-                attribute_value=attributes.ObjectGroup('Group1')
+                attribute_value=primitives.TextString(
+                    "Group1",
+                    enums.Tags.OBJECT_GROUP
+                )
             ),
             objects.Attribute(
                 attribute_name=objects.Attribute.AttributeName(

--- a/kmip/tests/unit/core/messages/test_messages.py
+++ b/kmip/tests/unit/core/messages/test_messages.py
@@ -26,7 +26,6 @@ from kmip.core.attributes import ContactInformation
 from kmip.core.attributes import CryptographicAlgorithm
 from kmip.core.attributes import CryptographicLength
 from kmip.core.attributes import Name
-from kmip.core.attributes import ObjectGroup
 
 from kmip.core import enums
 from kmip.core.enums import AttributeType
@@ -1005,7 +1004,7 @@ class TestRequestMessage(TestCase):
         attributes = []
 
         name = objects.Attribute.AttributeName('Object Group')
-        value = ObjectGroup('Group1')
+        value = TextString('Group1', tag=enums.Tags.OBJECT_GROUP)
         attribute = objects.Attribute(attribute_name=name,
                                       attribute_value=value)
         attributes.append(attribute)


### PR DESCRIPTION
This change updates the attribute factory, replacing the custom ObjectGroup class with the proper usage of the TextString primitive. ObjectGroup attribute usage and testing has been updated across the library to reflect this change.