### PR TITLE
Add SetAttribute support to the server

### DIFF
--- a/kmip/services/server/policy.py
+++ b/kmip/services/server/policy.py
@@ -1155,6 +1155,20 @@ class AttributePolicy(object):
         rule_set = self._attribute_rule_sets.get(attribute)
         return rule_set.deletable_by_client
 
+    def is_attribute_modifiable_by_client(self, attribute):
+        """
+        Check if the attribute can be modified by the client.
+
+        Args:
+            attribute (string): The name of the attribute (e.g., "Name").
+
+        Returns:
+            bool: True if the attribute can be modified by the client. False
+                otherwise.
+        """
+        rule_set = self._attribute_rule_sets.get(attribute)
+        return rule_set.modifiable_by_client
+
     def is_attribute_applicable_to_object_type(self, attribute, object_type):
         """
         Check if the attribute is supported by the given object type.

--- a/kmip/tests/unit/services/server/test_policy.py
+++ b/kmip/tests/unit/services/server/test_policy.py
@@ -90,6 +90,20 @@ class TestAttributePolicy(testtools.TestCase):
             rules.is_attribute_deletable_by_client("Contact Information")
         )
 
+    def test_is_attribute_modifiable_by_client(self):
+        """
+        Test that is_attribute_modifiable_by_client returns the expected
+        results in all cases.
+        """
+        rules = policy.AttributePolicy(contents.ProtocolVersion(1, 0))
+
+        self.assertFalse(
+            rules.is_attribute_modifiable_by_client("Unique Identifier")
+        )
+        self.assertTrue(
+            rules.is_attribute_modifiable_by_client("Name")
+        )
+
     def test_is_attribute_applicable_to_object_type(self):
         """
         Test that is_attribute_applicable_to_object_type returns the


### PR DESCRIPTION
This change adds SetAttribute operation support to the PyKMIP server, including additional attribute policy functionality to check for certain attribute characteristics that preclude SetAttribute operation functionality. Specifically, the operation cannot set the value of any multivalued attribute nor the value of any attribute not modifiable by the client. New unit tests have been added to cover these changes.

Partially implements #547