### PR TITLE
Rely on close() to close sockets and stop using shutdown()

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -301,10 +301,9 @@ class KMIPProxy(object):
         self.close()
 
     def close(self):
-        # Shutdown and close the socket.
+        # Close the socket.
         if self.socket:
             try:
-                self.socket.shutdown(socket.SHUT_RDWR)
                 self.socket.close()
             except (OSError, socket.error):
                 # Can be thrown if the socket is not actually connected to

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -362,12 +362,11 @@ class KmipServer(object):
 
         self._logger.info("Shutting down server socket handler.")
         try:
-            self._socket.shutdown(socket.SHUT_RDWR)
             self._socket.close()
         except Exception as e:
             self._logger.exception(e)
             raise exceptions.NetworkingError(
-                "Server failed to shutdown socket handler."
+                "Server failed to close socket handler."
             )
 
         if hasattr(self, "policy_monitor"):

--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -113,7 +113,6 @@ class KmipSession(threading.Thread):
                     self._logger.info("Failure handling message loop")
                     self._logger.exception(e)
 
-        self._connection.shutdown(socket.SHUT_RDWR)
         self._connection.close()
         self._logger.info("Stopping session: {0}".format(self.name))
 


### PR DESCRIPTION
I see this error when a client closes a connection to the server:
```
 [2022/08/19 00:09:02.481] Traceback (most recent call last):
 [2022/08/19 00:09:02.481]   File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 973, in _bootstrap_inner
 [2022/08/19 00:09:02.482]     self.run()
 [2022/08/19 00:09:02.482]   File "/System/Volumes/Data/data/mci/d2010f3ec27c908e548f765abcafefe8/drivers-tools/.evergreen/csfle/kmstlsvenv/lib/python3.9/site-packages/kmip/services/server/session.py", line 116, in run
 [2022/08/19 00:09:02.482]     self._connection.shutdown(socket.SHUT_RDWR)
 [2022/08/19 00:09:02.482]   File "/usr/local/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ssl.py", line 1280, in shutdown
 [2022/08/19 00:09:02.490]     super().shutdown(how)
 [2022/08/19 00:09:02.490] OSError: [Errno 57] Socket is not connected
```

The prevailing wisdom I've seen is to rely on socket.close() to cleanup the connection and not use socket.shutdown() unless for very niche reasons. Since this library isn't doing any funky like using a socket simultaneously in multiple threads/processes and is always calling close() directly after shutdown(SHUT_RDWR) it will be simpler and more robust to just call close().