### PR TITLE
add original creation date attribute

### DIFF
--- a/kmip/core/factories/attribute_values.py
+++ b/kmip/core/factories/attribute_values.py
@@ -114,6 +114,8 @@ class AttributeValueFactory(object):
             return primitives.Boolean(value, enums.Tags.NEVER_EXTRACTABLE)
         elif name is enums.AttributeType.CUSTOM_ATTRIBUTE:
             return attributes.CustomAttribute(value)
+        elif name is enums.AttributeType.ORIGINAL_CREATION_DATE:
+            return primitives.DateTime(value, enums.Tags.ORIGINAL_CREATION_DATE)
         else:
             if not isinstance(name, str):
                 raise ValueError('Unrecognized attribute type: '


### PR DESCRIPTION
Currently, the AttributeValueFactory class doesn't support creation of the ORIGINAL_CREATION_DATE attribute. I followed a similar approach to the LAST_CHANGE_DATE attribute, and created a primitives.DateTime object to reflect the original creation date. 