### PR TITLE
Add payload base classes to prepare for simplifying the client

### DIFF
--- a/kmip/core/messages/payloads/__init__.py
+++ b/kmip/core/messages/payloads/__init__.py
@@ -13,6 +13,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Import payload base classes
+from kmip.core.messages.payloads.base import (
+    RequestPayload,
+    ResponsePayload
+)
+
+# Import payload subclasses
 from kmip.core.messages.payloads.activate import (
     ActivateRequestPayload,
     ActivateResponsePayload
@@ -176,6 +183,8 @@ __all__ = [
     "RekeyKeyPairResponsePayload",
     "RekeyRequestPayload",
     "RekeyResponsePayload",
+    "RequestPayload",
+    "ResponsePayload",
     "RevokeRequestPayload",
     "RevokeResponsePayload",
     "SignRequestPayload",

--- a/kmip/core/messages/payloads/activate.py
+++ b/kmip/core/messages/payloads/activate.py
@@ -15,13 +15,11 @@
 
 from kmip.core import attributes
 from kmip.core import enums
-
-from kmip.core.primitives import Struct
-
 from kmip.core.utils import BytearrayStream
+from kmip.core.messages.payloads import base
 
 
-class ActivateRequestPayload(Struct):
+class ActivateRequestPayload(base.RequestPayload):
     """
     A request payload for the Activate operation.
 
@@ -40,8 +38,7 @@ class ActivateRequestPayload(Struct):
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
         """
-        super(ActivateRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+        super(ActivateRequestPayload, self).__init__()
         self.unique_identifier = unique_identifier
         self.validate()
 
@@ -103,7 +100,7 @@ class ActivateRequestPayload(Struct):
                 raise TypeError(msg)
 
 
-class ActivateResponsePayload(Struct):
+class ActivateResponsePayload(base.ResponsePayload):
     """
     A response payload for the Activate operation.
 
@@ -122,8 +119,7 @@ class ActivateResponsePayload(Struct):
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
         """
-        super(ActivateResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+        super(ActivateResponsePayload, self).__init__()
         if unique_identifier is None:
             self.unique_identifier = attributes.UniqueIdentifier()
         else:

--- a/kmip/core/messages/payloads/archive.py
+++ b/kmip/core/messages/payloads/archive.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class ArchiveRequestPayload(primitives.Struct):
+class ArchiveRequestPayload(base.RequestPayload):
     """
     A request payload for the Archive operation.
 
@@ -36,9 +37,7 @@ class ArchiveRequestPayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) to archive. Optional, defaults to None.
         """
-        super(ArchiveRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(ArchiveRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier
@@ -151,7 +150,7 @@ class ArchiveRequestPayload(primitives.Struct):
         })
 
 
-class ArchiveResponsePayload(primitives.Struct):
+class ArchiveResponsePayload(base.ResponsePayload):
     """
     A response payload for the Archive operation.
 
@@ -167,9 +166,7 @@ class ArchiveResponsePayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was archived. Optional, defaults to None.
         """
-        super(ArchiveResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(ArchiveResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier

--- a/kmip/core/messages/payloads/base.py
+++ b/kmip/core/messages/payloads/base.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from kmip.core import enums
+from kmip.core import primitives
+
+
+class RequestPayload(primitives.Struct):
+    """
+    An abstract base class for KMIP request payloads.
+    """
+    def __init__(self):
+        super(RequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+
+
+class ResponsePayload(primitives.Struct):
+    """
+    An abstract base class for KMIP response payloads.
+    """
+
+    def __init__(self):
+        super(ResponsePayload, self).__init__(enums.Tags.RESPONSE_PAYLOAD)

--- a/kmip/core/messages/payloads/cancel.py
+++ b/kmip/core/messages/payloads/cancel.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class CancelRequestPayload(primitives.Struct):
+class CancelRequestPayload(base.RequestPayload):
     """
     A request payload for the Cancel operation.
 
@@ -37,9 +38,7 @@ class CancelRequestPayload(primitives.Struct):
             asynchronous_correlation_value (bytes): The ID of a pending
                 operation to cancel, in bytes. Optional, defaults to None.
         """
-        super(CancelRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(CancelRequestPayload, self).__init__()
 
         self._asynchronous_correlation_value = None
         self.asynchronous_correlation_value = asynchronous_correlation_value
@@ -159,7 +158,7 @@ class CancelRequestPayload(primitives.Struct):
         })
 
 
-class CancelResponsePayload(primitives.Struct):
+class CancelResponsePayload(base.ResponsePayload):
     """
     A response payload for the Cancel operation.
 
@@ -183,9 +182,7 @@ class CancelResponsePayload(primitives.Struct):
                 specifying the result of canceling the operation. Optional,
                 defaults to None.
         """
-        super(CancelResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(CancelResponsePayload, self).__init__()
 
         self._asynchronous_correlation_value = None
         self._cancellation_result = None

--- a/kmip/core/messages/payloads/check.py
+++ b/kmip/core/messages/payloads/check.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class CheckRequestPayload(primitives.Struct):
+class CheckRequestPayload(base.RequestPayload):
     """
     A request payload for the Check operation.
 
@@ -55,7 +56,7 @@ class CheckRequestPayload(primitives.Struct):
                 lease should be available for on the checked object. Optional,
                 defaults to None.
         """
-        super(CheckRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(CheckRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._usage_limits_count = None
@@ -285,7 +286,7 @@ class CheckRequestPayload(primitives.Struct):
         })
 
 
-class CheckResponsePayload(primitives.Struct):
+class CheckResponsePayload(base.ResponsePayload):
     """
     A response payload for the Check operation.
 
@@ -320,7 +321,7 @@ class CheckResponsePayload(primitives.Struct):
                 lease should be available for on the checked object. Optional,
                 defaults to None.
         """
-        super(CheckResponsePayload, self).__init__(enums.Tags.RESPONSE_PAYLOAD)
+        super(CheckResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._usage_limits_count = None

--- a/kmip/core/messages/payloads/create.py
+++ b/kmip/core/messages/payloads/create.py
@@ -20,9 +20,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class CreateRequestPayload(primitives.Struct):
+class CreateRequestPayload(base.RequestPayload):
     """
     A request payload for the Create operation.
 
@@ -52,9 +53,7 @@ class CreateRequestPayload(primitives.Struct):
                 structure containing the storage masks permissible for the new
                 object. Added in KMIP 2.0. Optional, defaults to None.
         """
-        super(CreateRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD
-        )
+        super(CreateRequestPayload, self).__init__()
 
         self._object_type = None
         self._template_attribute = None
@@ -316,7 +315,7 @@ class CreateRequestPayload(primitives.Struct):
         return '{' + value + '}'
 
 
-class CreateResponsePayload(primitives.Struct):
+class CreateResponsePayload(base.ResponsePayload):
     """
     A response payload for the Create operation.
 
@@ -344,9 +343,7 @@ class CreateResponsePayload(primitives.Struct):
                 structure containing a set of attributes that were set on the
                 new object. Optional, defaults to None.
         """
-        super(CreateResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(CreateResponsePayload, self).__init__()
 
         self._object_type = None
         self._unique_identifier = None

--- a/kmip/core/messages/payloads/create_key_pair.py
+++ b/kmip/core/messages/payloads/create_key_pair.py
@@ -20,9 +20,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class CreateKeyPairRequestPayload(primitives.Struct):
+class CreateKeyPairRequestPayload(base.RequestPayload):
     """
     A request payload for the CreateKeyPair operation.
 
@@ -80,9 +81,7 @@ class CreateKeyPairRequestPayload(primitives.Struct):
                 permissible for the new public key. Added in KMIP 2.0.
                 Optional, defaults to None.
         """
-        super(CreateKeyPairRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(CreateKeyPairRequestPayload, self).__init__()
 
         self._common_template_attribute = None
         self._private_key_template_attribute = None
@@ -518,7 +517,7 @@ class CreateKeyPairRequestPayload(primitives.Struct):
         return '{' + value + '}'
 
 
-class CreateKeyPairResponsePayload(primitives.Struct):
+class CreateKeyPairResponsePayload(base.ResponsePayload):
     """
     A response payload for the CreateKeyPair operation.
 
@@ -556,9 +555,7 @@ class CreateKeyPairResponsePayload(primitives.Struct):
                 tag containing the set of attributes that were set on the new
                 public key. Optional, defaults to None.
         """
-        super(CreateKeyPairResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(CreateKeyPairResponsePayload, self).__init__()
 
         self._private_key_unique_identifier = None
         self._public_key_unique_identifier = None

--- a/kmip/core/messages/payloads/decrypt.py
+++ b/kmip/core/messages/payloads/decrypt.py
@@ -19,9 +19,10 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class DecryptRequestPayload(primitives.Struct):
+class DecryptRequestPayload(base.RequestPayload):
     """
     A request payload for the Decrypt operation.
 
@@ -74,9 +75,7 @@ class DecryptRequestPayload(primitives.Struct):
                 authenticated encryption cipher. Optional, defaults to None.
                 Added in KMIP 1.4.
         """
-        super(DecryptRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(DecryptRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -394,7 +393,7 @@ class DecryptRequestPayload(primitives.Struct):
         })
 
 
-class DecryptResponsePayload(primitives.Struct):
+class DecryptResponsePayload(base.ResponsePayload):
     """
     A response payload for the Decrypt operation.
 
@@ -417,9 +416,7 @@ class DecryptResponsePayload(primitives.Struct):
             data (bytes): The decrypted data in binary form. Required for
                 encoding and decoding.
         """
-        super(DecryptResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(DecryptResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._data = None

--- a/kmip/core/messages/payloads/delete_attribute.py
+++ b/kmip/core/messages/payloads/delete_attribute.py
@@ -20,9 +20,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class DeleteAttributeRequestPayload(primitives.Struct):
+class DeleteAttributeRequestPayload(base.RequestPayload):
     """
     A request payload for the DeleteAttribute operation.
 
@@ -65,9 +66,7 @@ class DeleteAttributeRequestPayload(primitives.Struct):
                 KMIP 2.0+. Optional, defaults to None. Must be specified if the
                 current attribute is not specified.
         """
-        super(DeleteAttributeRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(DeleteAttributeRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._attribute_name = None
@@ -374,7 +373,7 @@ class DeleteAttributeRequestPayload(primitives.Struct):
             return NotImplemented
 
 
-class DeleteAttributeResponsePayload(primitives.Struct):
+class DeleteAttributeResponsePayload(base.ResponsePayload):
     """
     A response payload for the DeleteAttribute operation.
 
@@ -397,9 +396,7 @@ class DeleteAttributeResponsePayload(primitives.Struct):
                 that was deleted. Used in KMIP 1.0 - 1.4. Defaults to None.
                 Required for read/write.
         """
-        super(DeleteAttributeResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(DeleteAttributeResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._attribute = None

--- a/kmip/core/messages/payloads/derive_key.py
+++ b/kmip/core/messages/payloads/derive_key.py
@@ -21,9 +21,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class DeriveKeyRequestPayload(primitives.Struct):
+class DeriveKeyRequestPayload(base.RequestPayload):
     """
     A request payload for the DeriveKey operation.
 
@@ -68,9 +69,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
                 cryptographic object. Optional, defaults to None. Required
                 for read/write.
         """
-        super(DeriveKeyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(DeriveKeyRequestPayload, self).__init__()
 
         self._object_type = None
         self._unique_identifiers = None
@@ -434,7 +433,7 @@ class DeriveKeyRequestPayload(primitives.Struct):
         })
 
 
-class DeriveKeyResponsePayload(primitives.Struct):
+class DeriveKeyResponsePayload(base.ResponsePayload):
     """
     A response payload for the DeriveKey operation.
 
@@ -461,9 +460,7 @@ class DeriveKeyResponsePayload(primitives.Struct):
                 newly derived cryptographic object. Optional, defaults to
                 None.
         """
-        super(DeriveKeyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(DeriveKeyResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._template_attribute = None

--- a/kmip/core/messages/payloads/destroy.py
+++ b/kmip/core/messages/payloads/destroy.py
@@ -16,18 +16,16 @@
 from kmip.core import attributes
 from kmip.core import enums
 from kmip.core.enums import Tags
-
-from kmip.core.primitives import Struct
-
+from kmip.core.messages.payloads import base
 from kmip.core.utils import BytearrayStream
 
 
 # 4.21
-class DestroyRequestPayload(Struct):
+class DestroyRequestPayload(base.RequestPayload):
 
     def __init__(self,
                  unique_identifier=None):
-        super(DestroyRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(DestroyRequestPayload, self).__init__()
         self.unique_identifier = unique_identifier
         self.validate()
 
@@ -67,12 +65,11 @@ class DestroyRequestPayload(Struct):
         pass
 
 
-class DestroyResponsePayload(Struct):
+class DestroyResponsePayload(base.ResponsePayload):
 
     def __init__(self,
                  unique_identifier=None):
-        super(DestroyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+        super(DestroyResponsePayload, self).__init__()
         self.unique_identifier = unique_identifier
         self.validate()
 

--- a/kmip/core/messages/payloads/discover_versions.py
+++ b/kmip/core/messages/payloads/discover_versions.py
@@ -16,20 +16,15 @@
 from six.moves import xrange
 
 from kmip.core import enums
-
 from kmip.core.messages.contents import ProtocolVersion
-
-from kmip.core.primitives import Struct
-
+from kmip.core.messages.payloads import base
 from kmip.core.utils import BytearrayStream
 
 
-class DiscoverVersionsRequestPayload(Struct):
+class DiscoverVersionsRequestPayload(base.RequestPayload):
 
     def __init__(self, protocol_versions=None):
-        super(DiscoverVersionsRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(DiscoverVersionsRequestPayload, self).__init__()
 
         if protocol_versions is None:
             self.protocol_versions = list()
@@ -85,12 +80,10 @@ class DiscoverVersionsRequestPayload(Struct):
             raise TypeError(msg)
 
 
-class DiscoverVersionsResponsePayload(Struct):
+class DiscoverVersionsResponsePayload(base.ResponsePayload):
 
     def __init__(self, protocol_versions=None):
-        super(DiscoverVersionsResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(DiscoverVersionsResponsePayload, self).__init__()
 
         if protocol_versions is None:
             self.protocol_versions = list()

--- a/kmip/core/messages/payloads/encrypt.py
+++ b/kmip/core/messages/payloads/encrypt.py
@@ -19,9 +19,10 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class EncryptRequestPayload(primitives.Struct):
+class EncryptRequestPayload(base.RequestPayload):
     """
     A request payload for the Encrypt operation.
 
@@ -63,9 +64,7 @@ class EncryptRequestPayload(primitives.Struct):
                 authenticated via the Authenticated Encryption Tag.
                 Added in KMIP 1.4.
         """
-        super(EncryptRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(EncryptRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -343,7 +342,7 @@ class EncryptRequestPayload(primitives.Struct):
         })
 
 
-class EncryptResponsePayload(primitives.Struct):
+class EncryptResponsePayload(base.ResponsePayload):
     """
     A response payload for the Encrypt operation.
 
@@ -384,9 +383,7 @@ class EncryptResponsePayload(primitives.Struct):
                 authenticated encryption cipher. Optional, defaults to None.
                 Added in KMIP 1.4.
         """
-        super(EncryptResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(EncryptResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._data = None

--- a/kmip/core/messages/payloads/get.py
+++ b/kmip/core/messages/payloads/get.py
@@ -20,11 +20,11 @@ from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import secrets
 from kmip.core import utils
-
 from kmip.core.factories import secrets as secret_factory
+from kmip.core.messages.payloads import base
 
 
-class GetRequestPayload(primitives.Struct):
+class GetRequestPayload(base.RequestPayload):
     """
     A request payload for the Get operation.
 
@@ -62,9 +62,7 @@ class GetRequestPayload(primitives.Struct):
                 information for wrapping the returned object. Optional,
                 defaults to None.
         """
-        super(GetRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(GetRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._key_format_type = None
@@ -301,7 +299,7 @@ class GetRequestPayload(primitives.Struct):
         })
 
 
-class GetResponsePayload(primitives.Struct):
+class GetResponsePayload(base.ResponsePayload):
     """
     A response payload for the Get operation.
 
@@ -330,9 +328,8 @@ class GetResponsePayload(primitives.Struct):
 
                 Optional, defaults to None. Required for read/write.
         """
-        super(GetResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(GetResponsePayload, self).__init__()
+
         self._object_type = None
         self._unique_identifier = None
         self._secret = None

--- a/kmip/core/messages/payloads/get_attribute_list.py
+++ b/kmip/core/messages/payloads/get_attribute_list.py
@@ -20,9 +20,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class GetAttributeListRequestPayload(primitives.Struct):
+class GetAttributeListRequestPayload(base.RequestPayload):
     """
     A request payload for the GetAttributeList operation.
 
@@ -44,8 +45,7 @@ class GetAttributeListRequestPayload(primitives.Struct):
                 which the retrieved attribute names should be associated.
                 Optional, defaults to None.
         """
-        super(GetAttributeListRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD)
+        super(GetAttributeListRequestPayload, self).__init__()
 
         self._unique_identifier = None
 
@@ -153,7 +153,7 @@ class GetAttributeListRequestPayload(primitives.Struct):
             return NotImplemented
 
 
-class GetAttributeListResponsePayload(primitives.Struct):
+class GetAttributeListResponsePayload(base.ResponsePayload):
     """
     A response payload for the GetAttributeList operation.
 
@@ -182,9 +182,7 @@ class GetAttributeListResponsePayload(primitives.Struct):
                 defaults to None.
         """
 
-        super(GetAttributeListResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(GetAttributeListResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._attribute_names = list()

--- a/kmip/core/messages/payloads/get_attributes.py
+++ b/kmip/core/messages/payloads/get_attributes.py
@@ -17,9 +17,10 @@ from kmip.core import exceptions
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class GetAttributesRequestPayload(primitives.Struct):
+class GetAttributesRequestPayload(base.RequestPayload):
     """
     A request payload for the GetAttributes operation.
 
@@ -48,8 +49,7 @@ class GetAttributesRequestPayload(primitives.Struct):
                 attributes associated with the managed object. Optional,
                 defaults to None.
         """
-        super(GetAttributesRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD)
+        super(GetAttributesRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._attribute_names = list()
@@ -272,7 +272,7 @@ class GetAttributesRequestPayload(primitives.Struct):
             return NotImplemented
 
 
-class GetAttributesResponsePayload(primitives.Struct):
+class GetAttributesResponsePayload(base.ResponsePayload):
     """
     A response payload for the GetAttributes operation.
 
@@ -297,8 +297,7 @@ class GetAttributesResponsePayload(primitives.Struct):
             attributes (list): A list of attribute structures associated with
                 the managed object. Optional, defaults to None.
         """
-        super(GetAttributesResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+        super(GetAttributesResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._attributes = list()

--- a/kmip/core/messages/payloads/get_usage_allocation.py
+++ b/kmip/core/messages/payloads/get_usage_allocation.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class GetUsageAllocationRequestPayload(primitives.Struct):
+class GetUsageAllocationRequestPayload(base.RequestPayload):
     """
     A request payload for the GetUsageAllocation operation.
 
@@ -42,9 +43,7 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
             usage_limits_count (int): The number of usage limits units that
                 should be reserved for the object. Optional, defaults to None.
         """
-        super(GetUsageAllocationRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(GetUsageAllocationRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._usage_limits_count = None
@@ -199,7 +198,7 @@ class GetUsageAllocationRequestPayload(primitives.Struct):
         })
 
 
-class GetUsageAllocationResponsePayload(primitives.Struct):
+class GetUsageAllocationResponsePayload(base.ResponsePayload):
     """
     A response payload for the GetUsageAllocation operation.
 
@@ -215,9 +214,7 @@ class GetUsageAllocationResponsePayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was allocated. Optional, defaults to None.
         """
-        super(GetUsageAllocationResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(GetUsageAllocationResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier

--- a/kmip/core/messages/payloads/locate.py
+++ b/kmip/core/messages/payloads/locate.py
@@ -19,9 +19,10 @@ from kmip.core import enums
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class LocateRequestPayload(primitives.Struct):
+class LocateRequestPayload(base.RequestPayload):
     """
     A request payload for the Locate operation.
 
@@ -64,7 +65,7 @@ class LocateRequestPayload(primitives.Struct):
                 objects. Optional, defaults to None. Required for read/write
                 for KMIP 2.0+.
         """
-        super(LocateRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(LocateRequestPayload, self).__init__()
 
         self._maximum_items = None
         self._offset_items = None
@@ -368,7 +369,7 @@ class LocateRequestPayload(primitives.Struct):
         return '{' + value + '}'
 
 
-class LocateResponsePayload(primitives.Struct):
+class LocateResponsePayload(base.ResponsePayload):
     """
     A response payload for the Locate operation.
 
@@ -391,8 +392,7 @@ class LocateResponsePayload(primitives.Struct):
             unique_identifiers (list): A list of strings specifying the object
                 identifiers for matching objects. Optional, defaults to None.
         """
-        super(LocateResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD)
+        super(LocateResponsePayload, self).__init__()
 
         self._located_items = None
         self._unique_identifiers = None

--- a/kmip/core/messages/payloads/mac.py
+++ b/kmip/core/messages/payloads/mac.py
@@ -16,24 +16,20 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import exceptions
 from kmip.core.enums import Tags
-
+from kmip.core.messages.payloads import base
 from kmip.core.objects import Data, MACData
-
-from kmip.core.primitives import Struct
-
 from kmip.core.utils import BytearrayStream
 
 
 # 4.33
-class MACRequestPayload(Struct):
+class MACRequestPayload(base.RequestPayload):
 
     def __init__(self,
                  unique_identifier=None,
                  cryptographic_parameters=None,
                  data=None):
 
-        super(MACRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+        super(MACRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -137,13 +133,12 @@ class MACRequestPayload(Struct):
         ostream.write(tstream.buffer)
 
 
-class MACResponsePayload(Struct):
+class MACResponsePayload(base.ResponsePayload):
 
     def __init__(self,
                  unique_identifier=None,
                  mac_data=None):
-        super(MACResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+        super(MACResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._mac_data = None

--- a/kmip/core/messages/payloads/obtain_lease.py
+++ b/kmip/core/messages/payloads/obtain_lease.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class ObtainLeaseRequestPayload(primitives.Struct):
+class ObtainLeaseRequestPayload(base.RequestPayload):
     """
     A request payload for the ObtainLease operation.
 
@@ -37,9 +38,7 @@ class ObtainLeaseRequestPayload(primitives.Struct):
                 a public key) to obtain a lease for. Optional, defaults to
                 None.
         """
-        super(ObtainLeaseRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(ObtainLeaseRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier
@@ -152,7 +151,7 @@ class ObtainLeaseRequestPayload(primitives.Struct):
         })
 
 
-class ObtainLeaseResponsePayload(primitives.Struct):
+class ObtainLeaseResponsePayload(base.ResponsePayload):
     """
     A response payload for the ObtainLease operation.
 
@@ -182,9 +181,7 @@ class ObtainLeaseResponsePayload(primitives.Struct):
                 when the last change was made to the object or one of its
                 attributes. Optional, defaults to None.
         """
-        super(ObtainLeaseResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(ObtainLeaseResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._lease_time = None

--- a/kmip/core/messages/payloads/poll.py
+++ b/kmip/core/messages/payloads/poll.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class PollRequestPayload(primitives.Struct):
+class PollRequestPayload(base.RequestPayload):
     """
     A request payload for the Poll operation.
 
@@ -38,9 +39,7 @@ class PollRequestPayload(primitives.Struct):
                 operation to poll the status of, in bytes. Optional, defaults
                 to None.
         """
-        super(PollRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(PollRequestPayload, self).__init__()
 
         self._asynchronous_correlation_value = None
         self.asynchronous_correlation_value = asynchronous_correlation_value

--- a/kmip/core/messages/payloads/query.py
+++ b/kmip/core/messages/payloads/query.py
@@ -21,9 +21,10 @@ from kmip.core import misc
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class QueryRequestPayload(primitives.Struct):
+class QueryRequestPayload(base.RequestPayload):
     """
     A request payload for the Query operation.
 
@@ -41,7 +42,7 @@ class QueryRequestPayload(primitives.Struct):
         Args:
             query_functions (list): A list of QueryFunction enumerations.
         """
-        super(QueryRequestPayload, self).__init__(enums.Tags.REQUEST_PAYLOAD)
+        super(QueryRequestPayload, self).__init__()
 
         self._query_functions = None
 
@@ -187,7 +188,7 @@ class QueryRequestPayload(primitives.Struct):
             return NotImplemented
 
 
-class QueryResponsePayload(primitives.Struct):
+class QueryResponsePayload(base.ResponsePayload):
     """
     A response payload for the Query operation.
 
@@ -290,10 +291,7 @@ class QueryResponsePayload(primitives.Struct):
                 the storage protections supported by the server. Optional,
                 defaults to None. Added in KMIP 2.0.
         """
-        super(QueryResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
-
+        super(QueryResponsePayload, self).__init__()
         self._operations = None
         self._object_types = None
         self._vendor_identification = None

--- a/kmip/core/messages/payloads/recover.py
+++ b/kmip/core/messages/payloads/recover.py
@@ -18,9 +18,10 @@ import six
 from kmip import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class RecoverRequestPayload(primitives.Struct):
+class RecoverRequestPayload(base.RequestPayload):
     """
     A request payload for the Recover operation.
 
@@ -36,9 +37,7 @@ class RecoverRequestPayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) to recover. Optional, defaults to None.
         """
-        super(RecoverRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(RecoverRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier
@@ -151,7 +150,7 @@ class RecoverRequestPayload(primitives.Struct):
         })
 
 
-class RecoverResponsePayload(primitives.Struct):
+class RecoverResponsePayload(base.ResponsePayload):
     """
     A response payload for the Recover operation.
 
@@ -167,9 +166,7 @@ class RecoverResponsePayload(primitives.Struct):
             unique_identifier (string): The ID of the managed object (e.g.,
                 a public key) that was recovered. Optional, defaults to None.
         """
-        super(RecoverResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(RecoverResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self.unique_identifier = unique_identifier

--- a/kmip/core/messages/payloads/register.py
+++ b/kmip/core/messages/payloads/register.py
@@ -21,11 +21,11 @@ from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import secrets
 from kmip.core import utils
-
 from kmip.core.factories import secrets as secret_factory
+from kmip.core.messages.payloads import base
 
 
-class RegisterRequestPayload(primitives.Struct):
+class RegisterRequestPayload(base.RequestPayload):
     """
     A request payload for the Register operation.
 
@@ -69,9 +69,7 @@ class RegisterRequestPayload(primitives.Struct):
                 object. Added in KMIP 2.0. Optional, defaults to None.
         """
 
-        super(RegisterRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(RegisterRequestPayload, self).__init__()
 
         self.secret_factory = secret_factory.SecretFactory()
 
@@ -388,7 +386,7 @@ class RegisterRequestPayload(primitives.Struct):
         return '{' + value + '}'
 
 
-class RegisterResponsePayload(primitives.Struct):
+class RegisterResponsePayload(base.ResponsePayload):
     """
     A response payload for the Register operation.
 
@@ -411,9 +409,7 @@ class RegisterResponsePayload(primitives.Struct):
                 structure containing a set of attributes that were set on the
                 new object. Optional, defaults to None.
         """
-        super(RegisterResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(RegisterResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._template_attribute = None

--- a/kmip/core/messages/payloads/rekey.py
+++ b/kmip/core/messages/payloads/rekey.py
@@ -16,9 +16,10 @@ from kmip.core import enums
 from kmip.core import objects
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class RekeyRequestPayload(primitives.Struct):
+class RekeyRequestPayload(base.RequestPayload):
     """
     A request payload for the Rekey operation.
 
@@ -47,9 +48,7 @@ class RekeyRequestPayload(primitives.Struct):
                 cryptographic length) that should be set on the replacement
                 key. Optional, defaults to None.
         """
-        super(RekeyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(RekeyRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._offset = None
@@ -227,7 +226,7 @@ class RekeyRequestPayload(primitives.Struct):
         })
 
 
-class RekeyResponsePayload(primitives.Struct):
+class RekeyResponsePayload(base.ResponsePayload):
     """
     A response payload for the Rekey operation.
 
@@ -250,9 +249,7 @@ class RekeyResponsePayload(primitives.Struct):
                 cryptographic length) that were set by the server on the
                 replacement key. Optional, defaults to None.
         """
-        super(RekeyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(RekeyResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._template_attribute = None

--- a/kmip/core/messages/payloads/rekey_key_pair.py
+++ b/kmip/core/messages/payloads/rekey_key_pair.py
@@ -18,13 +18,13 @@ from kmip.core import misc
 from kmip.core import objects
 
 from kmip.core import enums
+from kmip.core.messages.payloads import base
 from kmip.core.messages.payloads.create_key_pair import \
     CreateKeyPairResponsePayload
-from kmip.core.primitives import Struct
 from kmip.core.utils import BytearrayStream
 
 
-class RekeyKeyPairRequestPayload(Struct):
+class RekeyKeyPairRequestPayload(base.RequestPayload):
 
     def __init__(self,
                  private_key_uuid=None,
@@ -32,9 +32,7 @@ class RekeyKeyPairRequestPayload(Struct):
                  common_template_attribute=None,
                  private_key_template_attribute=None,
                  public_key_template_attribute=None):
-        super(RekeyKeyPairRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(RekeyKeyPairRequestPayload, self).__init__()
 
         self.private_key_uuid = private_key_uuid
         self.offset = offset

--- a/kmip/core/messages/payloads/revoke.py
+++ b/kmip/core/messages/payloads/revoke.py
@@ -17,13 +17,11 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import objects
 from kmip.core import primitives
-
-from kmip.core.primitives import Struct
-
+from kmip.core.messages.payloads import base
 from kmip.core.utils import BytearrayStream
 
 
-class RevokeRequestPayload(Struct):
+class RevokeRequestPayload(base.RequestPayload):
     """
     A request payload for the Revoke operation.
 
@@ -51,8 +49,7 @@ class RevokeRequestPayload(Struct):
             compromise_occurrence_date (DateTime): the datetime when the object
                 was first believed to be compromised.
         """
-        super(RevokeRequestPayload, self).__init__(
-            tag=enums.Tags.REQUEST_PAYLOAD)
+        super(RevokeRequestPayload, self).__init__()
         self.unique_identifier = unique_identifier
         self.compromise_occurrence_date = compromise_occurrence_date
         self.revocation_reason = revocation_reason
@@ -145,7 +142,7 @@ class RevokeRequestPayload(Struct):
             raise TypeError(msg)
 
 
-class RevokeResponsePayload(Struct):
+class RevokeResponsePayload(base.ResponsePayload):
     """
     A response payload for the Revoke operation.
     The payload contains the server response to the initial Revoke request.
@@ -161,8 +158,7 @@ class RevokeResponsePayload(Struct):
             unique_identifier (UniqueIdentifier): The UUID of a managed
                 cryptographic object.
         """
-        super(RevokeResponsePayload, self).__init__(
-            tag=enums.Tags.RESPONSE_PAYLOAD)
+        super(RevokeResponsePayload, self).__init__()
         if unique_identifier is None:
             self.unique_identifier = attributes.UniqueIdentifier()
         else:

--- a/kmip/core/messages/payloads/sign.py
+++ b/kmip/core/messages/payloads/sign.py
@@ -19,9 +19,10 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class SignRequestPayload(primitives.Struct):
+class SignRequestPayload(base.RequestPayload):
     """
     A request payload for the Sign operation.
 
@@ -51,9 +52,7 @@ class SignRequestPayload(primitives.Struct):
                 managed object will be used instead.
             data (bytes): The data to be signed, in binary form.
         """
-        super(SignRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(SignRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -247,7 +246,7 @@ class SignRequestPayload(primitives.Struct):
         })
 
 
-class SignResponsePayload(primitives.Struct):
+class SignResponsePayload(base.ResponsePayload):
     """
     A response payload for the Sign operation.
 
@@ -260,9 +259,7 @@ class SignResponsePayload(primitives.Struct):
     def __init__(self,
                  unique_identifier=None,
                  signature_data=None):
-        super(SignResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(SignResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._signature_data = None

--- a/kmip/core/messages/payloads/signature_verify.py
+++ b/kmip/core/messages/payloads/signature_verify.py
@@ -19,9 +19,10 @@ from kmip.core import attributes
 from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import utils
+from kmip.core.messages.payloads import base
 
 
-class SignatureVerifyRequestPayload(primitives.Struct):
+class SignatureVerifyRequestPayload(base.RequestPayload):
     """
     A request payload for the SignatureVerify operation.
 
@@ -77,9 +78,7 @@ class SignatureVerifyRequestPayload(primitives.Struct):
                 not the payload is the last in a series for a multi-payload
                 operation. Optional, defaults to None.
         """
-        super(SignatureVerifyRequestPayload, self).__init__(
-            enums.Tags.REQUEST_PAYLOAD
-        )
+        super(SignatureVerifyRequestPayload, self).__init__()
 
         self._unique_identifier = None
         self._cryptographic_parameters = None
@@ -438,7 +437,7 @@ class SignatureVerifyRequestPayload(primitives.Struct):
         })
 
 
-class SignatureVerifyResponsePayload(primitives.Struct):
+class SignatureVerifyResponsePayload(base.ResponsePayload):
     """
     A response payload for the SignatureVerify operation.
 
@@ -472,9 +471,7 @@ class SignatureVerifyResponsePayload(primitives.Struct):
                 value, allowing the linking together of individual payloads
                 for a single overarching operation. Optional, defaults to None.
         """
-        super(SignatureVerifyResponsePayload, self).__init__(
-            enums.Tags.RESPONSE_PAYLOAD
-        )
+        super(SignatureVerifyResponsePayload, self).__init__()
 
         self._unique_identifier = None
         self._validity_indicator = None


### PR DESCRIPTION
This change adds payload request and response base classes to prepare for future simplification updates to the current client architecture. No new tests are required for this change.