### PR TITLE
Pin tox to 3.14.1 and more_itertools to 7.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,7 +223,14 @@ install:
   # For more info, see: https://github.com/OpenKMIP/PyKMIP/issues/435
   - pip uninstall -y six
   - pip install six>=1.11.0
-  - pip install tox
+  # Pin more_itertools to <= 7.2.0. Version 8.0.0+ drops support for
+  # Python 3.4. Once PyKMIP drops support for Python 3.4, remove this.
+  - pip install "more_itertools<=7.2.0"
+  # Pin tox to <= 3.14.1. Version 3.14.2+ moves to newer versions of
+  # the importlib_metadata package which breaks on Python 3.4. Future
+  # versions of tox will also drop support for Python 2.7 and 3.4.
+  # Once PyKMIP also drops support for Python 2.7 and 3.4, remove this. 
+  - pip install "tox<=3.14.1"
   - pip install bandit
   - pip install codecov
   - pip install slugs


### PR DESCRIPTION
This change pins the upstream tox dependency to version 3.14.1 and the more_itertools dependency to version 7.2.0. The latest versions of these tools released in late November and early December 2019 have begun to drop support for Python 3.4, breaking various test builds on Ubuntu 12.04 LTS (at this time the updates have only made their way into the upstream packages for this OS). This will likely soon spread to all other Python 3.4 builds, so for now, short cut the issue by avoiding newer library releases. Once PyKMIP drops support for Python 3.4, this change can be undone.