### PR TITLE
Add ProxyKmipClient demos for the new attribute operations

### DIFF
--- a/kmip/demos/pie/delete_attribute.py
+++ b/kmip/demos/pie/delete_attribute.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+
+
+# NOTE: This demo script shows how to delete the first Name attribute from
+# the user-specified object. The object *must* have at least one Name
+# attribute for attribute deletion to work. Otherwise, the client
+# call to delete_attribute will fail.
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    parser = utils.build_cli_parser(enums.Operation.DELETE_ATTRIBUTE)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    if opts.uuid is None:
+        logger.error("No UUID provided, existing early from demo.")
+        sys.exit()
+
+    with client.ProxyKmipClient(
+        config=opts.config,
+        config_file=opts.config_file
+    ) as c:
+        try:
+            object_id, modified_attribute = c.delete_attribute(
+                unique_identifier=opts.uuid,
+                attribute_name="Name",
+                attribute_index=0
+            )
+            logger.info(
+                "Successfully deleted 'Name' attribute from object: {}".format(
+                    object_id
+                )
+            )
+            logger.info("Deleted attribute: {}".format(modified_attribute))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/pie/modify_attribute.py
+++ b/kmip/demos/pie/modify_attribute.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core.factories import attributes
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+
+
+# NOTE: This demo script shows how to modify the first Name attribute on
+# the user-specified object. The object *must* have at least one Name
+# attribute for attribute modification to work. Otherwise, the client
+# call to modify_attribute will fail.
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    parser = utils.build_cli_parser(enums.Operation.MODIFY_ATTRIBUTE)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    if opts.uuid is None:
+        logger.error("No UUID provided, existing early from demo.")
+        sys.exit()
+
+    factory = attributes.AttributeFactory()
+
+    with client.ProxyKmipClient(
+        config=opts.config,
+        config_file=opts.config_file
+    ) as c:
+        try:
+            object_id, modified_attribute = c.modify_attribute(
+                unique_identifier=opts.uuid,
+                attribute=factory.create_attribute(
+                    enums.AttributeType.NAME,
+                    "Modified Name",
+                    index=0
+                )
+            )
+            logger.info(
+                "Successfully modified 'Name' attribute on object: {}".format(
+                    object_id
+                )
+            )
+            logger.info("Modified attribute: {}".format(modified_attribute))
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/pie/set_attribute.py
+++ b/kmip/demos/pie/set_attribute.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2019 The Johns Hopkins University/Applied Physics Laboratory
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import sys
+
+from kmip.core.factories import attributes
+from kmip.core import enums
+from kmip.demos import utils
+
+from kmip.pie import client
+
+
+# NOTE: This demo script shows how to set the Sensitive attribute on
+# the user-specified object. The server must support KMIP 2.0, since
+# the SetAttribute operation is KMIP 2.0+ only and the Sensitive
+# attribute is KMIP 1.4+ only. Otherwise, the client call to
+# set_attribute will fail.
+
+if __name__ == '__main__':
+    logger = utils.build_console_logger(logging.INFO)
+
+    parser = utils.build_cli_parser(enums.Operation.SET_ATTRIBUTE)
+    opts, args = parser.parse_args(sys.argv[1:])
+
+    if opts.uuid is None:
+        logger.error("No UUID provided, existing early from demo.")
+        sys.exit()
+
+    factory = attributes.AttributeFactory()
+
+    with client.ProxyKmipClient(
+        config=opts.config,
+        config_file=opts.config_file,
+        kmip_version=enums.KMIPVersion.KMIP_2_0
+    ) as c:
+        try:
+            object_id = c.set_attribute(
+                unique_identifier=opts.uuid,
+                attribute_name="Sensitive",
+                attribute_value=True
+            )
+            logger.info(
+                "Successfully set the 'Sensitive' attribute on object: "
+                "{}".format(
+                    object_id
+                )
+            )
+        except Exception as e:
+            logger.error(e)

--- a/kmip/demos/utils.py
+++ b/kmip/demos/utils.py
@@ -229,6 +229,33 @@ def build_cli_parser(operation):
             dest="attribute_names",
             help="List of attribute names to retrieve, defaults to all "
                  "attributes")
+    elif operation is Operation.MODIFY_ATTRIBUTE:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
+    elif operation is Operation.DELETE_ATTRIBUTE:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
+    elif operation is Operation.SET_ATTRIBUTE:
+        parser.add_option(
+            "-i",
+            "--uuid",
+            action="store",
+            type="str",
+            default=None,
+            dest="uuid",
+            help="UID of a managed object")
     elif operation is Operation.LOCATE:
         parser.add_option(
             "--offset-items",


### PR DESCRIPTION
This change adds ProxyKmipClient demos for the new Set, Modify, and Delete Attribute operations. The demos are not intended for general use but instead to show how the client can be used to execute these new operations against a KMIP server. See the demo scripts themselves for more information.

Partially implements #547