### PR TITLE
Fixed raising an exception if some error happens when opening/closing a client connection

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -174,7 +174,7 @@ class ProxyKmipClient(object):
                 self._is_open = True
             except Exception as e:
                 self.logger.error("could not open client connection: %s", e)
-                raise
+                raise exceptions.ClientConnectionFailure
 
     def close(self):
         """
@@ -191,7 +191,7 @@ class ProxyKmipClient(object):
                 self._is_open = False
             except Exception as e:
                 self.logger.error("could not close client connection: %s", e)
-                raise
+                raise exceptions.ClientConnectionFailure
 
     @is_connected
     def create(self, algorithm, length, operation_policy_name=None, name=None,


### PR DESCRIPTION
This PR addresses an issue where exceptions were not properly raised during client connection operations. The changes include adding robust error handling to ensure that if an error occurs when opening or closing a client connection, an exception is raised accordingly. This improves the reliability of the client connection process and ensures smoother error tracking.