### PR TITLE
Fix compatibility with cryptography >= 42.0.0

### DIFF
--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -584,13 +584,17 @@ class CryptographyEngine(api.CryptographicEngine):
                     "encryption.".format(padding_method)
                 )
 
-            backend = default_backend()
-
             try:
-                public_key = backend.load_der_public_key(encryption_key)
+                public_key = serialization.load_der_public_key(
+                    encryption_key,
+                    backend=default_backend()
+                )
             except Exception:
                 try:
-                    public_key = backend.load_pem_public_key(encryption_key)
+                    public_key = serialization.load_pem_public_key(
+                        encryption_key,
+                        backend=default_backend()
+                    )
                 except Exception:
                     raise exceptions.CryptographicFailure(
                         "The public key bytes could not be loaded."
@@ -1433,8 +1437,6 @@ class CryptographyEngine(api.CryptographicEngine):
                 loaded, or when the signature verification process fails
                 unexpectedly.
         """
-        backend = default_backend()
-
         hash_algorithm = None
         dsa_hash_algorithm = None
         dsa_signing_algorithm = None
@@ -1488,10 +1490,16 @@ class CryptographyEngine(api.CryptographicEngine):
                 )
 
             try:
-                public_key = backend.load_der_public_key(signing_key)
+                public_key = serialization.load_der_public_key(
+                    signing_key,
+                    backend=default_backend()
+                )
             except Exception:
                 try:
-                    public_key = backend.load_pem_public_key(signing_key)
+                    public_key = serialization.load_pem_public_key(
+                        signing_key,
+                        backend=default_backend()
+                    )
                 except Exception:
                     raise exceptions.CryptographicFailure(
                         "The signing key bytes could not be loaded."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography>=1.4
+cryptography>=2.5
 enum-compat
 requests
 six>=1.11.0


### PR DESCRIPTION
The load_der_public_key method and the load_pem_private_key method were removed from Backend class in cryptography 42.0.0[1].

Closes #713

[1] https://github.com/pyca/cryptography/commit/41daf2d86dd9bf18081802fa5d851a7953810786