### PR TITLE
Fix pykmip client error with server_correlation_value issue

### DIFF
--- a/kmip/core/messages/contents.py
+++ b/kmip/core/messages/contents.py
@@ -506,6 +506,13 @@ class MessageExtension(Struct):
         super(MessageExtension, self).__init__(enums.Tags.MESSAGE_EXTENSION)
 
 
+# 6.19
+class ServerCorrelationValue(TextString):
+    def __init__(self, value=None):
+        super(ServerCorrelationValue, self).__init__(
+            value, enums.Tags.SERVER_CORRELATION_VALUE)
+
+
 # 9.1.3.2.2
 class KeyCompressionType(Enumeration):
 

--- a/kmip/core/messages/messages.py
+++ b/kmip/core/messages/messages.py
@@ -150,12 +150,14 @@ class ResponseHeader(Struct):
                  protocol_version=None,
                  time_stamp=None,
                  batch_count=None,
-                 server_hashed_password=None):
+                 server_hashed_password=None,
+                 server_correlation_value=None):
         super(ResponseHeader, self).__init__(tag=Tags.RESPONSE_HEADER)
         self.protocol_version = protocol_version
         self.time_stamp = time_stamp
         self.batch_count = batch_count
         self.server_hashed_password = server_hashed_password
+        self.server_correlation_value = server_correlation_value
 
         self.validate()
 
@@ -203,6 +205,10 @@ class ResponseHeader(Struct):
                 )
                 server_hashed_password.read(tstream, kmip_version=kmip_version)
                 self._server_hashed_password = server_hashed_password
+
+        if self.is_tag_next(enums.Tags.SERVER_CORRELATION_VALUE, tstream):
+            self.server_correlation_value = contents.ServerCorrelationValue()
+            self.server_correlation_value.read(tstream, kmip_version=kmip_version)
 
         self.batch_count = contents.BatchCount()
         self.batch_count.read(tstream, kmip_version=kmip_version)


### PR DESCRIPTION
When I use PyKMIP as a client connect to an HyTrust KMS server, I have the same issue as https://github.com/OpenKMIP/PyKMIP/issues/675. HyTrust server set server_correlation_value field in response header, but looks like current PyKMIP cannot correctly handle the server_correlation_value field. Then the ProxyKmipClient fails with error:
```
Traceback (most recent call last):
  File "/root/./kmipcli.py", line 157, in <module>
    attr=GetKmipKeyAttributes(c,id,names)
  File "/root/./kmipcli.py", line 100, in GetKmipKeyAttributes
    result=c.proxy.get_attributes(id,attribute_names=names)
  File "/root/pykmip/kmip/services/kmip_client.py", line 754, in get_attributes
    response = self._send_and_receive_message(request)
  File "/root/pykmip/kmip/services/kmip_client.py", line 1735, in _send_and_receive_message
    response.read(data, self.kmip_version)
  File "/root/pykmip/kmip/core/messages/messages.py", line 520, in read
    self.response_header.read(istream, kmip_version=kmip_version)
  File "/root/pykmip/kmip/core/messages/messages.py", line 208, in read
    self.batch_count.read(tstream, kmip_version=kmip_version)
  File "/root/pykmip/kmip/core/primitives.py", line 228, in read
    super(Integer, self).read(istream, kmip_version=kmip_version)
  File "/root/pykmip/kmip/core/primitives.py", line 105, in read
    self.read_tag(istream)
  File "/root/pykmip/kmip/core/primitives.py", line 56, in read_tag
    raise exceptions.ReadValueError(
kmip.core.exceptions.ReadValueError: Tried to read Base.tag: expected 0x42000d, received 0x420106
```
This fix will fix that error when server_correlation_value is presented.