### PR TITLE
make server.py compatible with Python3.13

### DIFF
--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -20,7 +20,7 @@ import multiprocessing
 import optparse
 import os
 import signal
-import six
+		  
 import socket
 import ssl
 import sys
@@ -243,7 +243,7 @@ class KmipServer(object):
         self.manager = multiprocessing.Manager()
         self.policies = self.manager.dict()
         policies = copy.deepcopy(operation_policy.policies)
-        for policy_name, policy_set in six.iteritems(policies):
+        for policy_name, policy_set in policies.items():
             self.policies[policy_name] = policy_set
 
         self.policy_monitor = monitor.PolicyDirectoryMonitor(
@@ -287,17 +287,29 @@ class KmipServer(object):
         for cipher in auth_suite_ciphers:
             self._logger.debug(cipher)
 
-        self._socket = ssl.wrap_socket(
-            self._socket,
-            keyfile=self.config.settings.get('key_path'),
+        # ssl.wrap_socket() was removed in Python 3.12+; build an SSLContext
+        # and use its wrap_socket() method instead, which is the supported
+        # replacement and preserves the same TLS configuration.
+        ssl_context = ssl.SSLContext(self.auth_suite.protocol)
+        ssl_context.verify_mode = ssl.CERT_REQUIRED
+        ssl_context.load_cert_chain(
             certfile=self.config.settings.get('certificate_path'),
+            keyfile=self.config.settings.get('key_path')
+        )
+        ssl_context.load_verify_locations(
+            cafile=self.config.settings.get('ca_path')
+        )
+        ssl_context.set_ciphers(self.auth_suite.ciphers)
+
+        self._socket = ssl_context.wrap_socket(
+            self._socket,
             server_side=True,
-            cert_reqs=ssl.CERT_REQUIRED,
-            ssl_version=self.auth_suite.protocol,
-            ca_certs=self.config.settings.get('ca_path'),
+										
+												 
+														 
             do_handshake_on_connect=False,
-            suppress_ragged_eofs=True,
-            ciphers=self.auth_suite.ciphers
+            suppress_ragged_eofs=True
+										   
         )
 
         try:


### PR DESCRIPTION
The script had one breaking issue for Python 3.13: it called ssl.wrap_socket(), which was deprecated in 3.7 and fully removed in Python 3.12, so start() would immediately throw AttributeError: module 'ssl' has no attribute 'wrap_socket'. I confirmed this by running the original file's logic against a 3.12 interpreter here. I replaced that call with the supported ssl.SSLContext equivalent: build a context with the same protocol from self.auth_suite.protocol, load the cert/key chain and CA file, set the same cipher string, then call context.wrap_socket(...) with the same server_side, do_handshake_on_connect, and suppress_ragged_eofs arguments. The resulting TLS behavior (protocol version, mutual-auth cert requirement, cipher list) is unchanged. I also dropped the six import and its one use (six.iteritems(policies) → policies.items()), since this is a pure Python 3 codebase now and six's only job here was a Python 2/3 dict-iteration shim.