### PR TITLE
Fixed compatability with Python 3.12

### DIFF
--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -285,13 +285,16 @@ class KMIPProxy(object):
             six.reraise(*last_error)
 
     def _create_socket(self, sock):
-        self.socket = ssl.wrap_socket(
-            sock,
+        context = ssl.create_default_context()
+        context.verify_mode = self.cert_reqs
+        context.check_hostname = False
+        context.load_cert_chain(
             keyfile=self.keyfile,
-            certfile=self.certfile,
-            cert_reqs=self.cert_reqs,
-            ssl_version=self.ssl_version,
-            ca_certs=self.ca_certs,
+            certfile=self.certfile
+        )
+        context.load_verify_locations(cafile=self.ca_certs)
+        self.socket = context.wrap_socket(
+            sock,
             do_handshake_on_connect=self.do_handshake_on_connect,
             suppress_ragged_eofs=self.suppress_ragged_eofs)
         self.socket.settimeout(self.timeout)

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -287,17 +287,20 @@ class KmipServer(object):
         for cipher in auth_suite_ciphers:
             self._logger.debug(cipher)
 
-        self._socket = ssl.wrap_socket(
-            self._socket,
-            keyfile=self.config.settings.get('key_path'),
+        context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = False
+        context.load_cert_chain(
             certfile=self.config.settings.get('certificate_path'),
+            keyfile=self.config.settings.get('key_path'),
+        )
+        context.load_verify_locations(cafile=self.config.settings.get('ca_path'))
+        context.set_ciphers(self.auth_suite.ciphers)
+        self._socket = context.wrap_socket(
+            self._socket,
             server_side=True,
-            cert_reqs=ssl.CERT_REQUIRED,
-            ssl_version=self.auth_suite.protocol,
-            ca_certs=self.config.settings.get('ca_path'),
             do_handshake_on_connect=False,
             suppress_ragged_eofs=True,
-            ciphers=self.auth_suite.ciphers
         )
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )


### PR DESCRIPTION
Python 3.12 removed the `ssl.wrap_socket()` function that was deprecated in Python 3.7, breaking both server and client functionality of PyKMIP. To fix the issue, we create an `ssl.SSLContext` object using `ssl.create_default_context()` and use its `wrap_socket()` instead.