### PR TITLE
Fix a bug with attribute index handling in ModifyAttribute

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1876,7 +1876,7 @@ class KmipEngine(object):
                     managed_object,
                     attribute_name
                 )
-                if 0 <= attribute_index <= len(existing_attributes):
+                if 0 <= attribute_index < len(existing_attributes):
                     self._set_attribute_on_managed_object_by_index(
                         managed_object,
                         attribute_name,

--- a/kmip/tests/unit/services/server/test_engine.py
+++ b/kmip/tests/unit/services/server/test_engine.py
@@ -4975,7 +4975,7 @@ class TestKmipEngine(testtools.TestCase):
                 attribute=attribute_factory.create_attribute(
                     enums.AttributeType.NAME,
                     "Modified Name",
-                    index=3
+                    index=1
                 )
             ),
         )


### PR DESCRIPTION
This changes fixes a minor bug with proper attribute index range checking in the server implementation of ModifyAttribute. A corner case that previously slipped through index checking and testing has been closed. An existing unit test has been modified to fix this bug.

Partially implements #547