### PR TITLE
Add integration tests for Locate using new attributes

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -1831,10 +1831,12 @@ class ApplicationSpecificInformation(sql.Base):
             raise TypeError("The application data must be a string.")
 
     def __repr__(self):
-        application_namespace = "application_namespace={}".format(
+        application_namespace = "application_namespace='{}'".format(
             self.application_namespace
         )
-        application_data = "application_data={}".format(self.application_data)
+        application_data = "application_data='{}'".format(
+            self.application_data
+        )
 
         return "ApplicationSpecificInformation({})".format(
             ", ".join(
@@ -1877,8 +1879,7 @@ class ObjectGroup(sql.Base):
     _object_group = sqlalchemy.Column(
         "object_group",
         sqlalchemy.String,
-        nullable=False,
-        unique=True
+        nullable=False
     )
     managed_objects = sqlalchemy.orm.relationship(
         "ManagedObject",
@@ -1909,7 +1910,7 @@ class ObjectGroup(sql.Base):
             raise TypeError("The object group must be a string.")
 
     def __repr__(self):
-        object_group = "object_group={}".format(self.object_group)
+        object_group = "object_group='{}'".format(self.object_group)
 
         return "ObjectGroup({})".format(object_group)
 

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -799,6 +799,8 @@ class KmipEngine(object):
                     )
             elif attribute_name == "Object Group":
                 for value in attribute_value:
+                    # TODO (peterhamilton) Enforce uniqueness of object groups
+                    # to avoid wasted space.
                     managed_object.object_groups.append(
                         objects.ObjectGroup(object_group=value.value)
                     )

--- a/kmip/tests/unit/pie/objects/test_application_specific_information.py
+++ b/kmip/tests/unit/pie/objects/test_application_specific_information.py
@@ -101,8 +101,8 @@ class TestApplicationSpecificInformation(testtools.TestCase):
         )
 
         args = [
-            "application_namespace={}".format("ssl"),
-            "application_data={}".format("www.example.com")
+            "application_namespace='{}'".format("ssl"),
+            "application_data='{}'".format("www.example.com")
         ]
 
         expected = "ApplicationSpecificInformation({})".format(", ".join(args))

--- a/kmip/tests/unit/pie/objects/test_object_group.py
+++ b/kmip/tests/unit/pie/objects/test_object_group.py
@@ -70,7 +70,9 @@ class TestObjectGroup(testtools.TestCase):
         """
         object_group = objects.ObjectGroup(object_group="Group1")
 
-        expected = "ObjectGroup({})".format("object_group={}".format("Group1"))
+        expected = "ObjectGroup({})".format(
+            "object_group='{}'".format("Group1")
+        )
         observed = repr(object_group)
 
         self.assertEqual(expected, observed)


### PR DESCRIPTION
This change adds integration tests that verify that objects can be found by Locate when filtering off of the new ObjectGroup and ApplicationSpecificInformation attributes. Some minor tweaks to the database attribute models are included to simplify usage.