### PR TITLE
Update the payload factories to support new attribute operations

### DIFF
--- a/kmip/core/factories/payloads/__init__.py
+++ b/kmip/core/factories/payloads/__init__.py
@@ -46,6 +46,8 @@ class PayloadFactory():
             return self._create_get_attribute_list_payload()
         elif operation is enums.Operation.ADD_ATTRIBUTE:
             return self._create_add_attribute_payload()
+        elif operation is enums.Operation.SET_ATTRIBUTE:
+            return self._create_set_attribute_payload()
         elif operation is enums.Operation.MODIFY_ATTRIBUTE:
             return self._create_modify_attribute_payload()
         elif operation is enums.Operation.DELETE_ATTRIBUTE:
@@ -142,6 +144,9 @@ class PayloadFactory():
         raise NotImplementedError()
 
     def _create_add_attribute_payload(self):
+        raise NotImplementedError()
+
+    def _create_set_attribute_payload(self):
         raise NotImplementedError()
 
     def _create_modify_attribute_payload(self):

--- a/kmip/core/factories/payloads/request.py
+++ b/kmip/core/factories/payloads/request.py
@@ -19,6 +19,7 @@ from kmip.core.messages import payloads
 
 class RequestPayloadFactory(PayloadFactory):
 
+    # TODO (peterhamilton) Alphabetize these
     def _create_create_payload(self):
         return payloads.CreateRequestPayload()
 
@@ -51,6 +52,15 @@ class RequestPayloadFactory(PayloadFactory):
 
     def _create_get_attributes_payload(self):
         return payloads.GetAttributesRequestPayload()
+
+    def _create_delete_attribute_payload(self):
+        return payloads.DeleteAttributeRequestPayload()
+
+    def _create_set_attribute_payload(self):
+        return payloads.SetAttributeRequestPayload()
+
+    def _create_modify_attribute_payload(self):
+        return payloads.ModifyAttributeRequestPayload()
 
     def _create_destroy_payload(self):
         return payloads.DestroyRequestPayload()

--- a/kmip/core/factories/payloads/response.py
+++ b/kmip/core/factories/payloads/response.py
@@ -19,6 +19,7 @@ from kmip.core.messages import payloads
 
 class ResponsePayloadFactory(PayloadFactory):
 
+    # TODO (peterhamilton) Alphabetize these
     def _create_create_payload(self):
         return payloads.CreateResponsePayload()
 
@@ -51,6 +52,15 @@ class ResponsePayloadFactory(PayloadFactory):
 
     def _create_get_attributes_payload(self):
         return payloads.GetAttributesResponsePayload()
+
+    def _create_delete_attribute_payload(self):
+        return payloads.DeleteAttributeResponsePayload()
+
+    def _create_set_attribute_payload(self):
+        return payloads.SetAttributeResponsePayload()
+
+    def _create_modify_attribute_payload(self):
+        return payloads.ModifyAttributeResponsePayload()
 
     def _create_destroy_payload(self):
         return payloads.DestroyResponsePayload()

--- a/kmip/tests/unit/core/factories/payloads/test_payload.py
+++ b/kmip/tests/unit/core/factories/payloads/test_payload.py
@@ -112,6 +112,12 @@ class TestPayloadFactory(testtools.TestCase):
             enums.Operation.DELETE_ATTRIBUTE
         )
 
+    def test_create_set_attribute_payload(self):
+        self._test_not_implemented(
+            self.factory.create,
+            enums.Operation.SET_ATTRIBUTE
+        )
+
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(
             self.factory.create,

--- a/kmip/tests/unit/core/factories/payloads/test_request.py
+++ b/kmip/tests/unit/core/factories/payloads/test_request.py
@@ -105,16 +105,16 @@ class TestRequestPayloadFactory(testtools.TestCase):
         )
 
     def test_create_modify_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create,
-            enums.Operation.MODIFY_ATTRIBUTE
-        )
+        payload = self.factory.create(enums.Operation.MODIFY_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.ModifyAttributeRequestPayload)
 
     def test_create_delete_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create,
-            enums.Operation.DELETE_ATTRIBUTE
-        )
+        payload = self.factory.create(enums.Operation.DELETE_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.DeleteAttributeRequestPayload)
+
+    def test_create_set_attribute_payload(self):
+        payload = self.factory.create(enums.Operation.SET_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.SetAttributeRequestPayload)
 
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(

--- a/kmip/tests/unit/core/factories/payloads/test_response.py
+++ b/kmip/tests/unit/core/factories/payloads/test_response.py
@@ -105,16 +105,16 @@ class TestResponsePayloadFactory(testtools.TestCase):
         )
 
     def test_create_modify_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create,
-            enums.Operation.MODIFY_ATTRIBUTE
-        )
+        payload = self.factory.create(enums.Operation.MODIFY_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.ModifyAttributeResponsePayload)
 
     def test_create_delete_attribute_payload(self):
-        self._test_not_implemented(
-            self.factory.create,
-            enums.Operation.DELETE_ATTRIBUTE
-        )
+        payload = self.factory.create(enums.Operation.DELETE_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.DeleteAttributeResponsePayload)
+
+    def test_create_set_attribute_payload(self):
+        payload = self.factory.create(enums.Operation.SET_ATTRIBUTE)
+        self.assertIsInstance(payload, payloads.SetAttributeResponsePayload)
 
     def test_create_obtain_lease_payload(self):
         self._test_not_implemented(


### PR DESCRIPTION
This change updates the request and response payload factories to add support for the Set, Modify, and DeleteAttribute payloads. Unit tests have been added to cover the changes.

Partially implements #547