### PR TITLE
Add SetAttribute support to the client

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -341,13 +341,19 @@ class KMIPProxy(object):
             )
 
         # TODO (peterhamilton) For now limit this to the new DeleteAttribute
-        # operation. Migrate over existing operations to use this method
-        # instead.
+        # and SetAttribute operations. Migrate over existing operations to use
+        # this method instead.
         if operation == enums.Operation.DELETE_ATTRIBUTE:
             if not isinstance(payload, payloads.DeleteAttributeRequestPayload):
                 raise TypeError(
                     "The request payload for the DeleteAttribute operation "
                     "must be a DeleteAttributeRequestPayload object."
+                )
+        elif operation == enums.Operation.SET_ATTRIBUTE:
+            if not isinstance(payload, payloads.SetAttributeRequestPayload):
+                raise TypeError(
+                    "The request payload for the SetAttribute operation must "
+                    "be a SetAttributeRequestPayload object."
                 )
 
         batch_item = messages.RequestBatchItem(
@@ -387,6 +393,15 @@ class KMIPProxy(object):
                 raise exceptions.InvalidMessage(
                     "Invalid response payload received for the "
                     "DeleteAttribute operation."
+                )
+        elif batch_item.operation.value == enums.Operation.SET_ATTRIBUTE:
+            if not isinstance(
+                batch_item.response_payload,
+                payloads.SetAttributeRequestPayload
+            ):
+                raise exceptions.InvalidMessage(
+                    "Invalid response payload received for the SetAttribute "
+                    "operation."
                 )
 
         return batch_item.response_payload

--- a/kmip/tests/unit/pie/test_client.py
+++ b/kmip/tests/unit/pie/test_client.py
@@ -25,6 +25,7 @@ from kmip.core import objects as obj
 from kmip.core.factories import attributes
 from kmip.core.messages import contents
 from kmip.core.messages import payloads
+from kmip.core import primitives
 from kmip.core.primitives import DateTime
 
 from kmip.services.kmip_client import KMIPProxy
@@ -793,6 +794,43 @@ class TestProxyKmipClient(testtools.TestCase):
             client.proxy.send_request_payload.assert_called_with(*args)
             self.assertEqual("1", unique_identifier)
             self.assertIsNone(attribute)
+
+    @mock.patch(
+        "kmip.pie.client.KMIPProxy",
+        mock.MagicMock(spec_set=KMIPProxy)
+    )
+    def test_set_attribute(self):
+        """
+        Test that the client can set an attribute.
+        """
+        request_payload = payloads.SetAttributeRequestPayload(
+            unique_identifier="1",
+            new_attribute=obj.NewAttribute(
+                attribute=primitives.Boolean(
+                    value=True,
+                    tag=enums.Tags.SENSITIVE
+                )
+            )
+        )
+        response_payload = payloads.SetAttributeResponsePayload(
+            unique_identifier="1"
+        )
+
+        with ProxyKmipClient() as client:
+            client.proxy.send_request_payload.return_value = response_payload
+
+            unique_identifier = client.set_attribute(
+                "1",
+                attribute_name="Sensitive",
+                attribute_value=True
+            )
+
+            args = (
+                enums.Operation.SET_ATTRIBUTE,
+                request_payload
+            )
+            client.proxy.send_request_payload.assert_called_with(*args)
+            self.assertEqual("1", unique_identifier)
 
     @mock.patch(
         'kmip.pie.client.KMIPProxy', mock.MagicMock(spec_set=KMIPProxy)

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -843,6 +843,18 @@ class TestKMIPClient(TestCase):
             *args
         )
 
+        args = (
+            OperationEnum.SET_ATTRIBUTE,
+            payloads.CreateRequestPayload()
+        )
+        self.assertRaisesRegex(
+            TypeError,
+            "The request payload for the SetAttribute operation must be a "
+            "SetAttributeRequestPayload object.",
+            self.client.send_request_payload,
+            *args
+        )
+
     @mock.patch(
         "kmip.services.kmip_client.KMIPProxy._build_request_message"
     )
@@ -957,10 +969,35 @@ class TestKMIPClient(TestCase):
                 attribute_index=2
             )
         )
-
         self.assertRaisesRegex(
             exceptions.InvalidMessage,
             "Invalid response payload received for the DeleteAttribute "
+            "operation.",
+            self.client.send_request_payload,
+            *args
+        )
+
+        batch_item = ResponseBatchItem(
+            operation=Operation(OperationEnum.SET_ATTRIBUTE),
+            result_status=ResultStatus(ResultStatusEnum.SUCCESS),
+            response_payload=response_payload
+        )
+        send_mock.return_value = ResponseMessage(batch_items=[batch_item])
+        args = (
+            OperationEnum.SET_ATTRIBUTE,
+            payloads.SetAttributeRequestPayload(
+                unique_identifier="1",
+                new_attribute=objects.NewAttribute(
+                    attribute=primitives.Boolean(
+                        value=True,
+                        tag=enums.Tags.SENSITIVE
+                    )
+                )
+            )
+        )
+        self.assertRaisesRegex(
+            exceptions.InvalidMessage,
+            "Invalid response payload received for the SetAttribute "
             "operation.",
             self.client.send_request_payload,
             *args


### PR DESCRIPTION
This change adds SetAttribute support to the ProxyKmipClient, leveraging the new generic request capability in the underlying KMIPProxy client. New unit tests have been added to cover the new client additions.

Partially implements #547