### PR TITLE
Set the except clause as a parenthesized tuple

### DIFF
--- a/kmip/demos/pie/locate.py
+++ b/kmip/demos/pie/locate.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     for initial_date in initial_dates:
         try:
             t = time.strptime(initial_date)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             logger.error(
                 "Invalid initial date provided: {}".format(initial_date)
             )


### PR DESCRIPTION
Hi folks,

In Fedora, the package build fails [1] for the current latest version (0.10.0), because python3.9 is used as default.
I know py39 is not yet supported, but this change makes the build process successful.

[1] https://koji.fedoraproject.org/koji/taskinfo?taskID=51511749