### PR TITLE
Add DeleteAttribute support to the server

### DIFF
--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -97,7 +97,8 @@ class ManagedObject(sql.Base):
     _names = sqlalchemy.orm.relationship(
         "ManagedObjectName",
         back_populates="mo",
-        cascade="all, delete-orphan"
+        cascade="all, delete-orphan",
+        order_by="ManagedObjectName.id"
     )
     names = association_proxy('_names', 'name')
     operation_policy_name = Column(
@@ -112,12 +113,14 @@ class ManagedObject(sql.Base):
         "ApplicationSpecificInformation",
         secondary=app_specific_info_map,
         back_populates="managed_objects",
+        order_by="ApplicationSpecificInformation.id",
         passive_deletes=True
     )
     object_groups = sqlalchemy.orm.relationship(
         "ObjectGroup",
         secondary=object_group_map,
         back_populates="managed_objects",
+        order_by="ObjectGroup.id",
         passive_deletes=True
     )
 

--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -129,6 +129,7 @@ class AttributePolicy(object):
         """
         self._version = version
 
+        # TODO (peterhamilton) Alphabetize these
         self._attribute_rule_sets = {
             'Unique Identifier': AttributeRuleSet(
                 True,
@@ -872,9 +873,9 @@ class AttributePolicy(object):
             'Object Group': AttributeRuleSet(
                 False,
                 ('server', 'client'),
-                False,
-                False,
-                False,
+                True,
+                True,
+                True,
                 True,
                 (
                     enums.Operation.CREATE,
@@ -1115,6 +1116,20 @@ class AttributePolicy(object):
                 return False
         else:
             return False
+
+    def is_attribute_deletable_by_client(self, attribute):
+        """
+        Check if the attribute can be deleted by the client.
+
+        Args:
+            attribute (string): The name of the attribute (e.g., "Name").
+
+        Returns:
+            bool: True if the attribute can be deleted by the client. False
+                otherwise.
+        """
+        rule_set = self._attribute_rule_sets.get(attribute)
+        return rule_set.deletable_by_client
 
     def is_attribute_applicable_to_object_type(self, attribute, object_type):
         """

--- a/kmip/tests/unit/services/server/test_policy.py
+++ b/kmip/tests/unit/services/server/test_policy.py
@@ -76,6 +76,20 @@ class TestAttributePolicy(testtools.TestCase):
         result = rules.is_attribute_deprecated(attribute_b)
         self.assertTrue(result)
 
+    def test_is_attribute_deletable_by_client(self):
+        """
+        Test that is_attribute_deletable_by_client returns the expected
+        results in all cases.
+        """
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
+
+        self.assertFalse(
+            rules.is_attribute_deletable_by_client("Cryptographic Algorithm")
+        )
+        self.assertTrue(
+            rules.is_attribute_deletable_by_client("Contact Information")
+        )
+
     def test_is_attribute_applicable_to_object_type(self):
         """
         Test that is_attribute_applicable_to_object_type returns the


### PR DESCRIPTION
This change adds DeleteAttribute operation support to the PyKMIP server, supporting functionality unique to KMIP 1.0 - 1.4 and the newer KMIP 2.0. Due to the current list of attributes supported by the server, only multivalued attributes can currently be deleted from a stored KMIP object. Over a dozen unit tests have been added to verify the functionality of the new additions.

Partially implements #547