### PR TITLE
check if shared_ciphers() is None before logging

### DIFF
--- a/kmip/services/server/session.py
+++ b/kmip/services/server/session.py
@@ -127,7 +127,7 @@ class KmipSession(threading.Thread):
         )
 
         try:
-            if hasattr(self._connection, 'shared_ciphers'):
+            if hasattr(self._connection, 'shared_ciphers') and self._connection.shared_ciphers() is not None:
                 shared_ciphers = self._connection.shared_ciphers()
                 self._logger.debug(
                     "Possible session ciphers: {0}".format(len(shared_ciphers))


### PR DESCRIPTION
# Summary
Check for `None` return in `ssl.SSLSocket.shared_ciphers()`

# Background & Motivation

This is motivated by an observed exception in the PyKMIP server logs:

```
2023-06-21 19:35:58,173 - kmip.server.session.00000003 - WARNING - Failure parsing request message.
2023-06-21 19:35:58,173 - kmip.server.session.00000003 - ERROR - object of type 'NoneType' has no len()
Traceback (most recent call last):
  File "/data/mci/ed2138b4a01580ba489bb7e3b9bc6679/drivers-tools/.evergreen/csfle/kmstlsvenv/lib/python3.11/site-packages/kmip/services/server/session.py", line 133, in _handle_message_loop
    "Possible session ciphers: {0}".format(len(shared_ciphers))
                                           ^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

`shared_ciphers` [is documented](https://docs.python.org/3/library/ssl.html#ssl.SSLSocket.shared_ciphers) as possibly returning `None`:

> shared_ciphers() returns None if no connection has been established or the socket is a client socket.

Python 3.11.3 [changed behavior of ssl.SSLSocket.shared_ciphers()](https://docs.python.org/release/3.11.4/whatsnew/changelog.html#id4). Which appears to result in `None` being returned in additional scenarios.