### PR TITLE
add AES256-SHA as a default cipher for TLS 1.2

### DIFF
--- a/kmip/services/auth.py
+++ b/kmip/services/auth.py
@@ -196,6 +196,7 @@ class TLS12AuthenticationSuite(AuthenticationSuite):
     """
 
     _default_cipher_suites = [
+        'AES256-SHA',
         'AES128-SHA256',
         'AES256-SHA256',
         'DH-DSS-AES256-SHA256',


### PR DESCRIPTION
# Summary

Add `AES256-SHA` as a default cipher suite for TLS 1.2.

# Motivation
The current default TLS 1.2 cipher suites do not intersect with the default cipher suites in the Golang TLS library. Golang TLS 1.2 default ciphers are [listed under cipherSuitesPreferenceOrder here](https://golang.org/src/crypto/tls/cipher_suites.go).

[KMIP 1.4 Profiles](http://docs.oasis-open.org/kmip/profiles/v1.4/os/kmip-profiles-v1.4-os.html#_Toc491431405) section 3.2.2 notes:

> Conformant KMIP servers and clients MAY support the cipher suites specified as MAY in Basic Authentication Cipher Suites (3.1.2) of the Basic Authentication Suite

`TLS_RSA_WITH_AES_256_CBC_SHA` is listed in section 3.1.2.

# Reproducing

To reproduce, run a PyKMIP server with TLS 1.2:

```
% cd /path/to/PyKMIP/bin
% ./create_certificates.py
% cat server.cfg 
[server]
hostname=127.0.0.1
port=5696
certificate_path=./server_certificate.pem
key_path=./server_key.pem
ca_path=./root_certificate.pem
auth_suite=TLS1.2
database_path=./pykmip.db
% pykmip-server --config_path ./server.cfg --log_path ./pykmip.log --logging_level=DEBUG
```

Then, use a Go TLS client to connect. Here is a [runnable example](https://github.com/kevinAlbs/go-bootstrap/blob/46bc2e6bcef9ae6cde1d67067c8db7db738f38d6/investigations/tls_conn/main.go). The relevant bit is:

```
conn, err := tls.Dial("tcp", "localhost:5696", &tls.Config{
		Certificates:       []tls.Certificate{cert},
		InsecureSkipVerify: true, // Do not verify hostname or server certificate signature.
	})
	if err != nil {
		panic("failed to connect: " + err.Error())
	}
```

This fails with `panic: failed to connect: remote error: tls: handshake failure`. The PyKMIP server logs:

```
Traceback (most recent call last):
  File "/Users/kevin.albertson/.venv/lib/python3.9/site-packages/kmip/services/server/session.py", line 102, in run
    self._connection.do_handshake()
  File "/usr/local/Cellar/python@3.9/3.9.7_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: NO_SHARED_CIPHER] no shared cipher (_ssl.c:1129)
```