### PR TITLE
Allow custom attributes

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -20,6 +20,7 @@ from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import objects as cobjects
 
+from kmip.core.objects import Attribute
 from kmip.core.factories import attributes
 
 from kmip.core.attributes import CryptographicParameters
@@ -556,6 +557,11 @@ class ProxyKmipClient(object):
                         name
                     )
                     object_attributes.append(name_attribute)
+
+        if hasattr(managed_object, '_application_specific_informations'):
+            if managed_object._application_specific_informations:
+                for attr in managed_object._application_specific_informations:
+                    object_attributes.append(attr)
 
         template = cobjects.TemplateAttribute(attributes=object_attributes)
         object_type = managed_object.object_type

--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -20,7 +20,6 @@ from kmip.core import enums
 from kmip.core import primitives
 from kmip.core import objects as cobjects
 
-from kmip.core.objects import Attribute
 from kmip.core.factories import attributes
 
 from kmip.core.attributes import CryptographicParameters

--- a/kmip/pie/objects.py
+++ b/kmip/pie/objects.py
@@ -1580,7 +1580,7 @@ class SecretData(CryptographicObject):
         'sqlite_autoincrement': True
     }
 
-    def __init__(self, value, data_type, masks=None, name='Secret Data'):
+    def __init__(self, value, data_type, app_specific_info=None, masks=None, name='Secret Data'):
         """
         Create a SecretData object.
 
@@ -1599,6 +1599,9 @@ class SecretData(CryptographicObject):
         self.value = value
         self.data_type = data_type
         self.names = [name]
+        
+        if app_specific_info:
+            self._application_specific_informations = app_specific_info
 
         if masks:
             self.cryptographic_usage_masks = masks


### PR DESCRIPTION
Add the ability to create and store custom attributes for SecretData objects and ensure that they are stored on the KMIP server when the register function is called