### PR TITLE
Add pending deprecation warnings for Python 2.7 and 3.4

### DIFF
--- a/kmip/__init__.py
+++ b/kmip/__init__.py
@@ -15,6 +15,8 @@
 
 import os
 import re
+import sys
+import warnings
 
 from kmip.core import enums
 from kmip.pie import client
@@ -44,3 +46,22 @@ __all__ = [
     'objects',
     'services'
 ]
+
+
+if sys.version_info[:2] == (2, 7):
+    warnings.warn(
+        (
+            "PyKMIP will drop support for Python 2.7 in a future release. "
+            "Please upgrade to a newer version of Python (3.5+ preferred)."
+        ),
+        PendingDeprecationWarning
+    )
+
+if sys.version_info[:2] == (3, 4):
+    warnings.warn(
+        (
+            "PyKMIP will drop support for Python 3.4 in a future release. "
+            "Please upgrade to a newer version of Python (3.5+ preferred)."
+        ),
+        PendingDeprecationWarning
+    )


### PR DESCRIPTION
This change adds pending deprecation warnings for both Python 2.7 and 3.4. Both of these Python versions have reached end-of-life and no longer receive security updates. Future versions of PyKMIP will drop support for both of these Python versions.