### PR TITLE
Repair some demos

### DIFF
--- a/kmip/demos/pie/register_certificate.py
+++ b/kmip/demos/pie/register_certificate.py
@@ -26,7 +26,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config

--- a/kmip/demos/pie/register_opaque_object.py
+++ b/kmip/demos/pie/register_opaque_object.py
@@ -26,7 +26,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config

--- a/kmip/demos/pie/register_private_key.py
+++ b/kmip/demos/pie/register_private_key.py
@@ -26,7 +26,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config

--- a/kmip/demos/pie/register_public_key.py
+++ b/kmip/demos/pie/register_public_key.py
@@ -26,7 +26,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config

--- a/kmip/demos/pie/register_secret_data.py
+++ b/kmip/demos/pie/register_secret_data.py
@@ -27,7 +27,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     usage_mask = [enums.CryptographicUsageMask.VERIFY]
     name = 'Demo Secret Data'
 
-    secret = objects.SecretData(value, data_type, usage_mask, name)
+    secret = objects.SecretData(value, data_type, None, usage_mask, name)
     secret.operation_policy_name = opts.operation_policy_name
 
     # Build the client and connect to the server

--- a/kmip/demos/pie/register_symmetric_key.py
+++ b/kmip/demos/pie/register_symmetric_key.py
@@ -26,7 +26,7 @@ from kmip.pie import objects
 if __name__ == '__main__':
     logger = utils.build_console_logger(logging.INFO)
 
-    parser = utils.build_cli_parser()
+    parser = utils.build_cli_parser(enums.Operation.REGISTER)
     opts, args = parser.parse_args(sys.argv[1:])
 
     config = opts.config


### PR DESCRIPTION
Pass the required argument to the `build_cli_parser` function where
it was missed. Pass the missed argument in the `objects.SecretData`
initialization.
Fixes #669.