### PR TITLE
Add attribute types: Always Sensitive, Extractable, Never Extractable

### DIFF
--- a/kmip/core/enums.py
+++ b/kmip/core/enums.py
@@ -127,6 +127,9 @@ class AttributeType(enum.Enum):
     KEY_VALUE_LOCATION               = 'Key Value Location'
     ORIGINAL_CREATION_DATE           = 'Original Creation Date'
     SENSITIVE                        = "Sensitive"
+    ALWAYS_SENSITIVE                 = 'Always Sensitive'
+    EXTRACTABLE                      = 'Extractable'
+    NEVER_EXTRACTABLE                = 'Never Extractable'
 
 
 class AuthenticationSuite(enum.Enum):

--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -106,6 +106,12 @@ class AttributeValueFactory(object):
             return primitives.DateTime(value, enums.Tags.LAST_CHANGE_DATE)
         elif name is enums.AttributeType.SENSITIVE:
             return primitives.Boolean(value, enums.Tags.SENSITIVE)
+        elif name is enums.AttributeType.ALWAYS_SENSITIVE:
+            return primitives.Boolean(value, enums.Tags.ALWAYS_SENSITIVE)
+        elif name is enums.AttributeType.EXTRACTABLE:
+            return primitives.Boolean(value, enums.Tags.EXTRACTABLE)
+        elif name is enums.AttributeType.NEVER_EXTRACTABLE:
+            return primitives.Boolean(value, enums.Tags.NEVER_EXTRACTABLE)
         elif name is enums.AttributeType.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
         else:


### PR DESCRIPTION
While working on extracting KMIP keys from Hashicorp Vault I noticed that I was unable to read these 3 Attribute Types:

Always Sensitive
Extractable
Never Extractable

Looking through the code, I saw that there were defined tags for these attributes, so I put this together to allow the attribute types to be read. 